### PR TITLE
Fix saving after undo

### DIFF
--- a/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
+++ b/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
@@ -1407,12 +1407,21 @@ describe("Code Editor Tag Tests", function () {
 
       cy.log("Overwrite text");
 
-      cy.get(cesc("#\\/_codeeditor1") + " .cm-content").type(
-        "{control+a}<alert>Ovewritten!</alert>",
-        {
-          delay: 0,
-        },
-      );
+      if (Cypress.platform === "darwin") {
+        cy.get(cesc("#\\/_codeeditor1") + " .cm-content").type(
+          "{command+a}<alert>Ovewritten!</alert>",
+          {
+            delay: 0,
+          },
+        );
+      } else {
+        cy.get(cesc("#\\/_codeeditor1") + " .cm-content").type(
+          "{control+a}<alert>Ovewritten!</alert>",
+          {
+            delay: 0,
+          },
+        );
+      }
       cy.get(updateAnchor).click();
 
       cy.get(cesc2("#/_p1")).should("have.text", "<alert>Ovewritten!</alert>");

--- a/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
+++ b/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
@@ -1344,4 +1344,107 @@ describe("Code Editor Tag Tests", function () {
     );
     cy.get(cesc2("#/pv")).should("have.text", "value: Hello!\nSelam!\nKaixo!");
   });
+
+  it("undo prompts save", () => {
+    let doenetML = `
+    <text>a</text>
+    <codeEditor showResults />
+
+    <p><copy prop="value" target="_codeeditor1" /></p>
+    `;
+
+    cy.get("#testRunner_toggleControls").click();
+    cy.get("#testRunner_allowLocalState").click();
+    cy.wait(100);
+    cy.get("#testRunner_toggleControls").click();
+
+    cy.window().then(async (win) => {
+      win.postMessage(
+        {
+          doenetML,
+        },
+        "*",
+      );
+    });
+
+    cy.get(cesc("#\\/_text1")).should("contain.text", "a");
+
+    cy.window().then(async (win) => {
+      let stateVariables = await win.returnAllStateVariables1();
+
+      let viewerName =
+        stateVariables["/_codeeditor1"].activeChildren[0].componentName;
+      let updateAnchor = "#" + cesc2(viewerName) + "_updateButton";
+      let contentAnchor = "#" + cesc2(viewerName) + "_content";
+
+      cy.get(cesc2("#/_p1")).should("have.text", "");
+      cy.get(contentAnchor).should("have.text", "");
+
+      cy.log("type text in editor");
+      cy.get(cesc("#\\/_codeeditor1") + " .cm-content").type("<p>Hello!</p>", {
+        delay: 0,
+      });
+      cy.get(updateAnchor).click();
+
+      cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>");
+      cy.get(contentAnchor).should("have.text", "Hello!");
+
+      cy.wait(1500); // wait for 1 second debounce
+
+      cy.reload();
+
+      cy.window().then(async (win) => {
+        win.postMessage(
+          {
+            doenetML,
+          },
+          "*",
+        );
+      });
+
+      cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>");
+      cy.get(contentAnchor).should("have.text", "Hello!");
+
+      cy.log("Overwrite text");
+
+      cy.get(cesc("#\\/_codeeditor1") + " .cm-content").type(
+        "{control+a}<alert>Ovewritten!</alert>",
+        {
+          delay: 0,
+        },
+      );
+      cy.get(updateAnchor).click();
+
+      cy.get(cesc2("#/_p1")).should("have.text", "<alert>Ovewritten!</alert>");
+      cy.get(contentAnchor).should("have.text", "Ovewritten!");
+
+      cy.wait(1500); // wait for 1 second debounce
+
+      if (Cypress.platform === "darwin") {
+        cy.get(".cm-content").type("{command}{z}");
+      } else {
+        cy.get(".cm-content").type("{control}{z}");
+      }
+      cy.get(updateAnchor).click();
+
+      cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>");
+      cy.get(contentAnchor).should("have.text", "Hello!");
+
+      cy.wait(1500); // wait for 1 second debounce
+
+      cy.reload();
+
+      cy.window().then(async (win) => {
+        win.postMessage(
+          {
+            doenetML,
+          },
+          "*",
+        );
+      });
+
+      cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>");
+      cy.get(contentAnchor).should("have.text", "Hello!");
+    });
+  });
 });

