### PR TITLE
Allow adding two activities to a section, and fix page crashing unhappy donut messages when adding collections or sub-sections

### DIFF
--- a/cypress/e2e/Navigation/Activity.cy.js
+++ b/cypress/e2e/Navigation/Activity.cy.js
@@ -45,4 +45,72 @@ describe("Activity test", function () {
       .type("{enter}", { scrollBehavior: false });
     cy.get('[data-test="rowLabel"]').should("contain.text", label2);
   });
+
+  it("Renaming section", () => {
+    const label1 = "section rename test";
+    const label2 = "this section was renamed";
+    cy.get('[data-test="Add Section Button"]').click();
+    cy.contains(".navigationRow", "Untitled Section").click();
+
+    cy.get('[data-test="Label Section"]', { timeout: 20000 })
+      .should("be.visible")
+      .clear({ scrollBehavior: false })
+      .type(label1, { scrollBehavior: false });
+    cy.get('[data-test="infoPanelItemLabel"]').click();
+    cy.get('[data-test="rowLabel"]').should("contain.text", label1);
+    cy.get('[data-test="Label Section"]', { timeout: 20000 })
+      .should("be.visible")
+      .clear({ scrollBehavior: false })
+      .type(label2, { scrollBehavior: false })
+      .type("{enter}", { scrollBehavior: false });
+    cy.get('[data-test="rowLabel"]').should("contain.text", label2);
+  });
+
+  it("Adding sub-sections", () => {
+    const label1 = "Adding sub-sections test";
+    cy.get('[data-test="Add Section Button"]').click();
+    cy.contains(".navigationRow", "Untitled Section").click();
+
+    cy.get('[data-test="Label Section"]', { timeout: 20000 })
+      .should("be.visible")
+      .clear({ scrollBehavior: false })
+      .type(label1, { scrollBehavior: false });
+    cy.get('[data-test="infoPanelItemLabel"]').click();
+    cy.get('[data-test="rowLabel"]').should("contain.text", label1);
+
+    // click on the section to expand it and show the sub-section
+    cy.get('[data-test="folderToggleOpenIcon"]').click();
+
+    cy.contains(".navigationRow", label1).click();
+    cy.get('[data-test="Add Activity Button"]').click();
+    cy.contains(".navigationRow", label1).click();
+    // this used to fail when there was an activity in a section
+    cy.get('[data-test="Add Section Button"]').click();
+
+    cy.contains(".navigationRow", "Untitled Section").click();
+  });
+
+  it("Adding collection below section", () => {
+    const label1 = "Adding collection below sections test";
+    cy.get('[data-test="Add Section Button"]').click();
+    cy.contains(".navigationRow", "Untitled Section").click();
+
+    cy.get('[data-test="Label Section"]', { timeout: 20000 })
+      .should("be.visible")
+      .clear({ scrollBehavior: false })
+      .type(label1, { scrollBehavior: false });
+    cy.get('[data-test="infoPanelItemLabel"]').click();
+    cy.get('[data-test="rowLabel"]').should("contain.text", label1);
+
+    // click on the section to expand it and show the sub-section
+    cy.get('[data-test="folderToggleOpenIcon"]').click();
+
+    cy.contains(".navigationRow", label1).click();
+    cy.get('[data-test="Add Activity Button"]').click();
+    cy.contains(".navigationRow", label1).click();
+    // this used to fail when there was an activity in a section
+    cy.get('[data-test="Add Collection Button"]').click();
+
+    cy.contains(".navigationRow", "Untitled Collection").click();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start:db": "docker compose exec mysql mysql -u root -phelloworld -e 'CREATE DATABASE IF NOT EXISTS doenet_local CHARACTER SET=utf8 COLLATE=utf8_unicode_ci;'",
     "test": "cypress open",
     "test:all": "cypress run -b 'chrome' --config video=false --headless",
+    "test:app": "cypress run -b 'electron' --config video=false,excludeSpecPattern=cypress/e2e/DoenetML/** --headless",
     "test:parallel": "cypress-parallel -s test:all -t 4 -d cypress/e2e/DoenetML",
     "publish:db": "docker compose exec -T -w /var/lib/mysql mysql mysqldump -u root -phelloworld --databases --add-drop-database --add-drop-table doenet_local > ./doenet_docker/volumes/db_init/db_template.sql",
     "reset:db": "docker compose exec -T mysql mysql -u root -phelloworld doenet_local < ./doenet_docker/volumes/db_init/db_template.sql",

--- a/src/_reactComponents/Course/CourseActions.jsx
+++ b/src/_reactComponents/Course/CourseActions.jsx
@@ -1182,6 +1182,8 @@ export const useCourse = (courseId) => {
               ) {
                 previousContainingDoenetId =
                   lastItemInSectionObj.containingDoenetId;
+              } else if (lastItemInSectionObj.type == "activity") {
+                previousContainingDoenetId = singleSelectedDoenetId;
               } else if (
                 lastItemInSectionObj.type == "bank" ||
                 lastItemInSectionObj.type == "section"
@@ -1220,6 +1222,8 @@ export const useCourse = (courseId) => {
             ) {
               previousContainingDoenetId =
                 lastItemInSectionObj.containingDoenetId;
+            } else if (lastItemInSectionObj.type == "activity") {
+              previousContainingDoenetId = singleSelectedDoenetId;
             } else if (
               lastItemInSectionObj.type == "bank" ||
               lastItemInSectionObj.type == "section"

--- a/src/_reactComponents/Course/CourseActions.jsx
+++ b/src/_reactComponents/Course/CourseActions.jsx
@@ -1139,6 +1139,8 @@ export const useCourse = (courseId) => {
               ) {
                 previousContainingDoenetId =
                   lastItemInSectionObj.containingDoenetId;
+              } else if (lastItemInSectionObj.type == "activity") {
+                previousContainingDoenetId = singleSelectedDoenetId;
               } else if (
                 lastItemInSectionObj.type == "bank" ||
                 lastItemInSectionObj.type == "section"


### PR DESCRIPTION
Fix bugs around adding objects below a section that contains an activity as the last child below it.

I still want to add some more tests for having the different types of objects selected. There is also an opportunity to consolidate some of this repeated code that I'm trying to figure out the right way to restructure.