### PR TITLE
Update php container Dockerfile to point at specific version of composer

### DIFF
--- a/doenet_docker/php/Dockerfile
+++ b/doenet_docker/php/Dockerfile
@@ -1,4 +1,6 @@
-FROM composer as composer
+# composer:2.2.18
+# https://hub.docker.com/layers/library/composer/2.2.18/images/sha256-7b05f8df23459b8631d50c6720025e7f44ab5072c18ec727f64c100ebd03ead4?context=explore
+FROM composer@sha256:7b05f8df23459b8631d50c6720025e7f44ab5072c18ec727f64c100ebd03ead4 as composer
 WORKDIR /build
 COPY ./doenet_docker/php/composer.json .
 RUN composer install --ignore-platform-reqs

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "buildx:mysql": "docker buildx build --platform linux/amd64 -f doenet_docker/mysql/Dockerfile -t lyanthropos/doenet_test:mysql-dev .",
     "test": "cypress open",
     "test:all": "cypress run -b 'chrome' --config video=false --headless",
+    "test:app": "cypress run -b 'electron' --config video=false --headless --spec 'cypress/e2e/ActivityViewer/*,cypress/e2e/AsStudent/*,cypress/e2e/Events/*,cypress/e2e/Navigation/*,cypress/e2e/Public/*,cypress/e2e/AssignedActivity/*,cypress/e2e/course/*,cypress/e2e/Editor/*,cypress/e2e/Gradebook/*,cypress/e2e/People/*'",
     "publish:db": "docker compose exec -T -w /var/lib/mysql mysql mysqldump -u root -phelloworld --databases --add-drop-database --add-drop-table doenet_local > ./doenet_docker/volumes/db_init/db_template.sql",
     "reset:db": "docker compose exec -T mysql mysql -u root -phelloworld doenet_local < ./doenet_docker/volumes/db_init/db_template.sql",
     "reset:volumes": "docker volume rm doenet_node_modules doenet_vendor",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "buildx:mysql": "docker buildx build --platform linux/amd64 -f doenet_docker/mysql/Dockerfile -t lyanthropos/doenet_test:mysql-dev .",
     "test": "cypress open",
     "test:all": "cypress run -b 'chrome' --config video=false --headless",
-    "test:app": "cypress run -b 'electron' --config video=false --headless --spec 'cypress/e2e/ActivityViewer/*,cypress/e2e/AsStudent/*,cypress/e2e/Events/*,cypress/e2e/Navigation/*,cypress/e2e/Public/*,cypress/e2e/AssignedActivity/*,cypress/e2e/course/*,cypress/e2e/Editor/*,cypress/e2e/Gradebook/*,cypress/e2e/People/*'",
+    "test:app": "cypress run -b 'electron' --config video=false --headless ignoreTestFiles='cypress/e2e/DoenetML/*'",
     "publish:db": "docker compose exec -T -w /var/lib/mysql mysql mysqldump -u root -phelloworld --databases --add-drop-database --add-drop-table doenet_local > ./doenet_docker/volumes/db_init/db_template.sql",
     "reset:db": "docker compose exec -T mysql mysql -u root -phelloworld doenet_local < ./doenet_docker/volumes/db_init/db_template.sql",
     "reset:volumes": "docker volume rm doenet_node_modules doenet_vendor",


### PR DESCRIPTION
- add a new npm script to run all tests besides the DoenetML ones
- electron runs about 25% faster for me, so I set that as the browser for this new script, to have a quick signal if the app side is likely in a good state. There is a tiny chance chrome behaves differently, but they are both based on Chromium

I ran into an issue after cleaning out my containers completely, I had messed things up while trying to backport the LTI stuff to 5.4,  after starting out from a clean environment I was getting this failure on requests to the php server. Pinning to this version of composer and rebuilding my container with `npm run buildx:php` fixed it for me. @Lyanthropos do you think pinning a version like this makes sense?

Apparently docker does not very proactively pull in new versions of containers that you depend on if it has any version cached locally. Which I guess is the reason I ran into this but everyone else has been fine. Although I am curious about Duane recently setting up his laptop and not hitting this.

https://stackoverflow.com/questions/74141587/does-docker-from-keyword-in-dockerfile-look-for-the-newest-image

> I have a CI Runner that automatically builds a docker image from a Dockerfile. My docker image is based                                                                       on another docker image. So the beginning of my Dockerfile looks like this:  
>  
> FROM linktoimage/imagename:latest
>                      Does docker check during the build process if my local version of imagename is still the latest (similar                                                                      to docker pull? Because i noticed that my ci runner shows sn older version of imagename if i run docker images on it
>  
> **Stackoverflow Answer**
> No, docker will not do this by default because of the build cache. It will use whatever existing image it has locally in the cache [1].
>  
> You can however enable the behavior you desire by using the --no-cache option:
>  $ docker build . --no-cache=true


```
                 Status: 500 - Internal Server Error
                 Headers: {
                   "date": "Tue, 15 Nov 2022 20:07:16 GMT",
                   "server": "Apache/2.4.48 (Unix)",
                   "x-powered-by": "PHP/5.4.45",
                   "access-control-allow-origin": "*",
                   "access-control-allow-headers": "access",
                   "access-control-allow-methods": "POST",
                   "access-control-allow-credentials": "true",
                   "content-type": "application/json",
                   "connection": "keep-alive",
                   "keep-alive": "timeout=5",
                   "transfer-encoding": "chunked"
                 }
                 Body: <br />
                 <b>Fatal error</b>:  Composer 2.3.0 dropped support for autoloading on PHP <5.6 and you are running 5.4.45, please upgrade PHP or use Composer 2.2 LTS via    "composer self-update --2.2". Aborting.
                  in <b>/usr/local/apache2/htdocs/api/vendor/autoload.php</b> on line <b>20</b><br />

```