### PR TITLE
ignore variants from children of <codeEditor>

### DIFF
--- a/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
+++ b/cypress/e2e/DoenetML/tagSpecific/codeeditor.cy.js
@@ -2126,4 +2126,30 @@ describe("Code Editor Tag Tests", function () {
       .then((str) => parseInt(str))
       .should("be.closeTo", 500, 5);
   });
+
+  it("ignore variants from children", () => {
+    cy.window().then(async (win) => {
+      win.postMessage(
+        {
+          doenetML: `
+          <text>a</text>
+          <codeEditor name="ce1" showResults ><selectFromSequence/></codeEditor>
+          `,
+        },
+        "*",
+      );
+    });
+
+    // to wait for page to load
+    cy.get(cesc2("#/_text1")).should("have.text", "a");
+
+    cy.log("Have only one variant despite selectFromSequence child")
+    cy.window().then(async (win) => {
+      let stateVariables = await win.returnAllStateVariables1();
+
+      expect(
+        stateVariables["/_document1"].sharedParameters.allPossibleVariants,
+      ).eqls(["a"]);
+    });
+  });
 });

--- a/src/Core/components/CodeEditor.js
+++ b/src/Core/components/CodeEditor.js
@@ -18,6 +18,8 @@ export default class CodeEditor extends BlockComponent {
 
   static renderChildren = true;
 
+  static ignoreVariantsFromChildren = true;
+
   static processWhenJustUpdatedForNewComponent = true;
 
   static get stateVariablesShadowedForReference() {

--- a/src/Core/utils/variants.js
+++ b/src/Core/utils/variants.js
@@ -131,7 +131,15 @@ export function gatherVariantComponents({
       continue;
     }
 
-    if (!serializedComponent.children) {
+    let compClass =
+      componentInfoObjects.allComponentClasses[
+        serializedComponent.componentType
+      ];
+
+    if (
+      compClass?.ignoreVariantsFromChildren ||
+      !serializedComponent.children
+    ) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #2291.