### PR TITLE
update chakra dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "doenet_tools",
       "version": "0.0.1",
       "dependencies": {
-        "@chakra-ui/icons": "^2.0.19",
-        "@chakra-ui/react": "^2.6.1",
+        "@chakra-ui/icons": "^2.1.0",
+        "@chakra-ui/react": "^2.8.0",
         "@codemirror/basic-setup": "^0.19.0",
         "@codemirror/commands": "^0.19.5",
         "@codemirror/gutter": "^0.19.9",
@@ -576,17 +576,17 @@
       }
     },
     "node_modules/@chakra-ui/accordion": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.1.11.tgz",
-      "integrity": "sha512-mfVPmqETp9pyRDHJ33AdF19oHv/LyxVzQJtlxUByuvs8Cj9QQZ2LQLg5kejm+b3mj03A7A6yfbuo3RNaI4Bhsg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.0.tgz",
+      "integrity": "sha512-A4TkRw3Jnt+Fam6dSSJ62rskdrvjF3JGctYcfXlojfFIpHPuIw4pDwfZgNAxlaxWkcj0e7JJKlQ88dnZW+QfFg==",
       "dependencies": {
-        "@chakra-ui/descendant": "3.0.14",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16"
+        "@chakra-ui/transition": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -595,14 +595,14 @@
       }
     },
     "node_modules/@chakra-ui/alert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.1.0.tgz",
-      "integrity": "sha512-OcfHwoXI5VrmM+tHJTHT62Bx6TfyfCxSa0PWUOueJzSyhlUOKBND5we6UtrOB7D0jwX45qKKEDJOLG5yCG21jQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.0.tgz",
+      "integrity": "sha512-De+BT88iYOu3Con7MxQeICb1SwgAdVdgpHIYjTh3qvGlNXAQjs81rhG0fONXvwW1FIYletvr9DY2Tlg8xJe7tQ==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/spinner": "2.0.13"
+        "@chakra-ui/spinner": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -610,18 +610,18 @@
       }
     },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.2.tgz",
-      "integrity": "sha512-pKfOS/mztc4sUXHNc8ypJ1gPWSolWT770jrgVRfolVbYlki8y5Y+As996zMF6k5lewTu6j9DQequ7Cc9a69IVQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.0.tgz",
+      "integrity": "sha512-cD8Ms5C8+dFda0LrORMdxiFhAZwOIY1BSlCadz6/mHUIgNdQy13AHPrXiq6qWdMslqVHq10k5zH7xMPLt6kjFg=="
     },
     "node_modules/@chakra-ui/avatar": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.2.10.tgz",
-      "integrity": "sha512-Scc0qJtJcxoGOaSS4TkoC2PhVLMacrBcfaNfLqV6wES56BcsjegHvpxREFunZkgVNph/XRHW6J1xOclnsZiPBQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
       "dependencies": {
-        "@chakra-ui/image": "2.0.16",
+        "@chakra-ui/image": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -630,12 +630,12 @@
       }
     },
     "node_modules/@chakra-ui/breadcrumb": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.1.5.tgz",
-      "integrity": "sha512-p3eQQrHQBkRB69xOmNyBJqEdfCrMt+e0eOH+Pm/DjFWfIVIbnIaFbmDCeWClqlLa21Ypc6h1hR9jEmvg8kmOog==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
       "dependencies": {
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -652,14 +652,14 @@
       }
     },
     "node_modules/@chakra-ui/button": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.0.18.tgz",
-      "integrity": "sha512-E3c99+lOm6ou4nQVOTLkG+IdOPMjsQK+Qe7VyP8A/xeAMFONuibrWPRPpprr4ZkB4kEoLMfNuyH2+aEza3ScUA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/spinner": "2.0.13"
+        "@chakra-ui/spinner": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -667,9 +667,9 @@
       }
     },
     "node_modules/@chakra-ui/card": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.1.6.tgz",
-      "integrity": "sha512-fFd/WAdRNVY/WOSQv4skpy0WeVhhI0f7dTY1Sm0jVl0KLmuP/GnpsWtKtqWjNcV00K963EXDyhlk6+9oxbP4gw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
       },
@@ -679,21 +679,21 @@
       }
     },
     "node_modules/@chakra-ui/checkbox": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.2.15.tgz",
-      "integrity": "sha512-Ju2yQjX8azgFa5f6VLPuwdGYobZ+rdbcYqjiks848JvPc75UsPhpS05cb4XlrKT7M16I8txDA5rPJdqqFicHCA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.0.tgz",
+      "integrity": "sha512-fX7M5sQK27aFWoj7vqnPkf1Q3AHmML/5dIRYfm7HEIsZXYH2C1CkM6+dijeSWIk6a0mp0r3el6SNDUti2ehH8g==",
       "dependencies": {
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/visually-hidden": "2.0.15",
-        "@zag-js/focus-visible": "0.2.2"
+        "@chakra-ui/visually-hidden": "2.1.0",
+        "@zag-js/focus-visible": "0.10.5"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -701,11 +701,11 @@
       }
     },
     "node_modules/@chakra-ui/clickable": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.0.14.tgz",
-      "integrity": "sha512-jfsM1qaD74ZykLHmvmsKRhDyokLUxEfL8Il1VoZMNX5RBI0xW/56vKpLTFF/v/+vLPLS+Te2cZdD4+2O+G6ulA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
       "dependencies": {
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -713,11 +713,11 @@
       }
     },
     "node_modules/@chakra-ui/close-button": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.0.17.tgz",
-      "integrity": "sha512-05YPXk456t1Xa3KpqTrvm+7smx+95dmaPiwjiBN3p7LHUQVHJd8ZXSDB0V+WKi419k3cVQeJUdU/azDO2f40sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.0.tgz",
+      "integrity": "sha512-KfJcz6UAaR2dDWSIv6UrCGkZQS54Fjl+DEEVOUTJ7gf4KOP4FQZCkv8hqsAB9FeCtnwU43adq2oaw3aZH/Uzew==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16"
+        "@chakra-ui/icon": "3.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -725,32 +725,32 @@
       }
     },
     "node_modules/@chakra-ui/color-mode": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.1.12.tgz",
-      "integrity": "sha512-sYyfJGDoJSLYO+V2hxV9r033qhte5Nw/wAn5yRGGZnEEN1dKPEdWQ3XZvglWSDTNd0w9zkoH2w6vP4FBBYb/iw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
       "dependencies": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/control-box": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.0.13.tgz",
-      "integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/counter": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.0.14.tgz",
-      "integrity": "sha512-KxcSRfUbb94dP77xTip2myoE7P2HQQN4V5fRJmNAGbzcyLciJ+aDylUU/UxgNcEjawUp6Q242NbWb1TSbKoqog==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
       "dependencies": {
         "@chakra-ui/number-utils": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -758,44 +758,44 @@
       }
     },
     "node_modules/@chakra-ui/css-reset": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.1.1.tgz",
-      "integrity": "sha512-jwEOfIAWmQsnChHQTW/eRE+dfE4MjmhvSvoUug5nkV1pI7veC/20noFlIZxzi82EbiQI8Fs0+Jnusgxr2yaOHA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.2.0.tgz",
+      "integrity": "sha512-nn7hjquIrPwCzwI4d/Y4wzM5A5xAeswREOfT8gT0Yd+U+Qnw3pPT8NPLbNJ3DvuOfJaCV6/N5ld/6RRTgYF/sQ==",
       "peerDependencies": {
         "@emotion/react": ">=10.0.35",
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/descendant": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.0.14.tgz",
-      "integrity": "sha512-+Ahvp9H4HMpfScIv9w1vaecGz7qWAaK1YFHHolz/SIsGLaLGlbdp+5UNabQC7L6TUnzzJDQDxzwif78rTD7ang==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7"
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/dom-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.0.6.tgz",
-      "integrity": "sha512-PVtDkPrDD5b8aoL6Atg7SLjkwhWb7BwMcLOF1L449L3nZN+DAO3nyAh6iUhZVJyunELj9d0r65CDlnMREyJZmA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
     },
     "node_modules/@chakra-ui/editable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.0.0.tgz",
-      "integrity": "sha512-q/7C/TM3iLaoQKlEiM8AY565i9NoaXtS6N6N4HWIEL5mZJPbMeHKxrCHUZlHxYuQJqFOGc09ZPD9fAFx1GkYwQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -809,26 +809,26 @@
       "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
     },
     "node_modules/@chakra-ui/focus-lock": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.0.16.tgz",
-      "integrity": "sha512-UuAdGCPVrCa1lecoAvpOQD7JFT7a9RdmhKWhFt5ioIcekSLJcerdLHuuL3w0qz//8kd1/SOt7oP0aJqdAJQrCw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
       "dependencies": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "react-focus-lock": "^2.9.2"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/form-control": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.0.18.tgz",
-      "integrity": "sha512-I0a0jG01IAtRPccOXSNugyRdUAe8Dy40ctqedZvznMweOXzbMCF1m+sHPLdWeWC/VI13VoAispdPY0/zHOdjsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.1.0.tgz",
+      "integrity": "sha512-3QmWG9v6Rx+JOwJP3Wt89+AWZxK0F1NkVAgXP3WVfE9VDXOKFRV/faLT0GEe2V+l7WZHF5PLdEBvKG8Cgw2mkA==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/@chakra-ui/icon": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.0.16.tgz",
-      "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.1.0.tgz",
+      "integrity": "sha512-t6v0lGCXRbwUJycN8A/nDTuLktMP+LRjKbYJnd2oL6Pm2vOl99XwEQ5cAEyEa4XoseYNEgXiLR+2TfvgfNFvcw==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
       },
@@ -863,11 +863,11 @@
       }
     },
     "node_modules/@chakra-ui/icons": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.19.tgz",
-      "integrity": "sha512-0A6U1ZBZhLIxh3QgdjuvIEhAZi3B9v8g6Qvlfa3mu6vSnXQn2CHBZXmJwxpXxO40NK/2gj/gKXrLeUaFR6H/Qw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-pGFxFfQ/P5VnSRnTzK8zGAJxoxkxpHo/Br9ohRZdOpuhnIHSW7va0P53UoycEO5/vNJ/7BN0oDY0k9qurChcew==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16"
+        "@chakra-ui/icon": "3.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -875,11 +875,11 @@
       }
     },
     "node_modules/@chakra-ui/image": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.0.16.tgz",
