### PR TITLE
Revert "Update dev enviroment to support Codespaces (#2172)"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
   "name": "DoenetTools",
-  "hostRequirements": {
-    "memory": "4gb"
-  },
 
   // Update the 'dockerComposeFile' list if you have more compose files or use different names.
   // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
@@ -20,7 +17,7 @@
   "workspaceFolder": "/home/node/workspace",
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [8080, 3306],
+  // "forwardPorts": ["dev:80"],
 
   // Uncomment the next line if you want start specific services in your Docker Compose config.
   // "runServices": [],
@@ -28,7 +25,7 @@
   // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
   "shutdownAction": "stopCompose",
 
-  // "initializeCommand": "docker compose -f docker-compose.yml -f .devcontainer/docker-compose.extend.yml down",
+  "initializeCommand": "docker compose -f docker-compose.yml -f .devcontainer/docker-compose.extend.yml down",
   // Uncomment the next line to run commands after the container is created - for example installing curl.
   "postCreateCommand": "npm install && npx vite optimize",
 

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -31,13 +31,13 @@ services:
       # Persist VS Code extensions between rebuilds
       # - vscode-extensions:/root/.vscode-server/extensions
       # mount ssh configuration
-      # - ~/.ssh:/.ssh
+      - ~/.ssh:/.ssh
     networks:
       - dev_net
     environment:
       - CYPRESS_CACHE_FOLDER=/home/node/workspace/.cache/Cypress
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
-      - NODE_OPTIONS=--max-old-space-size=3584
+      - NODE_OPTIONS=--max-old-space-size=4098
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     cap_add:
       - SYS_PTRACE
@@ -61,7 +61,6 @@ services:
       dockerfile: ./doenet_docker/apache/Dockerfile
       args:
         - BUILD_MODE=development
-        - NODE_OPTIONS=--max-old-space-size=3584
     volumes:
       - ./src/Media:/usr/local/apache2/htdocs/media
       - ./doenet_docker/apache/apache.conf:/usr/local/apache2/conf/httpd.conf
@@ -69,7 +68,7 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - db:/var/lib/mysql
+      - ./doenet_docker/volumes/db:/var/lib/mysql
       - ./doenet_docker/volumes/db_init:/docker-entrypoint-initdb.d
     restart: on-failure
 
@@ -90,4 +89,3 @@ services:
 volumes:
   node_modules:
   vendor:
-  db:

--- a/doenet_docker/apache/Dockerfile
+++ b/doenet_docker/apache/Dockerfile
@@ -1,14 +1,12 @@
 FROM node:19.8-bullseye AS build
 WORKDIR /build
-COPY package-lock.json package.json ./
+COPY package*.json ./
 RUN npm ci
 COPY index.html vite.config.js ./
 COPY src ./src
 COPY public ./public
-ARG BUILD_MODE=production
-ARG NODE_OPTIONS
-ENV NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=3584}
-RUN npm run build -- --outDir site --mode ${BUILD_MODE}
+ARG BUILD_MODE
+RUN NODE_OPTIONS=--max-old-space-size=4098 npm run build -- --outDir site --mode ${BUILD_MODE}
 
 FROM httpd:2.4.41-alpine
 RUN apk update; \


### PR DESCRIPTION
This reverts commit 6f8827840661b8d92bb9a6700502cc301ad58819.

This change is breaking several things in local dev environments on mac. The things we identified so far were the inability to run cypress tests against the built site on port 8080 and we also cannot connect to our local mysql databases with various tools (graphical query tool and the mysql cli client)