### PR TITLE
Fix bug with non-clobbering editor, was always renaming to backup file even when the OCC check failed

### DIFF
--- a/public/api/saveDoenetML.php
+++ b/public/api/saveDoenetML.php
@@ -21,40 +21,30 @@ $saveAsCid = mysqli_real_escape_string($conn, $_POST["saveAsCid"]);
 $lastKnownCid = mysqli_real_escape_string($conn, $_POST["lastKnownCid"]);
 $backup = mysqli_real_escape_string($conn, $_POST["backup"]);
 
-$success = true;
 $message = "";
 $cid = null;
 
-// set default response code - 200 OK
-http_response_code(200);
+try {
+    if ($pageId == "") {
+        throw new Exception("Internal Error: missing pageId");
+    } elseif ($courseId == "") {
+        throw new Exception("Internal Error: missing courseId");
+    } elseif ($userId == "") {
+        throw new Exception("You need to be signed in to edit a page");
+    }
 
-if ($pageId == "") {
-    $success = false;
-    $message = "Internal Error: missing pageId";
-} elseif ($courseId == "") {
-    $success = false;
-    $message = "Internal Error: missing courseId";
-} elseif ($userId == "") {
-    $success = false;
-    $message = "You need to be signed in to edit a page";
-}
-
-//Test Permission to edit content
-if ($success) {
+    //Test Permission to edit content
     $permissions = permissionsAndSettingsForOneCourseFunction(
         $conn,
         $userId,
         $courseId
     );
     if ($permissions["canEditContent"] != "1") {
-        $success = false;
-        $message = "You need edit permission to edit a page";
+        throw new Exception("You need edit permission to edit a page");
         // http_response_code(403);
     }
-}
 
-// check if pageId belongs to courseId
-if ($success) {
+    // check if pageId belongs to courseId
     $sql = "SELECT doenetId, label
         FROM pages
         WHERE courseId='$courseId' AND doenetId='$pageId'
@@ -77,14 +67,10 @@ if ($success) {
             $row = $result->fetch_assoc();
             $label = $row["label"];
         } else {
-
-            $success = false;
-            $message = "Invalid page";
+            throw new Exception("Invalid page");
         }
     }
-}
 
-if ($success) {
     if ($saveAsCid == "1") {
         $SHA = hash("sha256", $dangerousDoenetML);
         $cid = cidFromSHA($SHA);
@@ -98,50 +84,60 @@ if ($success) {
             $oldCid = cidFromSHA($SHA);
             
             if ($lastKnownCid != $oldCid) {
-                $success = false;
-                $message = "YOUR CHANGES TO THE DOCUMENT HAVE NOT BEEN SAVED. This document has been modified since you last saved. " .
-                "Reload the page to view the new version, or open it in a new tab to compare them yourself.";
+                throw new Exception("YOUR CHANGES TO THE DOCUMENT HAVE NOT BEEN SAVED. This document has been modified since you last saved. " .
+                "Reload the page to view the new version, or open it in a new tab to compare them yourself.");
             }
             if ($backup == "1") {
-                rename($path, "../media/$filename.bak");
+                $status = rename($path, "../media/$filename.bak");
+                if (!$status) {
+                    throw new Exception("Failed to save backup file, aborting save entirely, please retry.");
+                }
             }
         }
     }
 
-    if ($success) {
-        //TODO: Config file needed for server
-        $newfile = fopen("../media/$filename.doenet", "w");
-        if ($newfile === false) {
-            $success = false;
-            $message = "Unable to open file!";
+    //TODO: Config file needed for server
+    $newfile = fopen("../media/$filename.doenet", "w");
+    if ($newfile === false) {
+        throw new Exception("Unable to open file!");
+        // http_response_code(500);
+    } else {
+        $status = fwrite($newfile, $dangerousDoenetML);
+        if ($status === false) {
+            throw new Exception("Didn't save to file");
             // http_response_code(500);
         } else {
-            $status = fwrite($newfile, $dangerousDoenetML);
-            if ($status === false) {
-                $success = false;
-                $message = "Didn't save to file";
-                // http_response_code(500);
-            } else {
-                fclose($newfile);
-            }
+            fclose($newfile);
         }
     }
+
+    $response_arr = [
+        "success" => true,
+        "message" => $message,
+        // This cid is only defined in the case where you requested saveAsCid.
+        // In the case where we are saving by page id the client is expected to
+        // hash the content after a successful save to know what to send in the next
+        // request as the lastKnownCid.
+        "cid" => $cid,
+        "label" => $label,
+        "saveAsCid" => $saveAsCid,
+        "filename" => $filename
+    ];
+    http_response_code(200);
+
+} catch (Exception $e) {
+    $response_arr = [
+        'success' => false,
+        'message' => $e->getMessage(),
+    ];
+    http_response_code(200);
+    // TODO - enable error codes when all callers are confirmed to handle them correctly
+    // several of the exceptions in this file should be 500 level exceptions for internal server errors
+    //http_response_code(400);
+
+} finally {
+    // make it json format
+    echo json_encode($response_arr);
+    $conn->close();
 }
-
-$response_arr = [
-    "success" => $success,
-    "message" => $message,
-    // This cid is only defined in the case where you requested saveAsCid.
-    // In the case where we are saving by page id the client is expected to
-    // hash the content after a successful save to know what to send in the next
-    // request as the lastKnownCid.
-    "cid" => $cid,
-    "label" => $label,
-    "saveAsCid" => $saveAsCid,
-    "filename" => $filename
-];
-
-echo json_encode($response_arr);
-
-$conn->close();
 ?>


### PR DESCRIPTION
- as we weren't saving the new version when the validation failed, this has the effect of making users lose access to the file via the app