-      "integrity": "sha512-iFypk1slgP3OK7VIPOtkB0UuiqVxNalgA59yoRM43xLIeZAEZpKngUVno4A2kFS61yKN0eIY4hXD3Xjm+25EJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
       "dependencies": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -888,14 +888,14 @@
       }
     },
     "node_modules/@chakra-ui/input": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.0.22.tgz",
-      "integrity": "sha512-dCIC0/Q7mjZf17YqgoQsnXn0bus6vgriTRn8VmxOc+WcVl+KBSTBWujGrS5yu85WIFQ0aeqQvziDnDQybPqAbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.0.tgz",
+      "integrity": "sha512-HItI2vq6vupCuixdzof4sIanGdLlszhDtlR5be5z8Nrda1RkXVqI+9CTJPbNsx2nIKEfwPt01pnT9mozoOSMMw==",
       "dependencies": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -904,15 +904,15 @@
       }
     },
     "node_modules/@chakra-ui/layout": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.1.19.tgz",
-      "integrity": "sha512-g7xMVKbQFCODwKCkEF4/OmdPsr/fAavWUV+DGc1ZWVPdroUlg1FGTpK9bOTwkC/gnko7cMClILA+BIPR3Ylu9Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.0.tgz",
+      "integrity": "sha512-tp1/Bn+cHn0Q4HWKY62HtOwzhpH1GUA3i5fvs23HEhOEryTps05hyuQVeJ71fLqSs6f1QEIdm+9It+5WCj64vQ==",
       "dependencies": {
         "@chakra-ui/breakpoint-utils": "2.0.8",
-        "@chakra-ui/icon": "3.0.16",
+        "@chakra-ui/icon": "3.1.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -926,20 +926,20 @@
       "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
     },
     "node_modules/@chakra-ui/live-region": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.0.13.tgz",
-      "integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/media-query": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.2.12.tgz",
-      "integrity": "sha512-8pSLDf3oxxhFrhd40rs7vSeIBfvOmIKHA7DJlGUC/y+9irD24ZwgmCtFnn+y3gI47hTJsopbSX+wb8nr7XPswA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
       "dependencies": {
         "@chakra-ui/breakpoint-utils": "2.0.8",
-        "@chakra-ui/react-env": "3.0.0",
+        "@chakra-ui/react-env": "3.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -948,25 +948,25 @@
       }
     },
     "node_modules/@chakra-ui/menu": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.1.14.tgz",
-      "integrity": "sha512-z4YzlY/ub1hr4Ee2zCnZDs4t43048yLTf5GhEVYDO+SI92WlOfHlP9gYEzR+uj/CiRZglVFwUDKb3UmFtmKPyg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.0.tgz",
+      "integrity": "sha512-l7HQjriW4JGeCyxDdguAzekwwB+kHGDLxACi0DJNp37sil51SRaN1S1OrneISbOHVpHuQB+KVNgU0rqhoglVew==",
       "dependencies": {
-        "@chakra-ui/clickable": "2.0.14",
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
-        "@chakra-ui/popper": "3.0.14",
+        "@chakra-ui/popper": "3.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-animation-state": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-focus-effect": "2.0.10",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-outside-click": "2.1.0",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16"
+        "@chakra-ui/transition": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -975,18 +975,18 @@
       }
     },
     "node_modules/@chakra-ui/modal": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.2.11.tgz",
-      "integrity": "sha512-2J0ZUV5tEzkPiawdkgPz6bmex7NXAde1VXooMwdvK+vuT8PV3U61yorTJOZVLdw7TjjI1Yo94mzsp6UwBud43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.0.tgz",
+      "integrity": "sha512-S1sITrIeLSf21LJ0Vz8xZhj5fWEud5z5Dl2dmvOEv1ezypgOrCCBdOEnnqCkoEKZDbKvzZWZXWR5791ikLP6+g==",
       "dependencies": {
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/focus-lock": "2.0.16",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16",
+        "@chakra-ui/transition": "2.1.0",
         "aria-hidden": "^1.2.2",
         "react-remove-scroll": "^2.5.5"
       },
@@ -998,21 +998,21 @@
       }
     },
     "node_modules/@chakra-ui/number-input": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.0.19.tgz",
-      "integrity": "sha512-HDaITvtMEqOauOrCPsARDxKD9PSHmhWywpcyCSOX0lMe4xx2aaGhU0QQFhsJsykj8Er6pytMv6t0KZksdDv3YA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.0.tgz",
+      "integrity": "sha512-/gEAzQHhrMA+1rzyCMaN8OkKtUPuER6iA+nloYEYBoT7dH/EoNlRtBkiIQhDp+E4VpgZJ0SK3OVrm9/eBbtHHg==",
       "dependencies": {
-        "@chakra-ui/counter": "2.0.14",
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-interval": "2.0.5",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1031,15 +1031,15 @@
       "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
     },
     "node_modules/@chakra-ui/pin-input": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.0.20.tgz",
-      "integrity": "sha512-IHVmerrtHN8F+jRB3W1HnMir1S1TUCWhI7qDInxqPtoRffHt6mzZgLZ0izx8p1fD4HkW4c1d4/ZLEz9uH9bBRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
       "dependencies": {
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1048,20 +1048,20 @@
       }
     },
     "node_modules/@chakra-ui/popover": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.1.11.tgz",
-      "integrity": "sha512-ntFMKojU+ZIofwSw5IJ+Ur8pN5o+5kf/Fx5r5tCjFZd0DSkrEeJw9i00/UWJ6kYZb+zlpswxriv0FmxBlAF66w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.0.tgz",
+      "integrity": "sha512-cTqXdgkU0vgK82AR1nWcC2MJYhEL/y6uTeprvO2+j4o2D0yPrzVMuIZZRl0abrQwiravQyVGEMgA5y0ZLYwbiQ==",
       "dependencies": {
-        "@chakra-ui/close-button": "2.0.17",
+        "@chakra-ui/close-button": "2.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-animation-state": "2.0.8",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-focus-effect": "2.0.10",
-        "@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1071,12 +1071,12 @@
       }
     },
     "node_modules/@chakra-ui/popper": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.0.14.tgz",
-      "integrity": "sha512-RDMmmSfjsmHJbVn2agDyoJpTbQK33fxx//njwJdeyM0zTG/3/4xjI/Cxru3acJ2Y+1jFGmPqhO81stFjnbtfIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
       "dependencies": {
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@popperjs/core": "^2.9.3"
       },
       "peerDependencies": {
@@ -1084,12 +1084,12 @@
       }
     },
     "node_modules/@chakra-ui/portal": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.0.16.tgz",
-      "integrity": "sha512-bVID0qbQ0l4xq38LdqAN4EKD4/uFkDnXzFwOlviC9sl0dNhzICDb1ltuH/Adl1d2HTMqyN60O3GO58eHy7plnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1097,11 +1097,11 @@
       }
     },
     "node_modules/@chakra-ui/progress": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.1.6.tgz",
-      "integrity": "sha512-hHh5Ysv4z6bK+j2GJbi/FT9CVyto2PtNUNwBmr3oNMVsoOUMoRjczfXvvYqp0EHr9PCpxqrq7sRwgQXUzhbDSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8"
+        "@chakra-ui/react-context": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -1109,14 +1109,14 @@
       }
     },
     "node_modules/@chakra-ui/provider": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.2.4.tgz",
-      "integrity": "sha512-vz/WMEWhwoITCAkennRNYCeQHsJ6YwB/UjVaAK+61jWY42J7uCsRZ+3nB5rDjQ4m+aqPfTUPof8KLJBrtYrJbw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.0.tgz",
+      "integrity": "sha512-KJ/TNczpY+EStQXa2Y5PZ+senlBHrY7P+RpBgJLBZLGkQUCS3APw5KvCwgpA0COb2M4AZXCjw+rm+Ko7ontlgA==",
       "dependencies": {
-        "@chakra-ui/css-reset": "2.1.1",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-env": "3.0.0",
-        "@chakra-ui/system": "2.5.7",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.0",
         "@chakra-ui/utils": "2.0.15"
       },
       "peerDependencies": {
@@ -1127,16 +1127,16 @@
       }
     },
     "node_modules/@chakra-ui/radio": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.0.22.tgz",
-      "integrity": "sha512-GsQ5WAnLwivWl6gPk8P1x+tCcpVakCt5R5T0HumF7DGPXKdJbjS+RaFySrbETmyTJsKY4QrfXn+g8CWVrMjPjw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.0.tgz",
+      "integrity": "sha512-WiRlSCqKWgy4m9106w4g77kcLYqBxqGhFRO1pTTJp99rxpM6jNadOeK+moEjqj64N9mSz3njEecMJftKKcOYdg==",
       "dependencies": {
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@zag-js/focus-visible": "0.2.2"
+        "@zag-js/focus-visible": "0.10.5"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -1144,62 +1144,63 @@
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.6.1.tgz",
-      "integrity": "sha512-Lt8c8pLPTz59xxdSuL2FlE7le9MXx4zgjr60UnEc3yjAMjXNTqUAoWHyT4Zn1elCGUPWOedS3rMvp4KTshT+5w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.0.tgz",
+      "integrity": "sha512-tV82DaqE4fMbLIWq58BYh4Ol3gAlNEn+qYOzx8bPrZudboEDnboq8aVfSBwWOY++MLWz2Nn7CkT69YRm91e5sg==",
       "dependencies": {
-        "@chakra-ui/accordion": "2.1.11",
-        "@chakra-ui/alert": "2.1.0",
-        "@chakra-ui/avatar": "2.2.10",
-        "@chakra-ui/breadcrumb": "2.1.5",
-        "@chakra-ui/button": "2.0.18",
-        "@chakra-ui/card": "2.1.6",
-        "@chakra-ui/checkbox": "2.2.15",
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/control-box": "2.0.13",
-        "@chakra-ui/counter": "2.0.14",
-        "@chakra-ui/css-reset": "2.1.1",
-        "@chakra-ui/editable": "3.0.0",
-        "@chakra-ui/focus-lock": "2.0.16",
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/accordion": "2.3.0",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/hooks": "2.2.0",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/image": "2.0.16",
-        "@chakra-ui/input": "2.0.22",
-        "@chakra-ui/layout": "2.1.19",
-        "@chakra-ui/live-region": "2.0.13",
-        "@chakra-ui/media-query": "3.2.12",
-        "@chakra-ui/menu": "2.1.14",
-        "@chakra-ui/modal": "2.2.11",
-        "@chakra-ui/number-input": "2.0.19",
-        "@chakra-ui/pin-input": "2.0.20",
-        "@chakra-ui/popover": "2.1.11",
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/progress": "2.1.6",
-        "@chakra-ui/provider": "2.2.4",
-        "@chakra-ui/radio": "2.0.22",
-        "@chakra-ui/react-env": "3.0.0",
-        "@chakra-ui/select": "2.0.19",
-        "@chakra-ui/skeleton": "2.0.24",
-        "@chakra-ui/slider": "2.0.24",
-        "@chakra-ui/spinner": "2.0.13",
-        "@chakra-ui/stat": "2.0.18",
-        "@chakra-ui/stepper": "2.2.0",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/switch": "2.0.27",
-        "@chakra-ui/system": "2.5.7",
-        "@chakra-ui/table": "2.0.17",
-        "@chakra-ui/tabs": "2.1.9",
-        "@chakra-ui/tag": "3.0.0",
-        "@chakra-ui/textarea": "2.0.19",
-        "@chakra-ui/theme": "3.1.1",
-        "@chakra-ui/theme-utils": "2.0.17",
-        "@chakra-ui/toast": "6.1.3",
-        "@chakra-ui/tooltip": "2.2.8",
-        "@chakra-ui/transition": "2.0.16",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.0",
+        "@chakra-ui/layout": "2.3.0",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.0",
+        "@chakra-ui/modal": "2.3.0",
+        "@chakra-ui/number-input": "2.1.0",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.0",
+        "@chakra-ui/radio": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.0",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.0",
+        "@chakra-ui/stepper": "2.3.0",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/switch": "2.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "2.2.0",
+        "@chakra-ui/tag": "3.1.0",
+        "@chakra-ui/textarea": "2.1.0",
+        "@chakra-ui/theme": "3.2.0",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/toast": "7.0.0",
+        "@chakra-ui/tooltip": "2.3.0",
+        "@chakra-ui/transition": "2.1.0",
         "@chakra-ui/utils": "2.0.15",
-        "@chakra-ui/visually-hidden": "2.0.15"
+        "@chakra-ui/visually-hidden": "2.1.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0",
@@ -1218,19 +1219,19 @@
       }
     },
     "node_modules/@chakra-ui/react-context": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.0.8.tgz",
