### PR TITLE
Temporarily expose the content IDs in an error message to users to help us hunt down a bug...

### DIFF
--- a/public/api/saveDoenetML.php
+++ b/public/api/saveDoenetML.php
@@ -84,8 +84,12 @@ try {
             $oldCid = cidFromSHA($SHA);
             
             if ($lastKnownCid != $oldCid) {
-                throw new Exception("YOUR CHANGES TO THE DOCUMENT HAVE NOT BEEN SAVED. This document has been modified since you last saved. " .
-                "Reload the page to view the new version, or open it in a new tab to compare them yourself.");
+                throw new Exception(
+                    "YOUR CHANGES TO THE DOCUMENT HAVE NOT BEEN SAVED. " .
+                    "This document has been modified since you last saved. " .
+                    "Reload the page to view the new version, or open it " .
+                    "in a new tab to compare them yourself. ".
+                    "Content ids mismatched ($oldCid, $lastKnownCid)");
             }
             if ($backup == "1") {
                 $status = rename($path, "../media/$filename.bak");


### PR DESCRIPTION
… in the new feature to prevent clobbering the work of others

- several users have seen an issue where they are getting this message when they shouldn't be
- once we are confident this feature is working correctly there is no reason to expose these IDs to users and we should modify the message to remove them, this will just allow us to hopefully diagnose the problem easier