### PR TITLE
Allow removing promoted content

### DIFF
--- a/public/api/loadPromotedContent.php
+++ b/public/api/loadPromotedContent.php
@@ -16,7 +16,7 @@ try {
     $isAdmin = userIsAdmin($userId, $conn);
 
     $sql = 
-        "select groupName, currentlyFeatured, homepage,
+        "select groupName, promotedGroupId, currentlyFeatured, homepage,
                 pc.sortOrder, doenetId, cc.label, cc.imagePath,
                 screenName, email, lastName, firstName, 
                 profilePicture, trackingConsent, canUpload

--- a/public/api/loadPromotedContent.php
+++ b/public/api/loadPromotedContent.php
@@ -36,6 +36,9 @@ try {
 
     $result = $conn->query($sql);
     $promotedGroups = [];
+    if (!$result) {
+        throw new Exception("Failure loading promoted content. - " . $conn->error);
+    }
     while ($row = $result->fetch_assoc()) {
         if ($promotedGroups[$row['groupName']]) {
             // add to existing list for this group if it was found in the list of rows so far

--- a/public/api/removePromotedContent.php
+++ b/public/api/removePromotedContent.php
@@ -1,0 +1,51 @@
+<?php
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: access');
+header('Access-Control-Allow-Methods: POST');
+header('Access-Control-Allow-Credentials: true');
+header('Content-Type: application/json');
+
+include 'db_connection.php';
+include 'checkForCommunityAdminFunctions.php';
+
+$jwtArray = include 'jwtArray.php';
+$userId = $jwtArray['userId'];
+
+$_POST = json_decode(file_get_contents("php://input"),true);
+
+$doenetId = mysqli_real_escape_string($conn,$_POST["doenetId"]);
+$groupId = mysqli_real_escape_string($conn,$_POST["groupId"]);
+
+$response_arr;
+try {
+    // throws exception if current user is not an admin
+    checkForAdmin($userId, $conn);
+
+    $sql = 
+        "delete from promoted_content where doenetId = '$doenetId' and promotedGroupId = '$groupId'";
+
+    $result = $conn->query($sql);
+    if ($result) {
+        $response_arr = [
+            'success' => true,
+            'message' => $sql
+        ];
+    } else {
+        throw new Exception("Error removing promoted content from this group. - " . $conn->error);
+    }
+    // set response code - 200 OK
+    http_response_code(200);
+
+} catch (Exception $e) {
+    $response_arr = [
+        'success' => false,
+        'message' => $e->getMessage(),
+    ];
+    http_response_code(400);
+
+} finally {
+    // make it json format
+    echo json_encode($response_arr);
+    $conn->close();
+}
+?>

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -577,35 +577,37 @@ export function Community() {
             groupName += ' (Not currently featured on community page)';
           }
           return (
-            <Box key={'carosel-' + group.groupName}>
-              <Text fontSize="24px">{groupName}</Text>
-              <br />
-              <Wrap>
-                {isAdmin ? (
-                  group.map((cardObj, i) => {
-                    return (
-                      <ActivityCard
-                        {...cardObj}
-                        key={`swipercard${i}`}
-                        fullName={cardObj.firstName + ' ' + cardObj.lastName}
-                        imageLink={`/portfolioviewer/${cardObj.doenetId}`}
-                        menuItems={
-                          null
-                          /* z-index stacking issues, might be related to the carousel
+            <span key={'carosel-' + group.groupName}>
+              {isAdmin ? (
+                <span>
+                  <Text fontSize="24px">{groupName}</Text>
+                  <br />
+                  <Wrap>
+                    {group.map((cardObj, i) => {
+                      return (
+                        <ActivityCard
+                          {...cardObj}
+                          key={`swipercard${i}`}
+                          fullName={cardObj.firstName + ' ' + cardObj.lastName}
+                          imageLink={`/portfolioviewer/${cardObj.doenetId}`}
+                          menuItems={
+                            null
+                            /* z-index stacking issues, might be related to the carousel
                       <>
                         <MenuItem>Move Left</MenuItem>
                         <MenuItem>Move Right</MenuItem>
                       </>
                     */
-                        }
-                      />
-                    );
-                  })
-                ) : (
-                  <Carousel title={groupName} data={group} />
-                )}
-              </Wrap>
-            </Box>
+                          }
+                        />
+                      );
+                    })}
+                  </Wrap>
+                </span>
+              ) : (
+                <Carousel title={groupName} data={group} />
+              )}
+            </span>
           );
         })}
       </CarouselSection>

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -550,6 +550,10 @@ export function Community() {
       <Heading heading="Community Public Content" />
 
       <CarouselSection>
+        <Text>
+          You are logged in as an admin and can manage these lists, they will
+          show to other users as carousels
+        </Text>
         {Object.keys(carouselData)
           .map((groupName) => {
             return { activities: carouselData[groupName], groupName };
@@ -569,9 +573,6 @@ export function Community() {
             if (!isAdmin && group[0].groupName == 'Homepage') {
               return null;
             }
-            console.log(carouselData);
-            console.log(group[0]);
-            console.log(!group[0].currentlyFeatured);
             if (
               isAdmin &&
               group[0].groupName != 'Homepage' &&

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -577,11 +577,35 @@ export function Community() {
             groupName += ' (Not currently featured on community page)';
           }
           return (
-            <Carousel
-              key={'carosel-' + group.groupName}
-              title={groupName}
-              data={group}
-            />
+            <Box key={'carosel-' + group.groupName}>
+              <Text fontSize="24px">{groupName}</Text>
+              <br />
+              <Wrap>
+                {isAdmin ? (
+                  group.map((cardObj, i) => {
+                    return (
+                      <ActivityCard
+                        {...cardObj}
+                        key={`swipercard${i}`}
+                        fullName={cardObj.firstName + ' ' + cardObj.lastName}
+                        imageLink={`/portfolioviewer/${cardObj.doenetId}`}
+                        menuItems={
+                          null
+                          /* z-index stacking issues, might be related to the carousel
+                      <>
+                        <MenuItem>Move Left</MenuItem>
+                        <MenuItem>Move Right</MenuItem>
+                      </>
+                    */
+                        }
+                      />
+                    );
+                  })
+                ) : (
+                  <Carousel title={groupName} data={group} />
+                )}
+              </Wrap>
+            </Box>
           );
         })}
       </CarouselSection>

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -53,8 +53,6 @@ export async function action({ request }) {
     }
   }
 
-  console.log(formObj);
-
   switch (formObj?._action) {
     case 'Ban Content':
       return postApiAlertOnError('/api/markContentAsBanned.php', { doenetId });

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -570,6 +570,7 @@ export function Community() {
           .map((groupInfo) => {
             let groupName = groupInfo.groupName;
             const group = groupInfo.activities;
+            let notPromoted = false;
             if (!isAdmin && group[0].groupName == 'Homepage') {
               return null;
             }
@@ -579,12 +580,47 @@ export function Community() {
               (group[0].currentlyFeatured == '0' || !group[0].currentlyFeatured)
             ) {
               groupName += ' (Not currently featured on community page)';
+              notPromoted = true;
             }
             return (
               <>
                 {isAdmin ? (
                   <span>
                     <Text fontSize="24px">{groupName}</Text>
+                    {notPromoted ? (
+                      <Button
+                        onClick={() => {
+                          fetcher.submit(
+                            {
+                              _action: 'Promote Group',
+                              groupName: groupInfo.groupName,
+                              currentlyFeatured: true,
+                              homepage: false,
+                            },
+                            { method: 'post' },
+                          );
+                        }}
+                      >
+                        Promote
+                      </Button>
+                    ) : (
+                      <Button
+                        onClick={() => {
+                          fetcher.submit(
+                            {
+                              _action: 'Promote Group',
+                              groupName: groupInfo.groupName,
+                              currentlyFeatured: false,
+                              homepage: false,
+                            },
+                            { method: 'post' },
+                          );
+                        }}
+                      >
+                        Stop Promoting
+                      </Button>
+                    )}
+                    <br />
                     <br />
                     <Wrap>
                       {group.map((cardObj, i) => {

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -564,6 +564,9 @@ export function Community() {
       <CarouselSection>
         {Object.keys(carouselData).map((groupName) => {
           let group = carouselData[groupName];
+          if (!isAdmin && group[0].groupName == 'Homepage') {
+            return null;
+          }
           if (
             group.length > 1 &&
             isAdmin &&

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -577,7 +577,7 @@ export function Community() {
             groupName += ' (Not currently featured on community page)';
           }
           return (
-            <span key={'carosel-' + group.groupName}>
+            <>
               {isAdmin ? (
                 <span>
                   <Text fontSize="24px">{groupName}</Text>
@@ -607,7 +607,7 @@ export function Community() {
               ) : (
                 <Carousel title={groupName} data={group} />
               )}
-            </span>
+            </>
           );
         })}
       </CarouselSection>

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -548,10 +548,12 @@ export function Community() {
       <Heading heading="Community Public Content" />
 
       <CarouselSection>
-        <Text>
-          You are logged in as an admin and can manage these lists, they will
-          show to other users as carousels
-        </Text>
+        {isAdmin ? (
+          <Text>
+            You are logged in as an admin and can manage these lists, they will
+            show to other users as carousels
+          </Text>
+        ) : null}
         {Object.keys(carouselData)
           .map((groupName) => {
             return { activities: carouselData[groupName], groupName };

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -550,63 +550,80 @@ export function Community() {
       <Heading heading="Community Public Content" />
 
       <CarouselSection>
-        {Object.keys(carouselData).map((groupName) => {
-          let group = carouselData[groupName];
-          if (!isAdmin && group[0].groupName == 'Homepage') {
-            return null;
-          }
-          if (
-            group.length > 1 &&
-            isAdmin &&
-            (group[0].currentlyFeatured == '0' ||
-              !group[0].currentlyFeatured ||
-              group[0].groupName == 'Homepage')
-          ) {
-            groupName += ' (Not currently featured on community page)';
-          }
-          return (
-            <>
-              {isAdmin ? (
-                <span>
-                  <Text fontSize="24px">{groupName}</Text>
-                  <br />
-                  <Wrap>
-                    {group.map((cardObj, i) => {
-                      return (
-                        <ActivityCard
-                          {...cardObj}
-                          key={`swipercard${i}`}
-                          fullName={cardObj.firstName + ' ' + cardObj.lastName}
-                          imageLink={`/portfolioviewer/${cardObj.doenetId}`}
-                          menuItems={
-                            <>
-                              <MenuItem
-                                onClick={() => {
-                                  fetcher.submit(
-                                    {
-                                      _action: 'Remove Promoted Content',
-                                      doenetId: cardObj.doenetId,
-                                      groupId: cardObj.promotedGroupId,
-                                    },
-                                    { method: 'post' },
-                                  );
-                                }}
-                              >
-                                Remove from group
-                              </MenuItem>
-                            </>
-                          }
-                        />
-                      );
-                    })}
-                  </Wrap>
-                </span>
-              ) : (
-                <Carousel title={groupName} data={group} />
-              )}
-            </>
-          );
-        })}
+        {Object.keys(carouselData)
+          .map((groupName) => {
+            return { activities: carouselData[groupName], groupName };
+          })
+          .sort((a, b) => {
+            if (a.activities[0].groupName == 'Homepage') return -1;
+            else if (b.activities[0].groupName == 'Homepage') return 1;
+            else
+              return a.activities[0].currentlyFeatured >
+                b.activities[0].currentlyFeatured
+                ? -1
+                : 1;
+          })
+          .map((groupInfo) => {
+            let groupName = groupInfo.groupName;
+            const group = groupInfo.activities;
+            if (!isAdmin && group[0].groupName == 'Homepage') {
+              return null;
+            }
+            console.log(carouselData);
+            console.log(group[0]);
+            console.log(!group[0].currentlyFeatured);
+            if (
+              isAdmin &&
+              group[0].groupName != 'Homepage' &&
+              (group[0].currentlyFeatured == '0' || !group[0].currentlyFeatured)
+            ) {
+              groupName += ' (Not currently featured on community page)';
+            }
+            return (
+              <>
+                {isAdmin ? (
+                  <span>
+                    <Text fontSize="24px">{groupName}</Text>
+                    <br />
+                    <Wrap>
+                      {group.map((cardObj, i) => {
+                        return (
+                          <ActivityCard
+                            {...cardObj}
+                            key={`swipercard${i}`}
+                            fullName={
+                              cardObj.firstName + ' ' + cardObj.lastName
+                            }
+                            imageLink={`/portfolioviewer/${cardObj.doenetId}`}
+                            menuItems={
+                              <>
+                                <MenuItem
+                                  onClick={() => {
+                                    fetcher.submit(
+                                      {
+                                        _action: 'Remove Promoted Content',
+                                        doenetId: cardObj.doenetId,
+                                        groupId: cardObj.promotedGroupId,
+                                      },
+                                      { method: 'post' },
+                                    );
+                                  }}
+                                >
+                                  Remove from group
+                                </MenuItem>
+                              </>
+                            }
+                          />
+                        );
+                      })}
+                    </Wrap>
+                  </span>
+                ) : (
+                  <Carousel title={groupName} data={group} />
+                )}
+              </>
+            );
+          })}
       </CarouselSection>
     </>
   );

--- a/src/Tools/_framework/Paths/Community.jsx
+++ b/src/Tools/_framework/Paths/Community.jsx
@@ -562,28 +562,6 @@ export function Community() {
       <Heading heading="Community Public Content" />
 
       <CarouselSection>
-        {/* for admins, show the currently promoted groups first */}
-        {Object.keys(carouselData).map((groupName) => {
-          let group = carouselData[groupName];
-          console.log(group);
-          if (
-            group.length < 1 ||
-            group[0].currentlyFeatured != '1' ||
-            group[0].groupName == 'Homepage'
-          ) {
-            return null;
-          }
-          return (
-            <Carousel
-              key={'carosel-' + group.groupName}
-              title={groupName}
-              data={group}
-            />
-          );
-        })}
-        {/* for admins, show the rest of the groups, the ones not featured
-            these will be filtered out in the server for non-admins and will not show
-         */}
         {Object.keys(carouselData).map((groupName) => {
           let group = carouselData[groupName];
           if (
@@ -593,16 +571,15 @@ export function Community() {
               !group[0].currentlyFeatured ||
               group[0].groupName == 'Homepage')
           ) {
-            return (
-              <Carousel
-                key={'carosel-' + group.groupName}
-                title={
-                  groupName + ' (Not currently featured on community page)'
-                }
-                data={group}
-              />
-            );
+            groupName += ' (Not currently featured on community page)';
           }
+          return (
+            <Carousel
+              key={'carosel-' + group.groupName}
+              title={groupName}
+              data={group}
+            />
+          );
         })}
       </CarouselSection>
     </>

--- a/src/_reactComponents/PanelHeaderComponents/Carousel.jsx
+++ b/src/_reactComponents/PanelHeaderComponents/Carousel.jsx
@@ -88,6 +88,7 @@ export function Carousel({ title = '', data = [] }) {
         <Text fontSize="18px" fontWeight="700">
           {title}
         </Text>
+        <br />
 
         <Box display="flex">
           <LeftChevron


### PR DESCRIPTION
With these changes admins can remove individual materials from promoted groups.

There was a small bug with the charkra pulldown menus not displaying properly within our carousels provided by the Swiper library. We might need to fix that at some point, if we later need a menu on a card in a carousel, but for the sake of getting this done faster, as well as making it easier for admins to see everything that is in a promoted list while they managed it, I just moved the admin view of the community page to show all of the promoted groups as simple lists of cards without carousels.

Regular users still see the carousels to make it easier to view diversity categories featured and not get overloaded looking at too much at once.