-      "integrity": "sha512-tRTKdn6lCTXM6WPjSokAAKCw2ioih7Eg8cNgaYRSwKBck8nkz9YqxgIIEj3dJD7MGtpl24S/SNI98iRWkRwR/A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-env": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.0.0.tgz",
-      "integrity": "sha512-tfMRO2v508HQWAqSADFrwZgR9oU10qC97oV6zGbjHh9ALP0/IcFR+Bi71KRTveDTm85fMeAzZYGj57P3Dsipkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
       "dependencies": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -1245,128 +1246,128 @@
       }
     },
     "node_modules/@chakra-ui/react-use-animation-state": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.0.8.tgz",
-      "integrity": "sha512-xv9zSF2Rd1mHWQ+m5DLBWeh4atF8qrNvsOs3MNrvxKYBS3f79N3pqcQGrWAEvirXWXfiCeje2VAkEggqFRIo+Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
       "dependencies": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "@chakra-ui/react-use-event-listener": "2.0.7"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-callback-ref": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.0.7.tgz",
-      "integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-controllable-state": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.0.8.tgz",
-      "integrity": "sha512-F7rdCbLEmRjwwODqWZ3y+mKgSSHPcLQxeUygwk1BkZPXbKkJJKymOIjIynil2cbH7ku3hcSIWRvuhpCcfQWJ7Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-disclosure": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.0.8.tgz",
-      "integrity": "sha512-2ir/mHe1YND40e+FyLHnDsnDsBQPwzKDLzfe9GZri7y31oU83JSbHdlAXAhp3bpjohslwavtRCp+S/zRxfO9aQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-event-listener": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.0.7.tgz",
-      "integrity": "sha512-4wvpx4yudIO3B31pOrXuTHDErawmwiXnvAN7gLEOVREi16+YGNcFnRJ5X5nRrmB7j2MDUtsEDpRBFfw5Z9xQ5g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-focus-effect": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.0.10.tgz",
-      "integrity": "sha512-HswfpzjP8gCQM3/fbeR+8wrYqt0B3ChnVTqssnYXqp9Fa/5Y1Kx1ZADUWW93zMs5SF7hIEuNt8uKeh1/3HTcqQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
       "dependencies": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-focus-on-pointer-down": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.0.6.tgz",
-      "integrity": "sha512-OigXiLRVySn3tyVqJ/rn57WGuukW8TQe8fJYiLwXbcNyAMuYYounvRxvCy2b53sQ7QIZamza0N0jhirbH5FNoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
       "dependencies": {
-        "@chakra-ui/react-use-event-listener": "2.0.7"
+        "@chakra-ui/react-use-event-listener": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-interval": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.0.5.tgz",
-      "integrity": "sha512-1nbdwMi2K87V6p5f5AseOKif2CkldLaJlq1TOqaPRwb7v3aU9rltBtYdf+fIyuHSToNJUV6wd9budCFdLCl3Fg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-latest-ref": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.0.5.tgz",
-      "integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-merge-refs": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.0.7.tgz",
-      "integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-outside-click": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.1.0.tgz",
-      "integrity": "sha512-JanCo4QtWvMl9ZZUpKJKV62RlMWDFdPCE0Q64a7eWTOQgWWcpyBW7TOYRunQTqrK30FqkYFJCOlAWOtn+6Rw7A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-pan-event": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.0.9.tgz",
-      "integrity": "sha512-xu35QXkiyrgsHUOnctl+SwNcwf9Rl62uYE5y8soKOZdBm8E+FvZIt2hxUzK1EoekbJCMzEZ0Yv1ZQCssVkSLaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
       "dependencies": {
         "@chakra-ui/event-utils": "2.0.8",
-        "@chakra-ui/react-use-latest-ref": "2.0.5",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
         "framesync": "6.1.2"
       },
       "peerDependencies": {
@@ -1374,47 +1375,47 @@
       }
     },
     "node_modules/@chakra-ui/react-use-previous": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.0.5.tgz",
-      "integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-safe-layout-effect": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.0.5.tgz",
-      "integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-size": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.0.10.tgz",
-      "integrity": "sha512-fdIkH14GDnKQrtQfxX8N3gxbXRPXEl67Y3zeD9z4bKKcQUAYIMqs0MsPZY+FMpGQw8QqafM44nXfL038aIrC5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
       "dependencies": {
-        "@zag-js/element-size": "0.3.2"
+        "@zag-js/element-size": "0.10.5"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-timeout": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.0.5.tgz",
-      "integrity": "sha512-QqmB+jVphh3h/CS60PieorpY7UqSPkrQCB7f7F+i9vwwIjtP8fxVHMmkb64K7VlzQiMPzv12nlID5dqkzlv0mw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
       "dependencies": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-use-update-effect": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.0.7.tgz",
-      "integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
       "peerDependencies": {
         "react": ">=18"
       }
@@ -1431,11 +1432,11 @@
       }
     },
     "node_modules/@chakra-ui/select": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.0.19.tgz",
-      "integrity": "sha512-eAlFh+JhwtJ17OrB6fO6gEAGOMH18ERNrXLqWbYLrs674Le7xuREgtuAYDoxUzvYXYYTTdOJtVbcHGriI3o6rA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-6GEjCJNOm1pS9E7XRvodoVOuSFl82Jio3MGWgmcQrLznjJAhIZVMq85vCQqzGpjjfbHys/UctfdJY75Ctas/Jg==",
       "dependencies": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1449,12 +1450,12 @@
       "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
     },
     "node_modules/@chakra-ui/skeleton": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.0.24.tgz",
-      "integrity": "sha512-1jXtVKcl/jpbrJlc/TyMsFyI651GTXY5ma30kWyTXoby2E+cxbV6OR8GB/NMZdGxbQBax8/VdtYVjI0n+OBqWA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
       "dependencies": {
-        "@chakra-ui/media-query": "3.2.12",
-        "@chakra-ui/react-use-previous": "2.0.5",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1462,21 +1463,30 @@
         "react": ">=18"
       }
     },
+    "node_modules/@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
     "node_modules/@chakra-ui/slider": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.0.24.tgz",
-      "integrity": "sha512-o3hOaIiTzPMG8yf+HYWbrTmhxABicDViVOvOajRSXDodbZSCk1rZy1nmUeahjVtfVUB1IyJoNcXdn76IqJmhdg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
       "dependencies": {
         "@chakra-ui/number-utils": "2.0.7",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-latest-ref": "2.0.5",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-pan-event": "2.0.9",
-        "@chakra-ui/react-use-size": "2.0.10",
-        "@chakra-ui/react-use-update-effect": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -1484,9 +1494,9 @@
       }
     },
     "node_modules/@chakra-ui/spinner": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.0.13.tgz",
-      "integrity": "sha512-T1/aSkVpUIuiYyrjfn1+LsQEG7Onbi1UE9ccS/evgf61Dzy4GgTXQUnDuWFSgpV58owqirqOu6jn/9eCwDlzlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
       },
@@ -1496,12 +1506,12 @@
       }
     },
     "node_modules/@chakra-ui/stat": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.0.18.tgz",
-      "integrity": "sha512-wKyfBqhVlIs9bkSerUc6F9KJMw0yTIEKArW7dejWwzToCLPr47u+CtYO6jlJHV6lRvkhi4K4Qc6pyvtJxZ3VpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.0.tgz",
+      "integrity": "sha512-sqx0/AdFFZ80dsiM5owmhtQyYl+zON1r+IY0m70I/ABRVy+I3br06xdUhoaxh3tcP7c0O/BQgb+VCfXa9Y34CA==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1510,12 +1520,12 @@
       }
     },
     "node_modules/@chakra-ui/stepper": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.2.0.tgz",
-      "integrity": "sha512-8ZLxV39oghSVtOUGK8dX8Z6sWVSQiKVmsK4c3OQDa8y2TvxP0VtFD0Z5U1xJlOjQMryZRWhGj9JBc3iQLukuGg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.0.tgz",
+      "integrity": "sha512-q80QX/NLrjJQIlBP1N+Q8GVJb7/HiOpMoK1PlP4denB/KxkU2K8GEjss8U2vklR1XsWJy1fwfj03+66Q78Uk/Q==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1524,9 +1534,9 @@
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.0.tgz",
-      "integrity": "sha512-rToN30eOezrTZ5qBHmWqEwsYPenHtc3WU6ODAfMUwNnmCJQiu2erRGv8JwIjmRJnKSOEnNKccI2UXe2EwI6+JA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.1.tgz",
+      "integrity": "sha512-jhYKBLxwOPi9/bQt9kqV3ELa/4CjmNNruTyXlPp5M0v0+pDMUngPp48mVLoskm9RKZGE0h1qpvj/jZ3K7c7t8w==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.0.11",
@@ -1534,11 +1544,11 @@
       }
     },
     "node_modules/@chakra-ui/switch": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.0.27.tgz",