--- a/cypress/e2e/Editor/Editor.cy.js
+++ b/cypress/e2e/Editor/Editor.cy.js
@@ -65,17 +65,24 @@ describe("doenetEditor test", function () {
     cy.reload();
     cy.get(".cm-content").contains(doenetMLString);
     cy.get(".cm-content").type("newly added content");
+    cy.get(".cm-content").type("\n");
+    cy.get(".cm-content").type("even more stuff");
 
     cy.wait(5000); // make sure we have a debounced save event from the newly typed text
     if (Cypress.platform === "darwin") {
       cy.get(".cm-content").type("{command}{z}");
+      cy.get(".cm-content").type("{command}{z}");
+      cy.get(".cm-content").type("{command}{shift}{z}");
     } else {
       cy.get(".cm-content").type("{control}{z}");
+      cy.get(".cm-content").type("{control}{z}");
+      cy.get(".cm-content").type("{control}{y}");
     }
     cy.wait(5000); // wait for another debounce after the undo event
     cy.reload();
     cy.get(cesc2("#/_document1")).contains(doenetMLString);
-    cy.get(cesc2("#/_document1")).should("not.contain", "newly added content");
+    cy.get(cesc2("#/_document1")).contains("newly added content");
+    cy.get(cesc2("#/_document1")).should("not.contain", "even more stuff");
   });
 
   it("command+s updates viewer", () => {

--- a/cypress/e2e/Editor/Editor.cy.js
+++ b/cypress/e2e/Editor/Editor.cy.js
@@ -55,6 +55,29 @@ describe("doenetEditor test", function () {
     cy.get(cesc2("#/_document1")).contains(doenetMLString);
   });
 
+  it("undo event prompts save to server", () => {
+    const doenetMLString = "abcdefg";
+    cy.get(".cm-content").type(doenetMLString);
+
+    cy.get(".cm-content").type("{control}{s}");
+    cy.wait(1000); // wait for the doc to save to the server
+
+    cy.reload();
+    cy.get(".cm-content").contains(doenetMLString);
+    cy.get(".cm-content").type("newly added content");
+
+    cy.wait(5000); // make sure we have a debounced save event from the newly typed text
+    if (Cypress.platform === "darwin") {
+      cy.get(".cm-content").type("{command}{z}");
+    } else {
+      cy.get(".cm-content").type("{control}{z}");
+    }
+    cy.wait(5000); // wait for another debounce after the undo event
+    cy.reload();
+    cy.get(cesc2("#/_document1")).contains(doenetMLString);
+    cy.get(cesc2("#/_document1")).should("not.contain", "newly added content");
+  });
+
   it("command+s updates viewer", () => {
     const doenetMLString = "abcdefg";
     cy.get(".cm-content").type(doenetMLString);

--- a/src/Tools/_framework/CodeMirror.jsx
+++ b/src/Tools/_framework/CodeMirror.jsx
@@ -201,11 +201,7 @@ export default function CodeMirror({
       onBlurExtension,
       onFocusExtension,
       EditorState.changeFilter.of(changeFunc),
-      EditorView.updateListener.of(function (update) {
-        if (update.docChanged) {
-          onBeforeChange(update.state.sliceDoc());
-        }
-      }),
+      EditorView.updateListener.of(changeFunc),
     ],
     [changeFunc],
   );

--- a/src/Tools/_framework/CodeMirror.jsx
+++ b/src/Tools/_framework/CodeMirror.jsx
@@ -201,6 +201,11 @@ export default function CodeMirror({
       onBlurExtension,
       onFocusExtension,
       EditorState.changeFilter.of(changeFunc),
+      EditorView.updateListener.of(function (update) {
+        if (update.docChanged) {
+          onBeforeChange(update.state.sliceDoc());
+        }
+      }),
     ],
     [changeFunc],
   );


### PR DESCRIPTION
The API we were listening to does not fire events for undo/redo. This updateListener does give us events for these, although it also gives events for other things like changing cursor position or the selection range with a click and drag. The docs claim computing "docChanged" is cheap, so it doesn't look like doing this should be problematic, but it is definitely unintuitive that undo/redo don't fire events for the other changeFilter API. Several events will fire for both of these handlers, like a regular typing event, but it shouldn't be a problem as the actual save is debounced anyway so we won't get extra events to the server.

Fixes #1315