### PR TITLE
Send http error codes on failure

### DIFF
--- a/src/Api/MakeNewAssignment.php
+++ b/src/Api/MakeNewAssignment.php
@@ -157,7 +157,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/addDrive.php
+++ b/src/Api/addDrive.php
@@ -86,7 +86,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/addItem.php
+++ b/src/Api/addItem.php
@@ -298,7 +298,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/checkCredentials.php
+++ b/src/Api/checkCredentials.php
@@ -93,7 +93,7 @@ if ($row['minutes'] > 10){
 
 
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/checkForChangedAssignment.php
+++ b/src/Api/checkForChangedAssignment.php
@@ -82,7 +82,7 @@ $response_arr = [
     "cidChanged" => $cidChanged,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/checkPasscode.php
+++ b/src/Api/checkPasscode.php
@@ -147,7 +147,7 @@ $response_arr = array(
     "exams" => $exams,
     );
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/createCourse.php
+++ b/src/Api/createCourse.php
@@ -211,7 +211,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/createCourseItem.php
+++ b/src/Api/createCourseItem.php
@@ -312,7 +312,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/createPageLinks.php
+++ b/src/Api/createPageLinks.php
@@ -136,7 +136,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/createPageOrOrder.php
+++ b/src/Api/createPageOrOrder.php
@@ -81,7 +81,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/deleteFile.php
+++ b/src/Api/deleteFile.php
@@ -97,7 +97,7 @@ $response_arr = array(
 );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/deleteItem.php
+++ b/src/Api/deleteItem.php
@@ -67,7 +67,7 @@ $response_arr = array(
   );;
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getAllAssignmentSettings.php
+++ b/src/Api/getAllAssignmentSettings.php
@@ -88,7 +88,7 @@ $response_arr = array(
 );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getCidForAssignment.php
+++ b/src/Api/getCidForAssignment.php
@@ -146,7 +146,7 @@ $response_arr = [
     "label" => $label,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getCourseIdFromDoenetId.php
+++ b/src/Api/getCourseIdFromDoenetId.php
@@ -93,7 +93,7 @@ $response_arr = [
     'item' => $item,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getCoursePermissionsAndSettings.php
+++ b/src/Api/getCoursePermissionsAndSettings.php
@@ -29,7 +29,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getIndividualizeForAssignment.php
+++ b/src/Api/getIndividualizeForAssignment.php
@@ -60,7 +60,7 @@ $response_arr = [
     "individualize" => $individualize,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getPublicActivityDefinition.php
+++ b/src/Api/getPublicActivityDefinition.php
@@ -49,7 +49,7 @@ $response_arr = [
     "json" => $json,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getRestrictedTo.php
+++ b/src/Api/getRestrictedTo.php
@@ -63,7 +63,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getSurveyData.php
+++ b/src/Api/getSurveyData.php
@@ -95,7 +95,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/getSurveyList.php
+++ b/src/Api/getSurveyList.php
@@ -80,7 +80,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/handleBackAssignment.php
+++ b/src/Api/handleBackAssignment.php
@@ -42,7 +42,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/handleMakeContent.php
+++ b/src/Api/handleMakeContent.php
@@ -55,7 +55,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/handlePublishContent.php
+++ b/src/Api/handlePublishContent.php
@@ -39,7 +39,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadAssessmentCreditAchieved.php
+++ b/src/Api/loadAssessmentCreditAchieved.php
@@ -167,7 +167,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadAvailableDrives.php
+++ b/src/Api/loadAvailableDrives.php
@@ -122,7 +122,7 @@ $response_arr = array(
 );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadCoursePeople.php
+++ b/src/Api/loadCoursePeople.php
@@ -72,12 +72,12 @@ if ($success) {
 }
 
 $response_arr = [
-    'success' => $allowed,
+    'success' => $success,
     'message' => $message,
     'peopleArray' => $peopleArray,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadCourseRoles.php
+++ b/src/Api/loadCourseRoles.php
@@ -75,7 +75,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadDriveUsers.php
+++ b/src/Api/loadDriveUsers.php
@@ -98,7 +98,7 @@ $response_arr = array(
 );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadDueDateInfo.php
+++ b/src/Api/loadDueDateInfo.php
@@ -90,7 +90,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadFolderContent.php
+++ b/src/Api/loadFolderContent.php
@@ -159,7 +159,7 @@ $response_arr = array(
   );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadProfile.php
+++ b/src/Api/loadProfile.php
@@ -62,7 +62,7 @@ if ($result->num_rows > 0) {
 }
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadTODO.php
+++ b/src/Api/loadTODO.php
@@ -186,7 +186,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/loadUserCourses.php
+++ b/src/Api/loadUserCourses.php
@@ -58,7 +58,7 @@ $response_arr = array(
 );
     
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/mergePeopleData.php
+++ b/src/Api/mergePeopleData.php
@@ -217,7 +217,7 @@ $response_arr = [
     'peopleArray' => $peopleArray,
 ];
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/publishAssignment.php
+++ b/src/Api/publishAssignment.php
@@ -157,7 +157,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/recordEvent.php
+++ b/src/Api/recordEvent.php
@@ -111,7 +111,7 @@ $response_arr = array(
   "message"=>$message
   );
 
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/releaseDraft.php
+++ b/src/Api/releaseDraft.php
@@ -99,7 +99,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/releaseVersion.php
+++ b/src/Api/releaseVersion.php
@@ -88,7 +88,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/renameCourseItem.php
+++ b/src/Api/renameCourseItem.php
@@ -68,7 +68,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/renamePageLink.php
+++ b/src/Api/renamePageLink.php
@@ -51,7 +51,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/saveCompiledActivity.php
+++ b/src/Api/saveCompiledActivity.php
@@ -186,7 +186,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/saveCompleted.php
+++ b/src/Api/saveCompleted.php
@@ -66,7 +66,7 @@ $response_arr = array(
         );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/saveDueDateInfo.php
+++ b/src/Api/saveDueDateInfo.php
@@ -101,7 +101,7 @@ $response_arr = array(
 );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/saveUserToDrive.php
+++ b/src/Api/saveUserToDrive.php
@@ -154,7 +154,7 @@ if ($type === "Remove User"){
 
 }
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/switchVersionUpdate.php
+++ b/src/Api/switchVersionUpdate.php
@@ -40,7 +40,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/umn/shibToJWT.php
+++ b/src/Api/umn/shibToJWT.php
@@ -201,7 +201,7 @@ $response_arr = [
 ];
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/updateContentFlags.php
+++ b/src/Api/updateContentFlags.php
@@ -118,7 +118,7 @@ $response_arr = [
 ];
 
 //set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/updateCreateAndDeletePageLinks.php
+++ b/src/Api/updateCreateAndDeletePageLinks.php
@@ -164,7 +164,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/updateItem.php
+++ b/src/Api/updateItem.php
@@ -44,7 +44,7 @@ $response_arr = array(
   );
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/updatePageLinks.php
+++ b/src/Api/updatePageLinks.php
@@ -109,7 +109,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);

--- a/src/Api/updateRestrictedTo.php
+++ b/src/Api/updateRestrictedTo.php
@@ -144,7 +144,7 @@ $response_arr = array(
 
 
 // set response code - 200 OK
-http_response_code(200);
+http_response_code($response_arr['success'] ? 200 : 400);
 
 // make it json format
 echo json_encode($response_arr);


### PR DESCRIPTION
- makes it much easier to find which request failed in the cypress interface
- also will make it much more likely we handle errors in the front-end code, we shouldn't always expect to get something parsable back from the server, sometimes clients will be temporarily disconnected from the internet and requests will fail, in those cases they won't get a nicely formed response from our server. Also sometimes we'll have bugs in the backend and not send back a well-formed response. Passing back error codes will mean we plan for any server request to hit a failure path, including an ungraceful one.
- arguably some of these exceptions should be 500 instead of 400, but this at least gets us setting something other than a success code when we shouldn't be.

Not ready for merging, I want to check that this isn't breaking things in the tests, but mostly posting to gather other people's thoughts.