-      "integrity": "sha512-z76y2fxwMlvRBrC5W8xsZvo3gP+zAEbT3Nqy5P8uh/IPd5OvDsGeac90t5cgnQTyxMOpznUNNK+1eUZqtLxWnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.0.tgz",
+      "integrity": "sha512-uWHOaIDQdGh+mszxeppj5aYVepbkSK445KZlJJkfr9Bnr6sythTwM63HSufnVDiTEE4uRqegv9jEjZK2JKA+9A==",
       "dependencies": {
-        "@chakra-ui/checkbox": "2.2.15",
+        "@chakra-ui/checkbox": "2.3.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1548,15 +1558,15 @@
       }
     },
     "node_modules/@chakra-ui/system": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.5.7.tgz",
-      "integrity": "sha512-yB6en7YdJPxKvKY2jJROVwkBE2CLFmHS4ZDx27VdYs0Fa4kGiyDFhJAfnMtLBNDVsTy1NhUHL9aqR63u56QqFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.0.tgz",
+      "integrity": "sha512-MgAFRz9V1pW0dplwWsB99hx49LCC+LsrkMala7KXcP0OvWdrkjw+iu+voBksO3626+glzgIwlZW113Eja+7JEQ==",
       "dependencies": {
-        "@chakra-ui/color-mode": "2.1.12",
+        "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-utils": "2.0.12",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme-utils": "2.0.17",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme-utils": "2.0.19",
         "@chakra-ui/utils": "2.0.15",
         "react-fast-compare": "3.2.1"
       },
@@ -1567,11 +1577,11 @@
       }
     },
     "node_modules/@chakra-ui/table": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.0.17.tgz",
-      "integrity": "sha512-OScheTEp1LOYvTki2NFwnAYvac8siAhW9BI5RKm5f5ORL2gVJo4I72RUqE0aKe1oboxgm7CYt5afT5PS5cG61A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
       "dependencies": {
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1580,18 +1590,18 @@
       }
     },
     "node_modules/@chakra-ui/tabs": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.1.9.tgz",
-      "integrity": "sha512-Yf8e0kRvaGM6jfkJum0aInQ0U3ZlCafmrYYni2lqjcTtThqu+Yosmo3iYlnullXxCw5MVznfrkb9ySvgQowuYg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.2.0.tgz",
+      "integrity": "sha512-ulN7McHZ322qlbJXg8S+IwdN8Axh8q0HzYBOHzSdcnVphEytfv9TsfJhN0Hx5yjkpekAzG5fewn33ZdIpIpKyQ==",
       "dependencies": {
-        "@chakra-ui/clickable": "2.0.14",
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1600,12 +1610,12 @@
       }
     },
     "node_modules/@chakra-ui/tag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.0.0.tgz",
-      "integrity": "sha512-YWdMmw/1OWRwNkG9pX+wVtZio+B89odaPj6XeMn5nfNN8+jyhIEpouWv34+CO9G0m1lupJTxPSfgLAd7cqXZMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.0.tgz",
+      "integrity": "sha512-Mn2u828z5HvqEBEG+tUJWe3al5tzN87bK2U0QfThx3+zqWbBCWBSCVfnWRtkNh80m+5a1TekexDAPZqu5G8zdw==",
       "dependencies": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8"
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -1613,11 +1623,11 @@
       }
     },
     "node_modules/@chakra-ui/textarea": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.0.19.tgz",
-      "integrity": "sha512-adJk+qVGsFeJDvfn56CcJKKse8k7oMGlODrmpnpTdF+xvlsiTM+1GfaJvgNSpHHuQFdz/A0z1uJtfGefk0G2ZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.0.tgz",
+      "integrity": "sha512-4F7X/lPRsY+sPxYrWGrhh1pBtdnFvVllIOapzAwnjYwsflm+vf6c+9ZgoDWobXsNezJ9fcqN0FTPwaBnDvDQRQ==",
       "dependencies": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1626,24 +1636,24 @@
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.1.1.tgz",
-      "integrity": "sha512-VHcG0CPLd9tgvWnajpAGqrAYhx4HwgfK0E9VOrdwa/3bN+AgY/0EAAXzfe0Q0W2MBWzSgaYqZcQ5cDRpYbiYPA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.2.0.tgz",
+      "integrity": "sha512-q9mppdkhmaBnvOT8REr/lVNNBX/prwm50EzObJ+r+ErVhNQDc55gCFmtr+It3xlcCqmOteG6XUdwRCJz8qzOqg==",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.1.2",
+        "@chakra-ui/anatomy": "2.2.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/theme-tools": "2.0.17"
+        "@chakra-ui/theme-tools": "2.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.8.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.0.17.tgz",
-      "integrity": "sha512-Auu38hnihlJZQcPok6itRDBbwof3TpXGYtDPnOvrq4Xp7jnab36HLt7KEXSDPXbtOk3ZqU99pvI1en5LbDrdjg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.0.tgz",
+      "integrity": "sha512-TKv4trAY8q8+DWdZrpSabTd3SZtZrnzFDwUdzhbWBhFEDEVR3fAkRTPpnPDtf1X9w1YErWn3QAcMACVFz4+vkw==",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.1.2",
+        "@chakra-ui/anatomy": "2.2.0",
         "@chakra-ui/shared-utils": "2.0.5",
         "color2k": "^2.0.0"
       },
@@ -1652,49 +1662,50 @@
       }
     },
     "node_modules/@chakra-ui/theme-utils": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.17.tgz",
-      "integrity": "sha512-aUaVLFIU1Rs8m+5WVOUvqHKapOX8nSgUVGaeRWS4odxBM95dG4j15f4L88LEMw4D4+WWd0CSAS139OnRgj1rCw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.19.tgz",
+      "integrity": "sha512-UQ+KvozTN86+0oA80rdQd1a++4rm4ulo+DEabkgwNpkK3yaWsucOxkDQpi2sMIMvw5X0oaWvNBZJuVyK7HdOXg==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme": "3.1.1",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0",
         "lodash.mergewith": "4.6.2"
       }
     },
     "node_modules/@chakra-ui/toast": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-6.1.3.tgz",
-      "integrity": "sha512-dsg/Sdkuq+SCwdOeyzrnBO1ecDA7VKfLFjUtj9QBc/SFEN8r+FQrygy79TNo+QWr7zdjI8icbl8nsp59lpb8ag==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.0.tgz",
+      "integrity": "sha512-XQgSnn4DYRgfOBzBvh8GI/AZ7SfrO8wlVSmChfp92Nfmqm7tRDUT9x8ws/iNKAvMRHkhl7fmRjJ39ipeXYrMvA==",
       "dependencies": {
-        "@chakra-ui/alert": "2.1.0",
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-timeout": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme": "3.1.1"
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0"
       },
       "peerDependencies": {
-        "@chakra-ui/system": "2.5.7",
+        "@chakra-ui/system": "2.6.0",
         "framer-motion": ">=4.0.0",
         "react": ">=18",
         "react-dom": ">=18"
       }
     },
     "node_modules/@chakra-ui/tooltip": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.2.8.tgz",
-      "integrity": "sha512-AqtrCkalADrqqd1SgII4n8F0dDABxqxL3e8uj3yC3HDzT3BU/0NSwSQRA2bp9eoJHk07ZMs9kyzvkkBLc0pr2A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.0.tgz",
+      "integrity": "sha512-2s23f93YIij1qEDwIK//KtEu4LLYOslhR1cUhDBk/WUzyFR3Ez0Ee+HlqlGEGfGe9x77E6/UXPnSAKKdF/cpsg==",
       "dependencies": {
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/portal": "2.0.16",
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
@@ -1705,9 +1716,9 @@
       }
     },
     "node_modules/@chakra-ui/transition": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.0.16.tgz",
-      "integrity": "sha512-E+RkwlPc3H7P1crEXmXwDXMB2lqY2LLia2P5siQ4IEnRWIgZXlIw+8Em+NtHNgusel2N+9yuB0wT9SeZZeZ3CQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
       },
@@ -1728,9 +1739,9 @@
       }
     },
     "node_modules/@chakra-ui/visually-hidden": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.0.15.tgz",
-      "integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.1.0.tgz",
+      "integrity": "sha512-3OHKqTz78PX7V4qto+a5Y6VvH6TbU3Pg6Z0Z2KnDkOBP3Po8fiz0kk+/OSPzIwdcSsQKiocLi0c1pnnUPdMZPg==",
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
         "react": ">=18"
@@ -2970,9 +2981,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3906,15 +3917,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/@zag-js/dom-query": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.10.5.tgz",
+      "integrity": "sha512-zm6wA5+kqU48it6afNjaUhjVSixKZruTKB23z0V1xBqKbuiLOMMOZ5oK26cTPSXtZ5CPhDNZ2Qk4pliS5n9SVw=="
+    },
     "node_modules/@zag-js/element-size": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.3.2.tgz",
-      "integrity": "sha512-bVvvigUGvAuj7PCkE5AbzvTJDTw5f3bg9nQdv+ErhVN8SfPPppLJEmmWdxqsRzrHXgx8ypJt/+Ty0kjtISVDsQ=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
     },
     "node_modules/@zag-js/focus-visible": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.2.2.tgz",
-      "integrity": "sha512-0j2gZq8HiZ51z4zNnSkF1iSkqlwRDvdH+son3wHdoz+7IUdMN/5Exd4TxMJ+gq2Of1DiXReYLL9qqh2PdQ4wgA=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.10.5.tgz",
+      "integrity": "sha512-EhDHKLutMtvLFCjBjyIY6h1JoJJNXG3KJz7Dj1sh4tj4LWAqo/TqLvgHyUTB29XMHwoslFHDJHKVWmLGMi+ULQ==",
+      "dependencies": {
+        "@zag-js/dom-query": "0.10.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -11418,9 +11437,9 @@
       "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -11475,11 +11494,11 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
       "dependencies": {
-        "react-remove-scroll-bar": "^2.3.3",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.0",
@@ -14455,53 +14474,53 @@
       }
     },
     "@chakra-ui/accordion": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.1.11.tgz",
-      "integrity": "sha512-mfVPmqETp9pyRDHJ33AdF19oHv/LyxVzQJtlxUByuvs8Cj9QQZ2LQLg5kejm+b3mj03A7A6yfbuo3RNaI4Bhsg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.0.tgz",
+      "integrity": "sha512-A4TkRw3Jnt+Fam6dSSJ62rskdrvjF3JGctYcfXlojfFIpHPuIw4pDwfZgNAxlaxWkcj0e7JJKlQ88dnZW+QfFg==",
       "requires": {
-        "@chakra-ui/descendant": "3.0.14",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16"
+        "@chakra-ui/transition": "2.1.0"
       }
     },
     "@chakra-ui/alert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.1.0.tgz",
-      "integrity": "sha512-OcfHwoXI5VrmM+tHJTHT62Bx6TfyfCxSa0PWUOueJzSyhlUOKBND5we6UtrOB7D0jwX45qKKEDJOLG5yCG21jQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.0.tgz",
+      "integrity": "sha512-De+BT88iYOu3Con7MxQeICb1SwgAdVdgpHIYjTh3qvGlNXAQjs81rhG0fONXvwW1FIYletvr9DY2Tlg8xJe7tQ==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/spinner": "2.0.13"
+        "@chakra-ui/spinner": "2.1.0"
       }
     },
     "@chakra-ui/anatomy": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.2.tgz",
-      "integrity": "sha512-pKfOS/mztc4sUXHNc8ypJ1gPWSolWT770jrgVRfolVbYlki8y5Y+As996zMF6k5lewTu6j9DQequ7Cc9a69IVQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.0.tgz",
+      "integrity": "sha512-cD8Ms5C8+dFda0LrORMdxiFhAZwOIY1BSlCadz6/mHUIgNdQy13AHPrXiq6qWdMslqVHq10k5zH7xMPLt6kjFg=="
     },
     "@chakra-ui/avatar": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.2.10.tgz",
-      "integrity": "sha512-Scc0qJtJcxoGOaSS4TkoC2PhVLMacrBcfaNfLqV6wES56BcsjegHvpxREFunZkgVNph/XRHW6J1xOclnsZiPBQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
       "requires": {
-        "@chakra-ui/image": "2.0.16",
+        "@chakra-ui/image": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/breadcrumb": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.1.5.tgz",
-      "integrity": "sha512-p3eQQrHQBkRB69xOmNyBJqEdfCrMt+e0eOH+Pm/DjFWfIVIbnIaFbmDCeWClqlLa21Ypc6h1hR9jEmvg8kmOog==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
       "requires": {
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -14514,116 +14533,116 @@
       }
     },
     "@chakra-ui/button": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.0.18.tgz",
-      "integrity": "sha512-E3c99+lOm6ou4nQVOTLkG+IdOPMjsQK+Qe7VyP8A/xeAMFONuibrWPRPpprr4ZkB4kEoLMfNuyH2+aEza3ScUA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/spinner": "2.0.13"
+        "@chakra-ui/spinner": "2.1.0"
       }
     },
     "@chakra-ui/card": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.1.6.tgz",
-      "integrity": "sha512-fFd/WAdRNVY/WOSQv4skpy0WeVhhI0f7dTY1Sm0jVl0KLmuP/GnpsWtKtqWjNcV00K963EXDyhlk6+9oxbP4gw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/checkbox": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.2.15.tgz",
-      "integrity": "sha512-Ju2yQjX8azgFa5f6VLPuwdGYobZ+rdbcYqjiks848JvPc75UsPhpS05cb4XlrKT7M16I8txDA5rPJdqqFicHCA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.0.tgz",
+      "integrity": "sha512-fX7M5sQK27aFWoj7vqnPkf1Q3AHmML/5dIRYfm7HEIsZXYH2C1CkM6+dijeSWIk6a0mp0r3el6SNDUti2ehH8g==",
       "requires": {
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/visually-hidden": "2.0.15",
-        "@zag-js/focus-visible": "0.2.2"
+        "@chakra-ui/visually-hidden": "2.1.0",
+        "@zag-js/focus-visible": "0.10.5"
       }
     },
     "@chakra-ui/clickable": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.0.14.tgz",
-      "integrity": "sha512-jfsM1qaD74ZykLHmvmsKRhDyokLUxEfL8Il1VoZMNX5RBI0xW/56vKpLTFF/v/+vLPLS+Te2cZdD4+2O+G6ulA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
       "requires": {
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/close-button": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.0.17.tgz",
-      "integrity": "sha512-05YPXk456t1Xa3KpqTrvm+7smx+95dmaPiwjiBN3p7LHUQVHJd8ZXSDB0V+WKi419k3cVQeJUdU/azDO2f40sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.0.tgz",
+      "integrity": "sha512-KfJcz6UAaR2dDWSIv6UrCGkZQS54Fjl+DEEVOUTJ7gf4KOP4FQZCkv8hqsAB9FeCtnwU43adq2oaw3aZH/Uzew==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16"
+        "@chakra-ui/icon": "3.1.0"
       }
     },
     "@chakra-ui/color-mode": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.1.12.tgz",
-      "integrity": "sha512-sYyfJGDoJSLYO+V2hxV9r033qhte5Nw/wAn5yRGGZnEEN1dKPEdWQ3XZvglWSDTNd0w9zkoH2w6vP4FBBYb/iw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
       "requires": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       }
     },
     "@chakra-ui/control-box": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.0.13.tgz",
-      "integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
       "requires": {}
     },
     "@chakra-ui/counter": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.0.14.tgz",
-      "integrity": "sha512-KxcSRfUbb94dP77xTip2myoE7P2HQQN4V5fRJmNAGbzcyLciJ+aDylUU/UxgNcEjawUp6Q242NbWb1TSbKoqog==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
       "requires": {
         "@chakra-ui/number-utils": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/css-reset": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.1.1.tgz",
-      "integrity": "sha512-jwEOfIAWmQsnChHQTW/eRE+dfE4MjmhvSvoUug5nkV1pI7veC/20noFlIZxzi82EbiQI8Fs0+Jnusgxr2yaOHA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.2.0.tgz",
+      "integrity": "sha512-nn7hjquIrPwCzwI4d/Y4wzM5A5xAeswREOfT8gT0Yd+U+Qnw3pPT8NPLbNJ3DvuOfJaCV6/N5ld/6RRTgYF/sQ==",
       "requires": {}
     },
     "@chakra-ui/descendant": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.0.14.tgz",
-      "integrity": "sha512-+Ahvp9H4HMpfScIv9w1vaecGz7qWAaK1YFHHolz/SIsGLaLGlbdp+5UNabQC7L6TUnzzJDQDxzwif78rTD7ang==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7"
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
       }
     },
     "@chakra-ui/dom-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.0.6.tgz",
-      "integrity": "sha512-PVtDkPrDD5b8aoL6Atg7SLjkwhWb7BwMcLOF1L449L3nZN+DAO3nyAh6iUhZVJyunELj9d0r65CDlnMREyJZmA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
     },
     "@chakra-ui/editable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.0.0.tgz",
-      "integrity": "sha512-q/7C/TM3iLaoQKlEiM8AY565i9NoaXtS6N6N4HWIEL5mZJPbMeHKxrCHUZlHxYuQJqFOGc09ZPD9fAFx1GkYwQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -14633,23 +14652,23 @@
       "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
     },
     "@chakra-ui/focus-lock": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.0.16.tgz",
-      "integrity": "sha512-UuAdGCPVrCa1lecoAvpOQD7JFT7a9RdmhKWhFt5ioIcekSLJcerdLHuuL3w0qz//8kd1/SOt7oP0aJqdAJQrCw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
       "requires": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "react-focus-lock": "^2.9.2"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
       }
     },
     "@chakra-ui/form-control": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.0.18.tgz",
-      "integrity": "sha512-I0a0jG01IAtRPccOXSNugyRdUAe8Dy40ctqedZvznMweOXzbMCF1m+sHPLdWeWC/VI13VoAispdPY0/zHOdjsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.1.0.tgz",
+      "integrity": "sha512-3QmWG9v6Rx+JOwJP3Wt89+AWZxK0F1NkVAgXP3WVfE9VDXOKFRV/faLT0GEe2V+l7WZHF5PLdEBvKG8Cgw2mkA==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -14665,52 +14684,52 @@
       }
     },
     "@chakra-ui/icon": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.0.16.tgz",
-      "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.1.0.tgz",
+      "integrity": "sha512-t6v0lGCXRbwUJycN8A/nDTuLktMP+LRjKbYJnd2oL6Pm2vOl99XwEQ5cAEyEa4XoseYNEgXiLR+2TfvgfNFvcw==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/icons": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.19.tgz",
-      "integrity": "sha512-0A6U1ZBZhLIxh3QgdjuvIEhAZi3B9v8g6Qvlfa3mu6vSnXQn2CHBZXmJwxpXxO40NK/2gj/gKXrLeUaFR6H/Qw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-pGFxFfQ/P5VnSRnTzK8zGAJxoxkxpHo/Br9ohRZdOpuhnIHSW7va0P53UoycEO5/vNJ/7BN0oDY0k9qurChcew==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16"
+        "@chakra-ui/icon": "3.1.0"
       }
     },
     "@chakra-ui/image": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.0.16.tgz",
-      "integrity": "sha512-iFypk1slgP3OK7VIPOtkB0UuiqVxNalgA59yoRM43xLIeZAEZpKngUVno4A2kFS61yKN0eIY4hXD3Xjm+25EJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
       "requires": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/input": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.0.22.tgz",
-      "integrity": "sha512-dCIC0/Q7mjZf17YqgoQsnXn0bus6vgriTRn8VmxOc+WcVl+KBSTBWujGrS5yu85WIFQ0aeqQvziDnDQybPqAbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.0.tgz",
+      "integrity": "sha512-HItI2vq6vupCuixdzof4sIanGdLlszhDtlR5be5z8Nrda1RkXVqI+9CTJPbNsx2nIKEfwPt01pnT9mozoOSMMw==",
       "requires": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/layout": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.1.19.tgz",
-      "integrity": "sha512-g7xMVKbQFCODwKCkEF4/OmdPsr/fAavWUV+DGc1ZWVPdroUlg1FGTpK9bOTwkC/gnko7cMClILA+BIPR3Ylu9Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.0.tgz",
+      "integrity": "sha512-tp1/Bn+cHn0Q4HWKY62HtOwzhpH1GUA3i5fvs23HEhOEryTps05hyuQVeJ71fLqSs6f1QEIdm+9It+5WCj64vQ==",
       "requires": {
         "@chakra-ui/breakpoint-utils": "2.0.8",
-        "@chakra-ui/icon": "3.0.16",
+        "@chakra-ui/icon": "3.1.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -14720,76 +14739,76 @@
       "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
     },
     "@chakra-ui/live-region": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.0.13.tgz",
-      "integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
       "requires": {}
     },
     "@chakra-ui/media-query": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.2.12.tgz",
-      "integrity": "sha512-8pSLDf3oxxhFrhd40rs7vSeIBfvOmIKHA7DJlGUC/y+9irD24ZwgmCtFnn+y3gI47hTJsopbSX+wb8nr7XPswA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
       "requires": {
         "@chakra-ui/breakpoint-utils": "2.0.8",
-        "@chakra-ui/react-env": "3.0.0",
+        "@chakra-ui/react-env": "3.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/menu": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.1.14.tgz",
-      "integrity": "sha512-z4YzlY/ub1hr4Ee2zCnZDs4t43048yLTf5GhEVYDO+SI92WlOfHlP9gYEzR+uj/CiRZglVFwUDKb3UmFtmKPyg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.0.tgz",
+      "integrity": "sha512-l7HQjriW4JGeCyxDdguAzekwwB+kHGDLxACi0DJNp37sil51SRaN1S1OrneISbOHVpHuQB+KVNgU0rqhoglVew==",
       "requires": {
-        "@chakra-ui/clickable": "2.0.14",
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
-        "@chakra-ui/popper": "3.0.14",
+        "@chakra-ui/popper": "3.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-animation-state": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-focus-effect": "2.0.10",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-outside-click": "2.1.0",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16"
+        "@chakra-ui/transition": "2.1.0"
       }
     },
     "@chakra-ui/modal": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.2.11.tgz",
-      "integrity": "sha512-2J0ZUV5tEzkPiawdkgPz6bmex7NXAde1VXooMwdvK+vuT8PV3U61yorTJOZVLdw7TjjI1Yo94mzsp6UwBud43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.0.tgz",
+      "integrity": "sha512-S1sITrIeLSf21LJ0Vz8xZhj5fWEud5z5Dl2dmvOEv1ezypgOrCCBdOEnnqCkoEKZDbKvzZWZXWR5791ikLP6+g==",
       "requires": {
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/focus-lock": "2.0.16",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/transition": "2.0.16",
+        "@chakra-ui/transition": "2.1.0",
         "aria-hidden": "^1.2.2",
         "react-remove-scroll": "^2.5.5"
       }
     },
     "@chakra-ui/number-input": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.0.19.tgz",
-      "integrity": "sha512-HDaITvtMEqOauOrCPsARDxKD9PSHmhWywpcyCSOX0lMe4xx2aaGhU0QQFhsJsykj8Er6pytMv6t0KZksdDv3YA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.0.tgz",
+      "integrity": "sha512-/gEAzQHhrMA+1rzyCMaN8OkKtUPuER6iA+nloYEYBoT7dH/EoNlRtBkiIQhDp+E4VpgZJ0SK3OVrm9/eBbtHHg==",
       "requires": {
-        "@chakra-ui/counter": "2.0.14",
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-interval": "2.0.5",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -14804,145 +14823,146 @@
       "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
     },
     "@chakra-ui/pin-input": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.0.20.tgz",
-      "integrity": "sha512-IHVmerrtHN8F+jRB3W1HnMir1S1TUCWhI7qDInxqPtoRffHt6mzZgLZ0izx8p1fD4HkW4c1d4/ZLEz9uH9bBRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
       "requires": {
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/popover": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.1.11.tgz",
-      "integrity": "sha512-ntFMKojU+ZIofwSw5IJ+Ur8pN5o+5kf/Fx5r5tCjFZd0DSkrEeJw9i00/UWJ6kYZb+zlpswxriv0FmxBlAF66w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.0.tgz",
+      "integrity": "sha512-cTqXdgkU0vgK82AR1nWcC2MJYhEL/y6uTeprvO2+j4o2D0yPrzVMuIZZRl0abrQwiravQyVGEMgA5y0ZLYwbiQ==",
       "requires": {
-        "@chakra-ui/close-button": "2.0.17",
+        "@chakra-ui/close-button": "2.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-animation-state": "2.0.8",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-focus-effect": "2.0.10",
-        "@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/popper": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.0.14.tgz",
-      "integrity": "sha512-RDMmmSfjsmHJbVn2agDyoJpTbQK33fxx//njwJdeyM0zTG/3/4xjI/Cxru3acJ2Y+1jFGmPqhO81stFjnbtfIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
       "requires": {
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@popperjs/core": "^2.9.3"
       }
     },
     "@chakra-ui/portal": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.0.16.tgz",
-      "integrity": "sha512-bVID0qbQ0l4xq38LdqAN4EKD4/uFkDnXzFwOlviC9sl0dNhzICDb1ltuH/Adl1d2HTMqyN60O3GO58eHy7plnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       }
     },
     "@chakra-ui/progress": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.1.6.tgz",
-      "integrity": "sha512-hHh5Ysv4z6bK+j2GJbi/FT9CVyto2PtNUNwBmr3oNMVsoOUMoRjczfXvvYqp0EHr9PCpxqrq7sRwgQXUzhbDSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8"
+        "@chakra-ui/react-context": "2.1.0"
       }
     },
     "@chakra-ui/provider": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.2.4.tgz",
-      "integrity": "sha512-vz/WMEWhwoITCAkennRNYCeQHsJ6YwB/UjVaAK+61jWY42J7uCsRZ+3nB5rDjQ4m+aqPfTUPof8KLJBrtYrJbw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.0.tgz",
+      "integrity": "sha512-KJ/TNczpY+EStQXa2Y5PZ+senlBHrY7P+RpBgJLBZLGkQUCS3APw5KvCwgpA0COb2M4AZXCjw+rm+Ko7ontlgA==",
       "requires": {
-        "@chakra-ui/css-reset": "2.1.1",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-env": "3.0.0",
-        "@chakra-ui/system": "2.5.7",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.0",
         "@chakra-ui/utils": "2.0.15"
       }
     },
     "@chakra-ui/radio": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.0.22.tgz",
-      "integrity": "sha512-GsQ5WAnLwivWl6gPk8P1x+tCcpVakCt5R5T0HumF7DGPXKdJbjS+RaFySrbETmyTJsKY4QrfXn+g8CWVrMjPjw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.0.tgz",
+      "integrity": "sha512-WiRlSCqKWgy4m9106w4g77kcLYqBxqGhFRO1pTTJp99rxpM6jNadOeK+moEjqj64N9mSz3njEecMJftKKcOYdg==",
       "requires": {
-        "@chakra-ui/form-control": "2.0.18",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/form-control": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@zag-js/focus-visible": "0.2.2"
+        "@zag-js/focus-visible": "0.10.5"
       }
     },
     "@chakra-ui/react": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.6.1.tgz",
-      "integrity": "sha512-Lt8c8pLPTz59xxdSuL2FlE7le9MXx4zgjr60UnEc3yjAMjXNTqUAoWHyT4Zn1elCGUPWOedS3rMvp4KTshT+5w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.0.tgz",
+      "integrity": "sha512-tV82DaqE4fMbLIWq58BYh4Ol3gAlNEn+qYOzx8bPrZudboEDnboq8aVfSBwWOY++MLWz2Nn7CkT69YRm91e5sg==",
       "requires": {
-        "@chakra-ui/accordion": "2.1.11",
-        "@chakra-ui/alert": "2.1.0",
-        "@chakra-ui/avatar": "2.2.10",
-        "@chakra-ui/breadcrumb": "2.1.5",
-        "@chakra-ui/button": "2.0.18",
-        "@chakra-ui/card": "2.1.6",
-        "@chakra-ui/checkbox": "2.2.15",
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/control-box": "2.0.13",
-        "@chakra-ui/counter": "2.0.14",
-        "@chakra-ui/css-reset": "2.1.1",
-        "@chakra-ui/editable": "3.0.0",
-        "@chakra-ui/focus-lock": "2.0.16",
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/accordion": "2.3.0",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.2.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/hooks": "2.2.0",
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/image": "2.0.16",
-        "@chakra-ui/input": "2.0.22",
-        "@chakra-ui/layout": "2.1.19",
-        "@chakra-ui/live-region": "2.0.13",
-        "@chakra-ui/media-query": "3.2.12",
-        "@chakra-ui/menu": "2.1.14",
-        "@chakra-ui/modal": "2.2.11",
-        "@chakra-ui/number-input": "2.0.19",
-        "@chakra-ui/pin-input": "2.0.20",
-        "@chakra-ui/popover": "2.1.11",
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/progress": "2.1.6",
-        "@chakra-ui/provider": "2.2.4",
-        "@chakra-ui/radio": "2.0.22",
-        "@chakra-ui/react-env": "3.0.0",
-        "@chakra-ui/select": "2.0.19",
-        "@chakra-ui/skeleton": "2.0.24",
-        "@chakra-ui/slider": "2.0.24",
-        "@chakra-ui/spinner": "2.0.13",
-        "@chakra-ui/stat": "2.0.18",
-        "@chakra-ui/stepper": "2.2.0",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/switch": "2.0.27",
-        "@chakra-ui/system": "2.5.7",
-        "@chakra-ui/table": "2.0.17",
-        "@chakra-ui/tabs": "2.1.9",
-        "@chakra-ui/tag": "3.0.0",
-        "@chakra-ui/textarea": "2.0.19",
-        "@chakra-ui/theme": "3.1.1",
-        "@chakra-ui/theme-utils": "2.0.17",
-        "@chakra-ui/toast": "6.1.3",
-        "@chakra-ui/tooltip": "2.2.8",
-        "@chakra-ui/transition": "2.0.16",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.0",
+        "@chakra-ui/layout": "2.3.0",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.0",
+        "@chakra-ui/modal": "2.3.0",
+        "@chakra-ui/number-input": "2.1.0",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.0",
+        "@chakra-ui/radio": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.0",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.0",
+        "@chakra-ui/stepper": "2.3.0",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/switch": "2.1.0",
+        "@chakra-ui/system": "2.6.0",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "2.2.0",
+        "@chakra-ui/tag": "3.1.0",
+        "@chakra-ui/textarea": "2.1.0",
+        "@chakra-ui/theme": "3.2.0",
+        "@chakra-ui/theme-utils": "2.0.19",
+        "@chakra-ui/toast": "7.0.0",
+        "@chakra-ui/tooltip": "2.3.0",
+        "@chakra-ui/transition": "2.1.0",
         "@chakra-ui/utils": "2.0.15",
-        "@chakra-ui/visually-hidden": "2.0.15"
+        "@chakra-ui/visually-hidden": "2.1.0"
       }
     },
     "@chakra-ui/react-children-utils": {
@@ -14952,17 +14972,17 @@
       "requires": {}
     },
     "@chakra-ui/react-context": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.0.8.tgz",
-      "integrity": "sha512-tRTKdn6lCTXM6WPjSokAAKCw2ioih7Eg8cNgaYRSwKBck8nkz9YqxgIIEj3dJD7MGtpl24S/SNI98iRWkRwR/A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
       "requires": {}
     },
     "@chakra-ui/react-env": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.0.0.tgz",
-      "integrity": "sha512-tfMRO2v508HQWAqSADFrwZgR9oU10qC97oV6zGbjHh9ALP0/IcFR+Bi71KRTveDTm85fMeAzZYGj57P3Dsipkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
       "requires": {
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       }
     },
     "@chakra-ui/react-types": {
@@ -14972,133 +14992,133 @@
       "requires": {}
     },
     "@chakra-ui/react-use-animation-state": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.0.8.tgz",
-      "integrity": "sha512-xv9zSF2Rd1mHWQ+m5DLBWeh4atF8qrNvsOs3MNrvxKYBS3f79N3pqcQGrWAEvirXWXfiCeje2VAkEggqFRIo+Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
       "requires": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "@chakra-ui/react-use-event-listener": "2.0.7"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
       }
     },
     "@chakra-ui/react-use-callback-ref": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.0.7.tgz",
-      "integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
       "requires": {}
     },
     "@chakra-ui/react-use-controllable-state": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.0.8.tgz",
-      "integrity": "sha512-F7rdCbLEmRjwwODqWZ3y+mKgSSHPcLQxeUygwk1BkZPXbKkJJKymOIjIynil2cbH7ku3hcSIWRvuhpCcfQWJ7Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-disclosure": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.0.8.tgz",
-      "integrity": "sha512-2ir/mHe1YND40e+FyLHnDsnDsBQPwzKDLzfe9GZri7y31oU83JSbHdlAXAhp3bpjohslwavtRCp+S/zRxfO9aQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-event-listener": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.0.7.tgz",
-      "integrity": "sha512-4wvpx4yudIO3B31pOrXuTHDErawmwiXnvAN7gLEOVREi16+YGNcFnRJ5X5nRrmB7j2MDUtsEDpRBFfw5Z9xQ5g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-focus-effect": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.0.10.tgz",
-      "integrity": "sha512-HswfpzjP8gCQM3/fbeR+8wrYqt0B3ChnVTqssnYXqp9Fa/5Y1Kx1ZADUWW93zMs5SF7hIEuNt8uKeh1/3HTcqQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
       "requires": {
-        "@chakra-ui/dom-utils": "2.0.6",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
       }
     },
     "@chakra-ui/react-use-focus-on-pointer-down": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.0.6.tgz",
-      "integrity": "sha512-OigXiLRVySn3tyVqJ/rn57WGuukW8TQe8fJYiLwXbcNyAMuYYounvRxvCy2b53sQ7QIZamza0N0jhirbH5FNoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
       "requires": {
-        "@chakra-ui/react-use-event-listener": "2.0.7"
+        "@chakra-ui/react-use-event-listener": "2.1.0"
       }
     },
     "@chakra-ui/react-use-interval": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.0.5.tgz",
-      "integrity": "sha512-1nbdwMi2K87V6p5f5AseOKif2CkldLaJlq1TOqaPRwb7v3aU9rltBtYdf+fIyuHSToNJUV6wd9budCFdLCl3Fg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-latest-ref": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.0.5.tgz",
-      "integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
       "requires": {}
     },
     "@chakra-ui/react-use-merge-refs": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.0.7.tgz",
-      "integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
       "requires": {}
     },
     "@chakra-ui/react-use-outside-click": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.1.0.tgz",
-      "integrity": "sha512-JanCo4QtWvMl9ZZUpKJKV62RlMWDFdPCE0Q64a7eWTOQgWWcpyBW7TOYRunQTqrK30FqkYFJCOlAWOtn+6Rw7A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-pan-event": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.0.9.tgz",
-      "integrity": "sha512-xu35QXkiyrgsHUOnctl+SwNcwf9Rl62uYE5y8soKOZdBm8E+FvZIt2hxUzK1EoekbJCMzEZ0Yv1ZQCssVkSLaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
       "requires": {
         "@chakra-ui/event-utils": "2.0.8",
-        "@chakra-ui/react-use-latest-ref": "2.0.5",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
         "framesync": "6.1.2"
       }
     },
     "@chakra-ui/react-use-previous": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.0.5.tgz",
-      "integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
       "requires": {}
     },
     "@chakra-ui/react-use-safe-layout-effect": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.0.5.tgz",
-      "integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
       "requires": {}
     },
     "@chakra-ui/react-use-size": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.0.10.tgz",
-      "integrity": "sha512-fdIkH14GDnKQrtQfxX8N3gxbXRPXEl67Y3zeD9z4bKKcQUAYIMqs0MsPZY+FMpGQw8QqafM44nXfL038aIrC5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
       "requires": {
-        "@zag-js/element-size": "0.3.2"
+        "@zag-js/element-size": "0.10.5"
       }
     },
     "@chakra-ui/react-use-timeout": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.0.5.tgz",
-      "integrity": "sha512-QqmB+jVphh3h/CS60PieorpY7UqSPkrQCB7f7F+i9vwwIjtP8fxVHMmkb64K7VlzQiMPzv12nlID5dqkzlv0mw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
       "requires": {
-        "@chakra-ui/react-use-callback-ref": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
     "@chakra-ui/react-use-update-effect": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.0.7.tgz",
-      "integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
       "requires": {}
     },
     "@chakra-ui/react-utils": {
@@ -15110,11 +15130,11 @@
       }
     },
     "@chakra-ui/select": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.0.19.tgz",
-      "integrity": "sha512-eAlFh+JhwtJ17OrB6fO6gEAGOMH18ERNrXLqWbYLrs674Le7xuREgtuAYDoxUzvYXYYTTdOJtVbcHGriI3o6rA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-6GEjCJNOm1pS9E7XRvodoVOuSFl82Jio3MGWgmcQrLznjJAhIZVMq85vCQqzGpjjfbHys/UctfdJY75Ctas/Jg==",
       "requires": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
@@ -15124,64 +15144,70 @@
       "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
     },
     "@chakra-ui/skeleton": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.0.24.tgz",
-      "integrity": "sha512-1jXtVKcl/jpbrJlc/TyMsFyI651GTXY5ma30kWyTXoby2E+cxbV6OR8GB/NMZdGxbQBax8/VdtYVjI0n+OBqWA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
       "requires": {
-        "@chakra-ui/media-query": "3.2.12",
-        "@chakra-ui/react-use-previous": "2.0.5",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
+    "@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "requires": {}
+    },
     "@chakra-ui/slider": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.0.24.tgz",
-      "integrity": "sha512-o3hOaIiTzPMG8yf+HYWbrTmhxABicDViVOvOajRSXDodbZSCk1rZy1nmUeahjVtfVUB1IyJoNcXdn76IqJmhdg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
       "requires": {
         "@chakra-ui/number-utils": "2.0.7",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-callback-ref": "2.0.7",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-latest-ref": "2.0.5",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-pan-event": "2.0.9",
-        "@chakra-ui/react-use-size": "2.0.10",
-        "@chakra-ui/react-use-update-effect": "2.0.7"
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
       }
     },
     "@chakra-ui/spinner": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.0.13.tgz",
-      "integrity": "sha512-T1/aSkVpUIuiYyrjfn1+LsQEG7Onbi1UE9ccS/evgf61Dzy4GgTXQUnDuWFSgpV58owqirqOu6jn/9eCwDlzlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/stat": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.0.18.tgz",
-      "integrity": "sha512-wKyfBqhVlIs9bkSerUc6F9KJMw0yTIEKArW7dejWwzToCLPr47u+CtYO6jlJHV6lRvkhi4K4Qc6pyvtJxZ3VpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.0.tgz",
+      "integrity": "sha512-sqx0/AdFFZ80dsiM5owmhtQyYl+zON1r+IY0m70I/ABRVy+I3br06xdUhoaxh3tcP7c0O/BQgb+VCfXa9Y34CA==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/stepper": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.2.0.tgz",
-      "integrity": "sha512-8ZLxV39oghSVtOUGK8dX8Z6sWVSQiKVmsK4c3OQDa8y2TvxP0VtFD0Z5U1xJlOjQMryZRWhGj9JBc3iQLukuGg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.0.tgz",
+      "integrity": "sha512-q80QX/NLrjJQIlBP1N+Q8GVJb7/HiOpMoK1PlP4denB/KxkU2K8GEjss8U2vklR1XsWJy1fwfj03+66Q78Uk/Q==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/styled-system": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.0.tgz",
-      "integrity": "sha512-rToN30eOezrTZ5qBHmWqEwsYPenHtc3WU6ODAfMUwNnmCJQiu2erRGv8JwIjmRJnKSOEnNKccI2UXe2EwI6+JA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.1.tgz",
+      "integrity": "sha512-jhYKBLxwOPi9/bQt9kqV3ELa/4CjmNNruTyXlPp5M0v0+pDMUngPp48mVLoskm9RKZGE0h1qpvj/jZ3K7c7t8w==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.0.11",
@@ -15189,136 +15215,137 @@
       }
     },
     "@chakra-ui/switch": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.0.27.tgz",
-      "integrity": "sha512-z76y2fxwMlvRBrC5W8xsZvo3gP+zAEbT3Nqy5P8uh/IPd5OvDsGeac90t5cgnQTyxMOpznUNNK+1eUZqtLxWnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.0.tgz",
+      "integrity": "sha512-uWHOaIDQdGh+mszxeppj5aYVepbkSK445KZlJJkfr9Bnr6sythTwM63HSufnVDiTEE4uRqegv9jEjZK2JKA+9A==",
       "requires": {
-        "@chakra-ui/checkbox": "2.2.15",
+        "@chakra-ui/checkbox": "2.3.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/system": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.5.7.tgz",
-      "integrity": "sha512-yB6en7YdJPxKvKY2jJROVwkBE2CLFmHS4ZDx27VdYs0Fa4kGiyDFhJAfnMtLBNDVsTy1NhUHL9aqR63u56QqFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.0.tgz",
+      "integrity": "sha512-MgAFRz9V1pW0dplwWsB99hx49LCC+LsrkMala7KXcP0OvWdrkjw+iu+voBksO3626+glzgIwlZW113Eja+7JEQ==",
       "requires": {
-        "@chakra-ui/color-mode": "2.1.12",
+        "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
         "@chakra-ui/react-utils": "2.0.12",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme-utils": "2.0.17",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme-utils": "2.0.19",
         "@chakra-ui/utils": "2.0.15",
         "react-fast-compare": "3.2.1"
       }
     },
     "@chakra-ui/table": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.0.17.tgz",
-      "integrity": "sha512-OScheTEp1LOYvTki2NFwnAYvac8siAhW9BI5RKm5f5ORL2gVJo4I72RUqE0aKe1oboxgm7CYt5afT5PS5cG61A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
       "requires": {
-        "@chakra-ui/react-context": "2.0.8",
+        "@chakra-ui/react-context": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/tabs": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.1.9.tgz",
-      "integrity": "sha512-Yf8e0kRvaGM6jfkJum0aInQ0U3ZlCafmrYYni2lqjcTtThqu+Yosmo3iYlnullXxCw5MVznfrkb9ySvgQowuYg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.2.0.tgz",
+      "integrity": "sha512-ulN7McHZ322qlbJXg8S+IwdN8Axh8q0HzYBOHzSdcnVphEytfv9TsfJhN0Hx5yjkpekAzG5fewn33ZdIpIpKyQ==",
       "requires": {
-        "@chakra-ui/clickable": "2.0.14",
-        "@chakra-ui/descendant": "3.0.14",
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
         "@chakra-ui/lazy-utils": "2.0.5",
         "@chakra-ui/react-children-utils": "2.0.6",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-controllable-state": "2.0.8",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
-        "@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/tag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.0.0.tgz",
-      "integrity": "sha512-YWdMmw/1OWRwNkG9pX+wVtZio+B89odaPj6XeMn5nfNN8+jyhIEpouWv34+CO9G0m1lupJTxPSfgLAd7cqXZMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.0.tgz",
+      "integrity": "sha512-Mn2u828z5HvqEBEG+tUJWe3al5tzN87bK2U0QfThx3+zqWbBCWBSCVfnWRtkNh80m+5a1TekexDAPZqu5G8zdw==",
       "requires": {
-        "@chakra-ui/icon": "3.0.16",
-        "@chakra-ui/react-context": "2.0.8"
+        "@chakra-ui/icon": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0"
       }
     },
     "@chakra-ui/textarea": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.0.19.tgz",
-      "integrity": "sha512-adJk+qVGsFeJDvfn56CcJKKse8k7oMGlODrmpnpTdF+xvlsiTM+1GfaJvgNSpHHuQFdz/A0z1uJtfGefk0G2ZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.0.tgz",
+      "integrity": "sha512-4F7X/lPRsY+sPxYrWGrhh1pBtdnFvVllIOapzAwnjYwsflm+vf6c+9ZgoDWobXsNezJ9fcqN0FTPwaBnDvDQRQ==",
       "requires": {
-        "@chakra-ui/form-control": "2.0.18",
+        "@chakra-ui/form-control": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/theme": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.1.1.tgz",
-      "integrity": "sha512-VHcG0CPLd9tgvWnajpAGqrAYhx4HwgfK0E9VOrdwa/3bN+AgY/0EAAXzfe0Q0W2MBWzSgaYqZcQ5cDRpYbiYPA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.2.0.tgz",
+      "integrity": "sha512-q9mppdkhmaBnvOT8REr/lVNNBX/prwm50EzObJ+r+ErVhNQDc55gCFmtr+It3xlcCqmOteG6XUdwRCJz8qzOqg==",
       "requires": {
-        "@chakra-ui/anatomy": "2.1.2",
+        "@chakra-ui/anatomy": "2.2.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/theme-tools": "2.0.17"
+        "@chakra-ui/theme-tools": "2.1.0"
       }
     },
     "@chakra-ui/theme-tools": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.0.17.tgz",
-      "integrity": "sha512-Auu38hnihlJZQcPok6itRDBbwof3TpXGYtDPnOvrq4Xp7jnab36HLt7KEXSDPXbtOk3ZqU99pvI1en5LbDrdjg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.0.tgz",
+      "integrity": "sha512-TKv4trAY8q8+DWdZrpSabTd3SZtZrnzFDwUdzhbWBhFEDEVR3fAkRTPpnPDtf1X9w1YErWn3QAcMACVFz4+vkw==",
       "requires": {
-        "@chakra-ui/anatomy": "2.1.2",
+        "@chakra-ui/anatomy": "2.2.0",
         "@chakra-ui/shared-utils": "2.0.5",
         "color2k": "^2.0.0"
       }
     },
     "@chakra-ui/theme-utils": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.17.tgz",
-      "integrity": "sha512-aUaVLFIU1Rs8m+5WVOUvqHKapOX8nSgUVGaeRWS4odxBM95dG4j15f4L88LEMw4D4+WWd0CSAS139OnRgj1rCw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.19.tgz",
+      "integrity": "sha512-UQ+KvozTN86+0oA80rdQd1a++4rm4ulo+DEabkgwNpkK3yaWsucOxkDQpi2sMIMvw5X0oaWvNBZJuVyK7HdOXg==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme": "3.1.1",
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0",
         "lodash.mergewith": "4.6.2"
       }
     },
     "@chakra-ui/toast": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-6.1.3.tgz",
-      "integrity": "sha512-dsg/Sdkuq+SCwdOeyzrnBO1ecDA7VKfLFjUtj9QBc/SFEN8r+FQrygy79TNo+QWr7zdjI8icbl8nsp59lpb8ag==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.0.tgz",
+      "integrity": "sha512-XQgSnn4DYRgfOBzBvh8GI/AZ7SfrO8wlVSmChfp92Nfmqm7tRDUT9x8ws/iNKAvMRHkhl7fmRjJ39ipeXYrMvA==",
       "requires": {
-        "@chakra-ui/alert": "2.1.0",
-        "@chakra-ui/close-button": "2.0.17",
-        "@chakra-ui/portal": "2.0.16",
-        "@chakra-ui/react-context": "2.0.8",
-        "@chakra-ui/react-use-timeout": "2.0.5",
-        "@chakra-ui/react-use-update-effect": "2.0.7",
+        "@chakra-ui/alert": "2.2.0",
+        "@chakra-ui/close-button": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5",
-        "@chakra-ui/styled-system": "2.9.0",
-        "@chakra-ui/theme": "3.1.1"
+        "@chakra-ui/styled-system": "2.9.1",
+        "@chakra-ui/theme": "3.2.0"
       }
     },
     "@chakra-ui/tooltip": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.2.8.tgz",
-      "integrity": "sha512-AqtrCkalADrqqd1SgII4n8F0dDABxqxL3e8uj3yC3HDzT3BU/0NSwSQRA2bp9eoJHk07ZMs9kyzvkkBLc0pr2A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.0.tgz",
+      "integrity": "sha512-2s23f93YIij1qEDwIK//KtEu4LLYOslhR1cUhDBk/WUzyFR3Ez0Ee+HlqlGEGfGe9x77E6/UXPnSAKKdF/cpsg==",
       "requires": {
-        "@chakra-ui/popper": "3.0.14",
-        "@chakra-ui/portal": "2.0.16",
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
         "@chakra-ui/react-types": "2.0.7",
-        "@chakra-ui/react-use-disclosure": "2.0.8",
-        "@chakra-ui/react-use-event-listener": "2.0.7",
-        "@chakra-ui/react-use-merge-refs": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
         "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/transition": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.0.16.tgz",
-      "integrity": "sha512-E+RkwlPc3H7P1crEXmXwDXMB2lqY2LLia2P5siQ4IEnRWIgZXlIw+8Em+NtHNgusel2N+9yuB0wT9SeZZeZ3CQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5"
       }
@@ -15335,9 +15362,9 @@
       }
     },
     "@chakra-ui/visually-hidden": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.0.15.tgz",
-      "integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.1.0.tgz",
+      "integrity": "sha512-3OHKqTz78PX7V4qto+a5Y6VvH6TbU3Pg6Z0Z2KnDkOBP3Po8fiz0kk+/OSPzIwdcSsQKiocLi0c1pnnUPdMZPg==",
       "requires": {}
     },
     "@codemirror/autocomplete": {
@@ -16167,9 +16194,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@react-spring/animated": {
       "version": "9.5.5",
@@ -16858,15 +16885,23 @@
         "@web/test-runner-core": "^0.10.20"
       }
     },
+    "@zag-js/dom-query": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.10.5.tgz",
+      "integrity": "sha512-zm6wA5+kqU48it6afNjaUhjVSixKZruTKB23z0V1xBqKbuiLOMMOZ5oK26cTPSXtZ5CPhDNZ2Qk4pliS5n9SVw=="
+    },
     "@zag-js/element-size": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.3.2.tgz",
-      "integrity": "sha512-bVvvigUGvAuj7PCkE5AbzvTJDTw5f3bg9nQdv+ErhVN8SfPPppLJEmmWdxqsRzrHXgx8ypJt/+Ty0kjtISVDsQ=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
     },
     "@zag-js/focus-visible": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.2.2.tgz",
-      "integrity": "sha512-0j2gZq8HiZ51z4zNnSkF1iSkqlwRDvdH+son3wHdoz+7IUdMN/5Exd4TxMJ+gq2Of1DiXReYLL9qqh2PdQ4wgA=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.10.5.tgz",
+      "integrity": "sha512-EhDHKLutMtvLFCjBjyIY6h1JoJJNXG3KJz7Dj1sh4tj4LWAqo/TqLvgHyUTB29XMHwoslFHDJHKVWmLGMi+ULQ==",
+      "requires": {
+        "@zag-js/dom-query": "0.10.5"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -21650,9 +21685,9 @@
       "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
     },
     "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -21689,11 +21724,11 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz",
+      "integrity": "sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==",
       "requires": {
-        "react-remove-scroll-bar": "^2.3.3",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "compile_grammar": "npx lezer-generator --output src/Parser/doenet.js src/Parser/doenet.grammar"
   },
   "dependencies": {
-    "@chakra-ui/icons": "^2.0.19",
-    "@chakra-ui/react": "^2.6.1",
+    "@chakra-ui/icons": "^2.1.0",
+    "@chakra-ui/react": "^2.8.0",
     "@codemirror/basic-setup": "^0.19.0",
     "@codemirror/commands": "^0.19.5",
     "@codemirror/gutter": "^0.19.9",


### PR DESCRIPTION
Chakra was causing a failure on old (pre-Mojave) macOS systems due to the use of `Array.prototype.at()`