### PR TITLE
Add logging to php files related to exam data

### DIFF
--- a/cypress/e2e/AlertQueue/assignmentAlertQueue.cy.js
+++ b/cypress/e2e/AlertQueue/assignmentAlertQueue.cy.js
@@ -57,6 +57,58 @@ describe("Assignment Alert Queue Tests", function () {
     cy.get('[data-test="Alert Title"]').should('not.exist');
   });
 
+  it("Solution Shown Alert", () => {
+    const userId = "cyuserId";
+    const studentUserId = "cyStudentUserId";
+    const courseId = "aaq_courseid2";
+    const doenetML = `
+<problem>
+<p>1+1 = <answer name='ans1'>2</answer></p>
+<solution>2</solution>
+</problem>
+    `
+
+    cy.deleteCourseDBRows({ courseId });
+    cy.createCourse({ userId, courseId, studentUserId });
+    cy.signin({ userId });
+    cy.visit(`course?tool=navigation&courseId=${courseId}`);
+
+    cy.log('Assign a single page activity')
+    cy.get('[data-test="Add Activity Button"]').click();
+    cy.get(".navigationRow").last().dblclick();
+    cy.get(".cm-content").type(doenetML);
+    cy.get('[data-test="Viewer Update Button"]').click();
+    cy.get('.doenet-viewer').contains('Problem 1');
+
+
+    cy.get('[data-test="Controls Button"]').click();
+    cy.get('[data-test="Assign Tab"]').click();
+    cy.get('[data-test="Assign Button"]').eq(1).click();
+    cy.log('alert queue should show message and then be dismissed');
+    cy.get('[data-test="Alert Title"]').should('have.text', 'Activity is assigned.')
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+
+    cy.log('Set due date to a date in the past')
+    cy.get('[data-test="due date"]').type('2023-09-01T04:56').blur();
+    cy.get('[data-test="Alert Title"]').contains("Due date set.");
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+    cy.get('[data-test="Close Settings Button"]').click();
+
+    cy.log('sign in as student')
+    cy.signin({ userId: studentUserId });
+    cy.visit(`course?tool=navigation&courseId=${courseId}`);
+
+    cy.get(".navigationRow").last().dblclick();
+    cy.get(cesc("#\\/_solution1_button")).click();
+
+    cy.get('.mq-root-block').type('2{enter}')
+    cy.get('[data-test="Alert Title"]').contains("No credit awarded since the solution has been viewed.");
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+  });
+
   it("Due Date Alert", () => {
     const userId = "cyuserId";
     const studentUserId = "cyStudentUserId";
@@ -107,7 +159,8 @@ describe("Assignment Alert Queue Tests", function () {
 
   });
 
-  it("Due Date and Solution Shown Alert", () => {
+  //TODO: finish this implementation
+  it.skip("No Attempts Left Alert", () => {
     const userId = "cyuserId";
     const studentUserId = "cyStudentUserId";
     const courseId = "aaq_courseid2";
@@ -139,8 +192,66 @@ describe("Assignment Alert Queue Tests", function () {
     cy.get('[data-test="Alert Close Button"]').click();
     cy.get('[data-test="Alert Title"]').should('not.exist');
 
+    cy.log('Set max attempts to 1')
+    cy.get('[data-test="Grade Tab"]').click();
+    cy.get('[data-test="Number of Attempts Allowed Checkbox"]').click()
+    cy.get('[data-test="Alert Title"]').contains("1 attempt allowed.");
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+    cy.get('[data-test="Close Settings Button"]').click();
+
+    cy.log('sign in as student')
+    cy.signin({ userId: studentUserId });
+    cy.visit(`course?tool=navigation&courseId=${courseId}`);
+
+    cy.get(".navigationRow").last().dblclick();
+
+    cy.get('.mq-root-block').type('2{enter}');
+    cy.get('[data-test="New Attempt"').click();
+    cy.get('.mq-root-block').type('2{enter}');
+    cy.get('[data-test="Alert Title"]').contains("No credit awarded since the number of attempts allowed has been exceeded.");
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+  });
+  
+  //TODO: finish this implementation
+  it.skip("Timed Out Alert", () => {
+    const userId = "cyuserId";
+    const studentUserId = "cyStudentUserId";
+    const courseId = "aaq_courseid2";
+    const doenetML = `
+<problem>
+<p>1+1 = <answer name='ans1'>2</answer></p>
+<solution>2</solution>
+</problem>
+    `
+
+    cy.deleteCourseDBRows({ courseId });
+    cy.createCourse({ userId, courseId, studentUserId });
+    cy.signin({ userId });
+    cy.visit(`course?tool=navigation&courseId=${courseId}`);
+
+    cy.log('Assign a single page activity')
+    cy.get('[data-test="Add Activity Button"]').click();
+    cy.get(".navigationRow").last().dblclick();
+    cy.get(".cm-content").type(doenetML);
+    cy.get('[data-test="Viewer Update Button"]').click();
+    cy.get('.doenet-viewer').contains('Problem 1');
+
+
+    cy.get('[data-test="Controls Button"]').click();
+    cy.get('[data-test="Assign Tab"]').click();
+    cy.get('[data-test="Assign Button"]').eq(1).click();
+
+    cy.log('alert queue should show message and then be dismissed');
+    cy.get('[data-test="Alert Title"]').should('have.text', 'Activity is assigned.')
+    cy.get('[data-test="Alert Close Button"]').click();
+    cy.get('[data-test="Alert Title"]').should('not.exist');
+
     cy.log('Set due date to a date in the past')
-    cy.get('[data-test="due date"]').type('2023-09-01T04:56').blur();
+    cy.get('[data-test="Presentation Tab"]').click();
+    cy.get('[data-test="Time Limit"]').click('2023-09-01T04:56').blur();
+    cy.get('[data-test="Time Limit"]').click('2023-09-01T04:56').blur();
     cy.get('[data-test="Alert Title"]').contains("Due date set.");
     cy.get('[data-test="Alert Close Button"]').click();
     cy.get('[data-test="Alert Title"]').should('not.exist');
@@ -154,14 +265,11 @@ describe("Assignment Alert Queue Tests", function () {
     cy.get(cesc("#\\/_solution1_button")).click();
 
     cy.get('.mq-root-block').type('2{enter}')
-
-    cy.get('[data-test="Alert Title"]').should('have.length', 2);
-
-    cy.get(':nth-child(1) > [data-test="Alert Close Button"]').click({ force: true });
-    cy.get('[data-test="Alert Title"]').should('have.length', 1);
-    cy.get('[data-test="Alert Close Button"]').click({ force: true });
-
+    cy.get('[data-test="Alert Title"]').contains("No credit awarded since the time allowed has expired.");
+    cy.get('[data-test="Alert Close Button"]').click();
     cy.get('[data-test="Alert Title"]').should('not.exist');
   });
+
+
 
 });

--- a/public/api/baseModel.php
+++ b/public/api/baseModel.php
@@ -11,6 +11,8 @@ class Base_Model {
                       "\n" . $query);
             throw new Exception(
                 "Unexpected internal error occurred, please provide this error id to the doenet team " . $errorId);
+            //TODO: review if this is the right http response code, or if we should use a diffrent strategy
+            http_response_code(500);
         } else {
             return $result;
         }
@@ -72,8 +74,9 @@ class Base_Model {
         foreach($requiredKeys as $key) {
             if (!array_key_exists($key, $inputArray)) {
                 throw new Exception("Missing required field '$key'.");
+                //TODO: review if this is the right http response code, or if we should use a diffrent strategy
+                http_response_code(400);
             }
         }
     }
 }
-?>

--- a/public/api/baseModel.php
+++ b/public/api/baseModel.php
@@ -9,10 +9,10 @@ class Base_Model {
             error_log("Error occurred " . $errorId  .
                       "\n " . $conn->error .
                       "\n" . $query);
-            throw new Exception(
-                "Unexpected internal error occurred, please provide this error id to the doenet team " . $errorId);
             //TODO: review if this is the right http response code, or if we should use a diffrent strategy
             http_response_code(500);
+            throw new Exception(
+                "Unexpected internal error occurred, please provide this error id to the doenet team " . $errorId);
         } else {
             return $result;
         }
@@ -73,9 +73,9 @@ class Base_Model {
     public static function checkForRequiredInputs($inputArray, $requiredKeys) {
         foreach($requiredKeys as $key) {
             if (!array_key_exists($key, $inputArray)) {
-                throw new Exception("Missing required field '$key'.");
                 //TODO: review if this is the right http response code, or if we should use a diffrent strategy
                 http_response_code(400);
+                throw new Exception("Missing required field '$key'.");
             }
         }
     }

--- a/public/api/getQuickCheckSignedIn.php
+++ b/public/api/getQuickCheckSignedIn.php
@@ -6,11 +6,7 @@ header('Access-Control-Allow-Credentials: true');
 header('Content-Type: application/json');
 
 //ONLY TESTING IF THE SECURE SIGNED IN (JWT) COOKIE EXISTS
-$signedIn = false;
-
-if ($_COOKIE["JWT"] != NULL){
-    $signedIn = true;
-}
+$signedIn = isset($_COOKIE["JWT"]);
 
 $response_arr = ['signedIn' => $signedIn];
 

--- a/public/api/recordEvent.php
+++ b/public/api/recordEvent.php
@@ -21,7 +21,7 @@ try {
   Base_Model::checkForRequiredInputs(
     $_POST,
     [
-      "doenetId",
+      "activityId",
       "attemptNumber",
       "verb",
       "object",

--- a/public/api/recordEvent.php
+++ b/public/api/recordEvent.php
@@ -34,12 +34,11 @@ try {
 
   if ($userId == "") {
     if ($examUserId == "") {
-      $message = "No access - Need to sign in";
-      throw new Exception("No access - Need to sign in");
       http_response_code(401);
+      throw new Exception("No access - Need to sign in");
     } else if ($examDoenetId != $doenetId) {
-      throw new Exception("No access for doenetId: $doenetId");
       http_response_code(403);
+      throw new Exception("No access for doenetId: $doenetId");
     } else {
       $userId = $examUserId;
     }
@@ -82,8 +81,8 @@ try {
 
   //build response array
   $response_arr = array(
-    "success" => $success,
-    "message" => $message
+    "success" => true,
+    "message" => "Event recorded"
   );
   //set response code - 200 OK
   http_response_code(200);

--- a/public/api/recordEvent.php
+++ b/public/api/recordEvent.php
@@ -7,116 +7,97 @@ header("Access-Control-Allow-Credentials: true");
 
 
 include "db_connection.php";
+include "baseModel.php";
 
 $jwtArray = include "jwtArray.php";
 $userId = $jwtArray['userId'];
-$examUserId = array_key_exists("examineeUserId",$jwtArray) ? $jwtArray['examineeUserId'] : "";
-$examDoenetId = array_key_exists("doenetId",$jwtArray) ? $jwtArray['doenetId'] : "";
+$examUserId = array_key_exists("examineeUserId", $jwtArray) ? $jwtArray['examineeUserId'] : "";
+$examDoenetId = array_key_exists("doenetId", $jwtArray) ? $jwtArray['doenetId'] : "";
 
-$_POST = json_decode(file_get_contents("php://input"),true);
-$doenetId =  mysqli_real_escape_string($conn,$_POST["activityId"]);
-$activityCid =  mysqli_real_escape_string($conn,$_POST["activityCid"]);
-$pageCid =  mysqli_real_escape_string($conn,$_POST["pageCid"]);
-$pageNumber =  mysqli_real_escape_string($conn,$_POST["pageNumber"]);
-$attemptNumber =  mysqli_real_escape_string($conn,$_POST["attemptNumber"]);
-$verb =  mysqli_real_escape_string($conn,$_POST["verb"]);
-$object =  mysqli_real_escape_string($conn,$_POST["object"]);
-$result =  mysqli_real_escape_string($conn,$_POST["result"]);
-$context =  mysqli_real_escape_string($conn,$_POST["context"]);
-$version =  mysqli_real_escape_string($conn,$_POST["version"]);
-$activityVariantIndex =  mysqli_real_escape_string($conn,$_POST["activityVariantIndex"]);
-$pageVariantIndex =  mysqli_real_escape_string($conn,$_POST["pageVariantIndex"]);
-$timestamp =  mysqli_real_escape_string($conn,$_POST["timestamp"]);
+try {
+  $_POST = json_decode(file_get_contents("php://input"), true);
 
-$success = TRUE;
-$message = "";
-
-if ($doenetId == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing doenetId';
-}elseif ($attemptNumber == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing attemptNumber';
-}elseif ($verb == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing verb';
-}elseif ($object == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing object';
-}elseif ($result == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing result';
-}elseif ($context == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing context';
-}elseif ($version == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing version';
-}elseif ($timestamp == ""){
-  $success = FALSE;
-  $message = 'Internal Error: missing timestamp';
-}elseif ($userId == ""){
-  if ($examUserId == ""){
-    $success = FALSE;
-    $message = "No access - Need to sign in";
-  }else if ($examDoenetId != $doenetId){
-      $success = FALSE;
-      $message = "No access for doenetId: $doenetId";
-  }else{
-      $userId = $examUserId;
-  }
-}
-//TODO: Handle Anonymous
-// elseif ($userId == ""){
-//   $success = FALSE;
-//   $message = "You need to be signed in to create a $type";
-// }
-
-if ($pageCid == ""){
-  $pageCid = 'NULL';
-} else {
-  $pageCid = "'$pageCid'";
-}
-
-if ($activityCid == ""){
-  $activityCid = 'NULL';
-} else {
-  $activityCid = "'$activityCid'";
-}
-
-if ($pageVariantIndex == ""){
-  $pageVariantIndex = 'NULL';
-} else {
-  $pageVariantIndex = "'$pageVariantIndex'";
-}
-
-if ($activityVariantIndex == ""){
-  $activityVariantIndex = 'NULL';
-} else {
-  $activityVariantIndex = "'$activityVariantIndex'";
-}
-
-if ($pageNumber == ""){
-  $pageNumber = 'NULL';
-}
-
-if ($success){
-  $sql = "INSERT INTO event (userId,doenetId,activityCid,pageCid,pageNumber,attemptNumber,activityVariantIndex,pageVariantIndex,verb,object,result,context,version,timestamp)
-  VALUES ('$userId','$doenetId',$activityCid,$pageCid,$pageNumber,$attemptNumber,$activityVariantIndex,$pageVariantIndex,'$verb','$object','$result','$context','$version','$timestamp')";
-  $result = $conn->query($sql);
-}
-
-$response_arr = array(
-  "success"=>$success,
-  "message"=>$message
+  //validate input
+  Base_Model::checkForRequiredInputs(
+    $_POST,
+    [
+      "doenetId",
+      "attemptNumber",
+      "verb",
+      "object",
+      "result",
+      "context",
+      "version",
+      "timestamp"
+    ]
   );
 
-http_response_code(200);
+  if ($userId == "") {
+    if ($examUserId == "") {
+      $message = "No access - Need to sign in";
+      throw new Exception("No access - Need to sign in");
+      http_response_code(401);
+    } else if ($examDoenetId != $doenetId) {
+      throw new Exception("No access for doenetId: $doenetId");
+      http_response_code(403);
+    } else {
+      $userId = $examUserId;
+    }
+  }
 
-// make it json format
-echo json_encode($response_arr);
+  //TODO: Handle Anonymous
+  // elseif ($userId == ""){
+  //   $success = FALSE;
+  //   $message = "You need to be signed in to create a $type";
+  // }
 
-$conn->close();
+  $doenetId =  mysqli_real_escape_string($conn, $_POST["activityId"]);
+  $activityCid =  mysqli_real_escape_string($conn, $_POST["activityCid"]);
+  $pageCid =  mysqli_real_escape_string($conn, $_POST["pageCid"]);
+  $pageNumber =  mysqli_real_escape_string($conn, $_POST["pageNumber"]);
+  $attemptNumber =  mysqli_real_escape_string($conn, $_POST["attemptNumber"]);
+  $verb =  mysqli_real_escape_string($conn, $_POST["verb"]);
+  $object =  mysqli_real_escape_string($conn, $_POST["object"]);
+  $result =  mysqli_real_escape_string($conn, $_POST["result"]);
+  $context =  mysqli_real_escape_string($conn, $_POST["context"]);
+  $version =  mysqli_real_escape_string($conn, $_POST["version"]);
+  $activityVariantIndex =  mysqli_real_escape_string($conn, $_POST["activityVariantIndex"]);
+  $pageVariantIndex =  mysqli_real_escape_string($conn, $_POST["pageVariantIndex"]);
+  $timestamp =  mysqli_real_escape_string($conn, $_POST["timestamp"]);
 
-?>
+  $pageCid = $pageCid == "" ? "NULL" : "'$pageCid'";
+  $activityCid = $activityCid == "" ? "NULL" : "'$activityCid'";
+  $pageVariantIndex = $pageVariantIndex == "" ? "NULL" : "'$pageVariantIndex'";
+  $activityVariantIndex = $activityVariantIndex == "" ? "NULL" : "'$activityVariantIndex'";
 
+  if ($pageNumber == "") {
+    $pageNumber = 'NULL';
+  }
+
+  $sql =
+    "INSERT INTO event (userId,doenetId,activityCid,pageCid,pageNumber,attemptNumber,activityVariantIndex,pageVariantIndex,verb,object,result,context,version,timestamp)
+    VALUES ('$userId','$doenetId',$activityCid,$pageCid,$pageNumber,$attemptNumber,$activityVariantIndex,$pageVariantIndex,'$verb','$object','$result','$context','$version','$timestamp')";
+
+  Base_Model::runQuery($conn, $sql);
+
+  //build response array
+  $response_arr = array(
+    "success" => $success,
+    "message" => $message
+  );
+  //set response code - 200 OK
+  http_response_code(200);
+} catch (Exception $e) {
+  $response_arr = array(
+    "success" => false,
+    "message" => $e->getMessage()
+  );
+  if (http_response_code() == 200) {
+    http_response_code(500);
+  }
+} finally {
+  // make it json format
+  echo json_encode($response_arr);
+  //close database connection
+  $conn->close();
+}

--- a/public/api/saveActivityState.php
+++ b/public/api/saveActivityState.php
@@ -150,13 +150,13 @@ try {
         if (!$stateOverwritten) {
             // attempt to insert a rows in activity_state
 
+            //TODO: better way to deal with this conditional insert. Update the Base_Model to handle correclty
             $sql =
                 "INSERT INTO activity_state
                 (userId,doenetId,cid,attemptNumber,deviceName,saveId,variantIndex,activityInfo,activityState)
                 VALUES ('$userId','$doenetId','$cid','$attemptNumber','$device','$saveId','$variantIndex','$activityInfo','$activityState')";
 
-            //TODO: verify that this works for the following if statement
-            Base_Model::runQuery($conn, $sql);
+            $conn->query($sql);
 
             if ($conn->affected_rows < 1) {
                 // no rows were inserted

--- a/public/api/saveActivityState.php
+++ b/public/api/saveActivityState.php
@@ -52,11 +52,11 @@ try {
     //exam security
     if ($userId == "") {
         if ($examUserId == "") {
-            throw new Exception("No access - Need to sign in");
             http_response_code(401);
+            throw new Exception("No access - Need to sign in");
         } elseif ($examDoenetId != $doenetId) {
-            throw new Exception("No access for doenetId: $doenetId");
             http_response_code(403);
+            throw new Exception("No access for doenetId: $doenetId");
         } else {
             $userId = $examUserId;
         }
@@ -87,8 +87,8 @@ try {
         }
     } elseif ($updateDataOnContentChange != "1") {
         // something strange happened
-        throw new Exception("Database error 1");
         http_response_code(500);
+        throw new Exception("Database error 1");
     }
 
     if ($serverSaveId != "") {
@@ -135,8 +135,8 @@ try {
                 $newAttemptNumber = $row["maxAttemptNumber"];
             } else {
                 // something strange happened
-                throw new Exception("Database error 2");
                 http_response_code(500);
+                throw new Exception("Database error 2");
             }
 
             if ($newAttemptNumber !== $attemptNumber) {
@@ -201,8 +201,8 @@ try {
 
                             if (!($conn->affected_rows > 0)) {
                                 // something went wrong
-                                throw new Exception("Database error 3");
                                 http_response_code(500);
+                                throw new Exception("Database error 3");
                             }
                         }
                     }
@@ -234,8 +234,8 @@ try {
                         $newActivityState = $row["activityState"];
                     } else {
                         // something strange happened (another process changed the database in between queries?)
-                        throw new Exception("Database error 4");
                         http_response_code(500);
+                        throw new Exception("Database error 4");
                     }
                 }
             }

--- a/public/api/saveActivityState.php
+++ b/public/api/saveActivityState.php
@@ -53,8 +53,10 @@ try {
     if ($userId == "") {
         if ($examUserId == "") {
             throw new Exception("No access - Need to sign in");
+            http_response_code(401);
         } elseif ($examDoenetId != $doenetId) {
             throw new Exception("No access for doenetId: $doenetId");
+            http_response_code(403);
         } else {
             $userId = $examUserId;
         }
@@ -86,6 +88,7 @@ try {
     } elseif ($updateDataOnContentChange != "1") {
         // something strange happened
         throw new Exception("Database error 1");
+        http_response_code(500);
     }
 
     if ($serverSaveId != "") {
@@ -133,6 +136,7 @@ try {
             } else {
                 // something strange happened
                 throw new Exception("Database error 2");
+                http_response_code(500);
             }
 
             if ($newAttemptNumber !== $attemptNumber) {
@@ -198,6 +202,7 @@ try {
                             if (!($conn->affected_rows > 0)) {
                                 // something went wrong
                                 throw new Exception("Database error 3");
+                                http_response_code(500);
                             }
                         }
                     }
@@ -230,6 +235,7 @@ try {
                     } else {
                         // something strange happened (another process changed the database in between queries?)
                         throw new Exception("Database error 4");
+                        http_response_code(500);
                     }
                 }
             }
@@ -258,8 +264,10 @@ try {
         "success" => false,
         "message" => $e->getMessage(),
     ];
-    //set response code - 400 bad request
-    http_response_code(400);
+    //TODO: review http response code pattern for Doenet
+    if (http_response_code() == 200) {
+        http_response_code(500);
+    }
 } finally {
     // make it json format and echo it out
     echo json_encode($response_arr);

--- a/public/api/saveCreditForItem.php
+++ b/public/api/saveCreditForItem.php
@@ -121,8 +121,7 @@ try {
         AND doenetId = '$doenetId'
         ";
 
-    $result = Base_Model::queryExpectingOneRow($conn, $sql);
-    $row = $result->fetch_assoc();
+    $row = Base_Model::queryExpectingOneRow($conn, $sql);
     $dueDateOverride = $row['dueDateOverride'];
     $creditOverride_for_assignment = $row['creditOverride'];
     $previousCredit_for_assignment = $row['credit'];
@@ -352,8 +351,6 @@ try {
         'totalPointsOrPercent' => $totalPointsOrPercent,
     ];
 } catch (Exception $e) {
-    $response_arr['success'] = false;
-    $response_arr['message'] = $e->getMessage();
     $response_arr = [
         'success' => false,
         'message' => $e->getMessage(),
@@ -367,8 +364,6 @@ try {
         http_response_code(500);
     }
 } finally {
-    $response_arr['creditByItem'] = $credit_by_item;
-
     // set response code - 200 OK
     http_response_code(200);
 

--- a/public/api/saveCreditForItem.php
+++ b/public/api/saveCreditForItem.php
@@ -28,7 +28,7 @@ try {
     Base_Model::checkForRequiredInputs(
         $_POST,
         [
-            'doenetId',
+            'activityId',
             'attemptNumber',
             'credit',
             'itemNumber',

--- a/public/api/saveCreditForItem.php
+++ b/public/api/saveCreditForItem.php
@@ -19,6 +19,8 @@ $examDoenetId = array_key_exists('doenetId', $jwtArray)
     ? $jwtArray['doenetId']
     : '';
 
+$response_arr = [];
+$credit_by_item = [];
 try {
     $_POST = json_decode(file_get_contents('php://input'), true);
 
@@ -54,7 +56,7 @@ try {
 
     //TODO: check if attempt is older than given attempt
 
-
+    /* Begin data lookup */
     //**Find assessment settings
     $sql =
         "SELECT attemptAggregation,
@@ -72,40 +74,9 @@ try {
     $dueDate = $row['dueDate'];
     $totalPointsOrPercent = $row['totalPointsOrPercent'];
 
-    $valid = 1;
-
-    $timeExpired = false;
-    $databaseError = false;
-    $pastDueDate = false;
-    $exceededAttemptsAllowed = false;
-    $viewedSolution = false;
-
-    // if there is a time limit,
-    // multiply by factor for user
-    if ($timeLimit > 0) {
-        // have to use course_content
-        // to get courseId from doenetID
-        $sql = "SELECT timeLimitMultiplier 
-            FROM course_user cu
-            INNER JOIN course_content cc
-                ON cc.courseId = cu.courseId
-            WHERE cc.doenetId = '$doenetId'
-            AND cu.userId = '$userId'
-            ";
-
-        $result = Base_Model::runQuery($conn, $sql);
-
-        if ($result->num_rows < 1) {
-            $databaseError = 1;
-            $valid = 0;
-        } else {
-            $row = $result->fetch_assoc();
-            $timeLimit = ceil($timeLimit * $row['timeLimitMultiplier']);
-        }
-    }
-
     // Get time began and creditOverride from user_assignment_attempt
-    $sql = "SELECT 
+    $sql =
+        "SELECT 
         CONVERT_TZ(NOW(), @@session.time_zone, '+00:00') AS now,
         began, 
         creditOverride, 
@@ -113,33 +84,28 @@ try {
         FROM user_assignment_attempt
         WHERE userId = '$userId'
         AND doenetId = '$doenetId'
+        AND attemptNumber = '$attemptNumber'";
+
+    $row = Base_Model::queryExpectingOneRow($conn, $sql);
+
+    $now_seconds = strtotime($row['now']);
+    $began_seconds = strtotime($row['began']);
+    $creditOverride_for_attempt = $row['creditOverride'];
+    $previousCredit_for_attempt = $row['credit'];
+
+    // look up the stored credit for each item of attempt
+    $sql =
+        "SELECT credit
+        FROM user_assignment_attempt_item
+        WHERE userId = '$userId'
+        AND doenetId = '$doenetId'
         AND attemptNumber = '$attemptNumber'
+        ORDER BY itemNumber
         ";
-    $result = $conn->query($sql);
+    $result = Base_Model::runQuery($conn, $sql);
 
-    if ($result->num_rows < 1) {
-        $databaseError = 2;
-        $valid = 0;
-    } else {
-        $row = $result->fetch_assoc();
-        $creditOverride_for_attempt = $row['creditOverride'];
-        $previousCredit_for_attempt = $row['credit'];
-
-        if ($timeLimit > 0) {
-            // give a buffer of one minute
-            $effectiveTimeLimit = $timeLimit + 1;
-
-            // if began more than timeLimit ago, we're past time
-            $began_seconds = strtotime($row['began']);
-            $now_seconds = strtotime($row['now']);
-            $effective_timelimit_seconds = $effectiveTimeLimit * 60;
-            $diff_seconds =
-                $now_seconds - ($began_seconds + $effective_timelimit_seconds);
-            if ($began_seconds + $effective_timelimit_seconds < $now_seconds) {
-                $timeExpired = true;
-                $valid = 0;
-            }
-        }
+    while ($row = $result->fetch_assoc()) {
+        $credit_by_item[] = $row['credit'];
     }
 
     // look for a overrides in due date, credit, or number of attempts allowed for asssignment,
@@ -155,47 +121,15 @@ try {
         AND doenetId = '$doenetId'
         ";
 
-    $result = $conn->query($sql);
-    if ($result->num_rows < 1) {
-        $databaseError = 3;
-        $valid = 0;
-    } else {
-        $row = $result->fetch_assoc();
-        $dueDateOverride = $row['dueDateOverride'];
-        $creditOverride_for_assignment = $row['creditOverride'];
-        $previousCredit_for_assignment = $row['credit'];
-        $numberOfAttemptsAllowedAdjustment =
-            $row['numberOfAttemptsAllowedAdjustment'];
+    $result = Base_Model::queryExpectingOneRow($conn, $sql);
+    $row = $result->fetch_assoc();
+    $dueDateOverride = $row['dueDateOverride'];
+    $creditOverride_for_assignment = $row['creditOverride'];
+    $previousCredit_for_assignment = $row['credit'];
+    $numberOfAttemptsAllowedAdjustment =
+        $row['numberOfAttemptsAllowedAdjustment'];
 
-        // If there is a due date override for this user
-        // use that for the due date
-        if ($dueDateOverride) {
-            $dueDate = $dueDateOverride;
-        }
-        //If null then it's never past due
-        if ($dueDate) {
-            $dueDate_seconds = strtotime($dueDate);
-            $now_seconds = strtotime($row['now']);
-            $dueDate_diff = $now_seconds - $dueDate_seconds;
-            // give one minute buffer on due date
-            if ($dueDate_seconds < $now_seconds) {
-                $pastDueDate = true;
-                $valid = 0;
-            }
-        }
-
-        //$numberOfAttemptsAllowed is '' when unlimited
-        if ($numberOfAttemptsAllowed != '') {
-            if ($numberOfAttemptsAllowedAdjustment) {
-                $numberOfAttemptsAllowed = $numberOfAttemptsAllowed + $numberOfAttemptsAllowedAdjustment;
-            }
-            if ($attemptNumber > $numberOfAttemptsAllowed) {
-                $exceededAttemptsAllowed = true;
-                $valid = 0;
-            }
-        }
-    }
-
+    //look for current credit or credit override, as well as viewed solution state
     $sql = "SELECT credit, creditOverride, viewedSolution
         FROM user_assignment_attempt_item
         WHERE userId = '$userId'
@@ -203,21 +137,81 @@ try {
         AND attemptNumber = '$attemptNumber'
         AND itemNumber = '$itemNumber'
         ";
-    $result = $conn->query($sql);
+    $row = Base_Model::queryExpectingOneRow($conn, $sql);
 
-    if ($result->num_rows < 1) {
-        $databaseError = 4;
-        $valid = 0;
-    } else {
-        $row = $result->fetch_assoc();
+    $previousCredit = $row['credit'];
+    $creditOverride_for_item = $row['creditOverride'];
+    $viewedSolution = $row['viewedSolution'] == '1';
+    /* End data lookup */
 
-        $previousCredit = $row['credit'];
-        $creditOverride_for_item = $row['creditOverride'];
-        $viewedSolution = $row['viewedSolution'] == '1';
-        if ($viewedSolution) {
-            $valid = 0;
+    /* start invalidating guards */
+
+    //is solution is viewd, no credit can be awarded
+    if ($viewedSolution) {
+        http_response_code(412);
+        throw new Exception("No credit awarded since the solution has been viewed.");
+    }
+
+    // If there is a due date override for this user
+    // use that for the due date
+    if ($dueDateOverride) {
+        $dueDate = $dueDateOverride;
+    }
+
+    //If null then it's never past due
+    if ($dueDate) {
+        $dueDate_seconds = strtotime($dueDate);
+        $now_seconds = strtotime($row['now']);
+        $dueDate_diff = $now_seconds - $dueDate_seconds;
+        // give one minute buffer on due date
+        if ($dueDate_seconds < $now_seconds) {
+            http_response_code(412);
+            throw new Exception("No credit awarded since the due date has passed.");
         }
     }
+
+    //$numberOfAttemptsAllowed is '' when unlimited
+    if ($numberOfAttemptsAllowed != '') {
+        if ($numberOfAttemptsAllowedAdjustment) {
+            $numberOfAttemptsAllowed = $numberOfAttemptsAllowed + $numberOfAttemptsAllowedAdjustment;
+        }
+        if ($attemptNumber > $numberOfAttemptsAllowed) {
+            http_response_code(412);
+            throw new Exception("No credit awarded since the number of attempts allowed has been exceeded.");
+        }
+    }
+
+    // if there is a time limit,
+    // multiply by factor for user
+    if ($timeLimit > 0) {
+        // have to use course_content
+        // to get courseId from doenetID
+        $sql = "SELECT timeLimitMultiplier 
+            FROM course_user cu
+            INNER JOIN course_content cc
+                ON cc.courseId = cu.courseId
+            WHERE cc.doenetId = '$doenetId'
+            AND cu.userId = '$userId'
+            ";
+
+        $row = Base_Model::queryExpectingOneRow($conn, $sql);
+        $timeLimit = ceil($timeLimit * $row['timeLimitMultiplier']);
+
+        // give a buffer of one minute
+        $effectiveTimeLimit = $timeLimit + 1;
+
+        // if began more than timeLimit ago, we're past time
+
+        $effective_timelimit_seconds = $effectiveTimeLimit * 60;
+        $diff_seconds =
+            $now_seconds - ($began_seconds + $effective_timelimit_seconds);
+        if ($began_seconds + $effective_timelimit_seconds < $now_seconds) {
+            http_response_code(412);
+            throw new Exception("No credit awarded since the time allowed has expired.");
+        }
+    }
+
+    /* end invalidating guards */
 
     // we update credit in
     //   - user_assignment
@@ -225,170 +219,131 @@ try {
     //   - user_assignment_attempt_item
     // only if valid
 
-    $set_credit_by_item = false;
-    $credit_by_item = [];
 
-    if ($valid) {
-        // if have a credit override on that item
-        // then there is nothing to do,
-        // as the score for the item must stay unchanged,
-        // which means the resulting score for attempt and assignment
-        // also cannot change
-        if ($creditOverride_for_item == null) {
-            if ($attemptAggregation == 'm') {
-                // Find previous credit if maximizing scores
-                // Update credit in the database if it's larger
-                $credit_for_item = MAX($previousCredit, $credit);
-            } elseif ($attemptAggregation == 'l') {
-                $credit_for_item = $credit;
-            }
-
-            // Store credit in user_assignment_attempt_item
-            $sql = "UPDATE user_assignment_attempt_item
-                SET credit='$credit_for_item'
-                WHERE userId = '$userId'
-                AND doenetId = '$doenetId'
-                AND attemptNumber = '$attemptNumber'
-                AND itemNumber = '$itemNumber'
-                ";
-            $result = $conn->query($sql);
-
-            // if have a credit override on the attempt
-            // then we don't need to recalculate credit on the attempt or the assignment
-
-            if ($creditOverride_for_attempt == null) {
-                // **update user_assignment_attempt for the content
-
-                // Get the attempt's defined weights and credits
-                $sql = "SELECT credit,itemNumber,weight
-                    FROM user_assignment_attempt_item
-                    WHERE userId = '$userId'
-                    AND doenetId = '$doenetId'
-                    AND attemptNumber = '$attemptNumber'
-                    ORDER BY itemNumber
-                    ";
-                $result = $conn->query($sql);
-                $total_credits = 0;
-                $total_weights = 0;
-
-                $set_credit_by_item = true;
-
-                while ($row = $result->fetch_assoc()) {
-                    $loopItemNumber = $row['itemNumber'];
-                    $item_weight = $row['weight'];
-                    $total_weights = $total_weights + $item_weight;
-                    //Not guaranteed for credit to be stored due to async communication with db
-                    //So use value given here to be careful
-                    if ($loopItemNumber == $itemNumber) {
-                        $item_credit = $credit_for_item;
-                    } else {
-                        $item_credit = $row['credit'];
-                    }
-
-                    $total_credits =
-                        $total_credits + $item_credit * $item_weight;
-
-                    $credit_by_item[] = $item_credit;
-                }
-                $credit_for_attempt = 0;
-                if ($total_weights > 0) {
-                    //Prevent divide by zero
-                    $credit_for_attempt = $total_credits / $total_weights;
-                }
-
-                // Store credit in user_assignment_attempt
-                $sql = "UPDATE user_assignment_attempt
-                    SET credit='$credit_for_attempt'
-                    WHERE userId = '$userId'
-                    AND doenetId = '$doenetId'
-                    AND attemptNumber = '$attemptNumber'
-                    ";
-                $result = $conn->query($sql);
-
-                // if have credit override on assignment, don't update assignment credit
-                if ($creditOverride_for_assignment == null) {
-                    //Find maximum credit over all attempts
-                    $sql = "SELECT MAX(credit) AS maxCredit
-                        FROM user_assignment_attempt
-                        WHERE userId = '$userId'
-                        AND doenetId = '$doenetId'
-                        ";
-
-                    $result = $conn->query($sql);
-                    $row = $result->fetch_assoc();
-
-                    $credit_for_assignment = MAX(
-                        $credit_for_attempt,
-                        $row['maxCredit']
-                    );
-
-                    // update credit in user_assigment
-                    $sql = "UPDATE user_assignment
-                        SET credit='$credit_for_assignment'
-                        WHERE userId = '$userId'
-                        AND doenetId = '$doenetId'
-                        ";
-                    $result = $conn->query($sql);
-                } else {
-                    // have non-NULL override of credit for assignment
-                    $credit_for_assignment = $creditOverride_for_assignment;
-                }
-            } else {
-                // have non-NULL override of credit for attempt
-                $credit_for_attempt = $creditOverride_for_attempt;
-                $credit_for_assignment = $previousCredit_for_assignment;
-            }
-        } else {
-            // have non-NULL override of credit for item
-            $credit_for_item = $creditOverride_for_item;
-            $credit_for_attempt = $previousCredit_for_attempt;
-            $credit_for_assignment = $previousCredit_for_assignment;
+    // if have a credit override on that item
+    // then there is nothing to do,
+    // as the score for the item must stay unchanged,
+    // which means the resulting score for attempt and assignment
+    // also cannot change
+    if ($creditOverride_for_item == null) {
+        if ($attemptAggregation == 'm') {
+            // Find previous credit if maximizing scores
+            // Update credit in the database if it's larger
+            $credit_for_item = MAX($previousCredit, $credit);
+        } elseif ($attemptAggregation == 'l') {
+            $credit_for_item = $credit;
         }
-    } else {
-        // have invalid attempt
 
-        if ($databaseError) {
-            $credit_for_item = 0;
-            $credit_for_attempt = 0;
-            $credit_for_assignment = 0;
-        } else {
-            $credit_for_item = $previousCredit;
-            $credit_for_attempt = $previousCredit_for_attempt;
-            $credit_for_assignment = $previousCredit_for_assignment;
-        }
-    }
-
-    if (!$set_credit_by_item && !$databaseError) {
-        // look up the stored credit for each item of attempt
-        $sql = "SELECT credit
-            FROM user_assignment_attempt_item
+        // Store credit in user_assignment_attempt_item
+        $sql = "UPDATE user_assignment_attempt_item
+            SET credit='$credit_for_item'
             WHERE userId = '$userId'
             AND doenetId = '$doenetId'
             AND attemptNumber = '$attemptNumber'
-            ORDER BY itemNumber
+            AND itemNumber = '$itemNumber'
             ";
-        $result = $conn->query($sql);
+        $result = Base_Model::runQuery($conn, $sql);
 
-        while ($row = $result->fetch_assoc()) {
-            $credit_by_item[] = $row['credit'];
+        // if have a credit override on the attempt
+        // then we don't need to recalculate credit on the attempt or the assignment
+
+        if ($creditOverride_for_attempt == null) {
+            // **update user_assignment_attempt for the content
+
+            // Get the attempt's defined weights and credits
+            $sql = "SELECT credit,itemNumber,weight
+                FROM user_assignment_attempt_item
+                WHERE userId = '$userId'
+                AND doenetId = '$doenetId'
+                AND attemptNumber = '$attemptNumber'
+                ORDER BY itemNumber
+                ";
+            $result = Base_Model::runQuery($conn, $sql);
+            $total_credits = 0;
+            $total_weights = 0;
+
+            $credit_by_item = [];
+            while ($row = $result->fetch_assoc()) {
+                $loopItemNumber = $row['itemNumber'];
+                $item_weight = $row['weight'];
+                $total_weights = $total_weights + $item_weight;
+                //Not guaranteed for credit to be stored due to async communication with db
+                //So use value given here to be careful
+                if ($loopItemNumber == $itemNumber) {
+                    $item_credit = $credit_for_item;
+                } else {
+                    $item_credit = $row['credit'];
+                }
+
+                $total_credits =
+                    $total_credits + $item_credit * $item_weight;
+
+                $credit_by_item[] = $item_credit;
+            }
+            $credit_for_attempt = 0;
+            if ($total_weights > 0) {
+                //Prevent divide by zero
+                $credit_for_attempt = $total_credits / $total_weights;
+            }
+
+            // Store credit in user_assignment_attempt
+            $sql = "UPDATE user_assignment_attempt
+                SET credit='$credit_for_attempt'
+                WHERE userId = '$userId'
+                AND doenetId = '$doenetId'
+                AND attemptNumber = '$attemptNumber'
+                ";
+            $result = Base_Model::runQuery($conn, $sql);
+
+            // if have credit override on assignment, don't update assignment credit
+            if ($creditOverride_for_assignment == null) {
+                //Find maximum credit over all attempts
+                $sql = "SELECT MAX(credit) AS maxCredit
+                    FROM user_assignment_attempt
+                    WHERE userId = '$userId'
+                    AND doenetId = '$doenetId'
+                    ";
+
+                $result = Base_Model::runQuery($conn, $sql);
+                $row = $result->fetch_assoc();
+
+                $credit_for_assignment = MAX(
+                    $credit_for_attempt,
+                    $row['maxCredit']
+                );
+
+                // update credit in user_assigment
+                $sql = "UPDATE user_assignment
+                    SET credit='$credit_for_assignment'
+                    WHERE userId = '$userId'
+                    AND doenetId = '$doenetId'
+                    ";
+                $result = Base_Model::runQuery($conn, $sql);
+            } else {
+                // have non-NULL override of credit for assignment
+                $credit_for_assignment = $creditOverride_for_assignment;
+            }
+        } else {
+            // have non-NULL override of credit for attempt
+            $credit_for_attempt = $creditOverride_for_attempt;
+            $credit_for_assignment = $previousCredit_for_assignment;
         }
+    } else {
+        // have non-NULL override of credit for item
+        $credit_for_item = $creditOverride_for_item;
+        $credit_for_attempt = $previousCredit_for_attempt;
+        $credit_for_assignment = $previousCredit_for_assignment;
     }
-
 
     $response_arr = [
         'success' => true,
         'message' => "Credit for item $itemNumber saved",
         'access' => true,
-        'viewedSolution' => $viewedSolution,
-        'timeExpired' => $timeExpired,
-        'pastDueDate' => $pastDueDate,
-        'exceededAttemptsAllowed' => $exceededAttemptsAllowed,
-        'databaseError' => $databaseError,
         'valid' => $valid,
+        'creditByItem' => $credit_by_item,
         'creditForItem' => $credit_for_item,
         'creditForAttempt' => $credit_for_attempt,
         'creditForAssignment' => $credit_for_assignment,
-        'creditByItem' => $credit_by_item,
         'began_seconds' => $began_seconds,
         'effective_timelimit_seconds' => $effective_timelimit_seconds,
         'now_seconds' => $now_seconds,
@@ -397,16 +352,26 @@ try {
         'totalPointsOrPercent' => $totalPointsOrPercent,
     ];
 } catch (Exception $e) {
+    $response_arr['success'] = false;
+    $response_arr['message'] = $e->getMessage();
     $response_arr = [
-        $success = false,
-        $message = $e->getMessage()
+        'success' => false,
+        'message' => $e->getMessage(),
+        'creditByItem' => $credit_by_item,
+        'creditForItem' => $previousCredit ?? 0,
+        'creditForAttempt' => $previousCredit_for_attempt ?? 0,
+        'creditForAssignment' => $previousCredit_for_assignment ?? 0,
     ];
+
     if (http_response_code() == 200) {
         http_response_code(500);
     }
 } finally {
+    $response_arr['creditByItem'] = $credit_by_item;
+
     // set response code - 200 OK
     http_response_code(200);
+
     echo json_encode($response_arr);
     $conn->close();
 }

--- a/public/api/saveCreditForItem.php
+++ b/public/api/saveCreditForItem.php
@@ -5,6 +5,7 @@ header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Credentials: true');
 header('Content-Type: application/json');
 include 'db_connection.php';
+include 'baseModel.php';
 
 date_default_timezone_set('UTC');
 // America/Chicago

--- a/public/api/saveCreditForItem.php
+++ b/public/api/saveCreditForItem.php
@@ -160,7 +160,6 @@ try {
     //If null then it's never past due
     if ($dueDate) {
         $dueDate_seconds = strtotime($dueDate);
-        $now_seconds = strtotime($row['now']);
         $dueDate_diff = $now_seconds - $dueDate_seconds;
         // give one minute buffer on due date
         if ($dueDate_seconds < $now_seconds) {
@@ -338,7 +337,6 @@ try {
         'success' => true,
         'message' => "Credit for item $itemNumber saved",
         'access' => true,
-        'valid' => $valid,
         'creditByItem' => $credit_by_item,
         'creditForItem' => $credit_for_item,
         'creditForAttempt' => $credit_for_attempt,

--- a/public/api/savePageState.php
+++ b/public/api/savePageState.php
@@ -6,6 +6,7 @@ header("Access-Control-Allow-Credentials: true");
 header("Content-Type: application/json");
 
 include "db_connection.php";
+include "baseModel.php";
 
 $jwtArray = include "jwtArray.php";
 $userId = $jwtArray["userId"];

--- a/public/api/savePageState.php
+++ b/public/api/savePageState.php
@@ -14,70 +14,59 @@ $examDoenetId = $jwtArray["doenetId"];
 
 $device = $jwtArray["deviceName"];
 
-$_POST = json_decode(file_get_contents("php://input"), true);
-$doenetId = mysqli_real_escape_string($conn, $_POST["activityId"]);
-$cid = mysqli_real_escape_string($conn, $_POST["cid"]);
-$pageNumber = mysqli_real_escape_string($conn, $_POST["pageNumber"]);
-$attemptNumber = mysqli_real_escape_string($conn, $_POST["attemptNumber"]);
-$coreInfo = mysqli_real_escape_string($conn, $_POST["coreInfo"]);
-$coreState = mysqli_real_escape_string($conn, $_POST["coreState"]);
-$rendererState = mysqli_real_escape_string($conn, $_POST["rendererState"]);
-$saveId = mysqli_real_escape_string($conn, $_POST["saveId"]);
-$serverSaveId = mysqli_real_escape_string($conn, $_POST["serverSaveId"]);
-$updateDataOnContentChange = mysqli_real_escape_string(
-    $conn,
-    $_POST["updateDataOnContentChange"]
-);
+try {
+    $_POST = json_decode(file_get_contents("php://input"), true);
 
-$success = true;
-$message = "";
-if ($doenetId == "") {
-    $success = false;
-    $message = "Internal Error: missing doenetId";
-} elseif ($cid == "") {
-    $success = false;
-    $message = "Internal Error: missing cid";
-} elseif ($pageNumber == "") {
-    $success = false;
-    $message = "Internal Error: missing pageNumber";
-} elseif ($attemptNumber == "") {
-    $success = false;
-    $message = "Internal Error: missing attemptNumber";
-} elseif ($coreInfo == "") {
-    $success = false;
-    $message = "Internal Error: missing coreInfo";
-} elseif ($coreState == "") {
-    $success = false;
-    $message = "Internal Error: missing coreState";
-} elseif ($rendererState == "") {
-    $success = false;
-    $message = "Internal Error: missing rendererState";
-} elseif ($saveId == "") {
-    $success = false;
-    $message = "Internal Error: missing saveId";
-    // }elseif ($serverSaveId == ""){
-    //   $success = FALSE;
-    //   $message = 'Internal Error: missing serverSaveId';
-} elseif ($userId == "") {
-    if ($examUserId == "") {
-        $success = false;
-        $message = "No access - Need to sign in";
-    } elseif ($examDoenetId != $doenetId) {
-        $success = false;
-        $message = "No access for doenetId: $doenetId";
-    } else {
-        $userId = $examUserId;
+    //validate input
+    Base_Model::checkForRequiredInputs(
+        $_POST,
+        [
+            "doenetId",
+            "cid",
+            "pageNumber",
+            "attemptNumber",
+            "coreInfo",
+            "coreState",
+            "rendererState",
+            "saveId",
+        ]
+    );
+
+    //sanitize input
+    $doenetId = mysqli_real_escape_string($conn, $_POST["activityId"]);
+    $cid = mysqli_real_escape_string($conn, $_POST["cid"]);
+    $pageNumber = mysqli_real_escape_string($conn, $_POST["pageNumber"]);
+    $attemptNumber = mysqli_real_escape_string($conn, $_POST["attemptNumber"]);
+    $coreInfo = mysqli_real_escape_string($conn, $_POST["coreInfo"]);
+    $coreState = mysqli_real_escape_string($conn, $_POST["coreState"]);
+    $rendererState = mysqli_real_escape_string($conn, $_POST["rendererState"]);
+    $saveId = mysqli_real_escape_string($conn, $_POST["saveId"]);
+    $serverSaveId = mysqli_real_escape_string($conn, $_POST["serverSaveId"]);
+    $updateDataOnContentChange = mysqli_real_escape_string(
+        $conn,
+        $_POST["updateDataOnContentChange"]
+    );
+
+    //exam security
+    if ($userId == "") {
+        if ($examUserId == "") {
+            http_response_code(401);
+            throw new Exception("No access - Need to sign in");
+        } elseif ($examDoenetId != $doenetId) {
+            http_response_code(403);
+            throw new Exception("No access for doenetId: $doenetId");
+        } else {
+            $userId = $examUserId;
+        }
     }
-}
 
-// TODO: check if cid of assignment has changed,
-// if so, include {cidChanged: true} in response
-// in order to alert the user
+    // TODO: check if cid of assignment has changed,
+    // if so, include {cidChanged: true} in response
+    // in order to alert the user
 
-$stateOverwritten = false;
-$savedState = false;
+    $stateOverwritten = false;
+    $savedState = false;
 
-if ($success) {
     if ($serverSaveId != "") {
         $sql = "UPDATE page_state SET
             coreState = '$coreState',
@@ -110,20 +99,20 @@ if ($success) {
             // get new attempt number from user_assignment_attempt
             // since that gets updated as soon as a new attempt is created
 
-            $sql = "SELECT MAX(attemptNumber) as maxAttemptNumber
+            $sql =
+                "SELECT MAX(attemptNumber) as maxAttemptNumber
                 FROM user_assignment_attempt 
                 WHERE userId = '$userId' 
-                AND doenetId = '$doenetId'
-                ";
+                AND doenetId = '$doenetId'";
 
-            $result = $conn->query($sql);
+            $result = Base_Model::runQuery($conn, $sql);
             if ($result->num_rows > 0) {
                 $row = $result->fetch_assoc();
                 $newAttemptNumber = $row["maxAttemptNumber"];
             } else {
                 // something strange happened
-                $success = false;
-                $message = "Database error 1";
+                http_response_code(500);
+                throw new Exception("Database error 1");
             }
 
             if ($newAttemptNumber !== $attemptNumber) {
@@ -134,15 +123,16 @@ if ($success) {
             }
         }
 
-        if ($success && !$stateOverwritten) {
+        if (!$stateOverwritten) {
             // attempt to insert a rows in page_state
 
-            $sql = "INSERT INTO page_state
+            $sql =
+                "INSERT INTO page_state
                 (userId,doenetId,cid,pageNumber,attemptNumber,deviceName,saveId,coreInfo,coreState,rendererState)
-                VALUES ('$userId','$doenetId','$cid','$pageNumber','$attemptNumber','$device','$saveId','$coreInfo','$coreState','$rendererState')
-            ";
+                VALUES ('$userId','$doenetId','$cid','$pageNumber','$attemptNumber','$device','$saveId','$coreInfo','$coreState','$rendererState')";
 
-            $conn->query($sql);
+            //TODO: verify that this works for the following if statement
+            Base_Model::runQuery($conn, $sql);
 
             if ($conn->affected_rows < 1) {
                 // no rows were inserted
@@ -154,42 +144,43 @@ if ($success) {
                     // if the cid changed,
                     // then update the table rather than getting information from the table
 
-                    $sql = "SELECT cid
-                    FROM page_state
-                    WHERE userId='$userId'
-                    AND doenetId='$doenetId'
-                    AND pageNumber = '$pageNumber'
-                    AND attemptNumber = '$attemptNumber'
-                    ";
+                    $sql =
+                        "SELECT cid
+                        FROM page_state
+                        WHERE userId='$userId'
+                        AND doenetId='$doenetId'
+                        AND pageNumber = '$pageNumber'
+                        AND attemptNumber = '$attemptNumber'";
 
-                    $result = $conn->query($sql);
+                    $result = Base_Model::runQuery($conn, $sql);
 
                     if ($result->num_rows > 0) {
                         $row = $result->fetch_assoc();
                         if ($row["cid"] != $cid) {
                             // update the matching row in page_state
                             // to match current cid and state
-                            $sql = "UPDATE page_state SET
-                            cid = '$cid',
-                            coreInfo = '$coreInfo',
-                            coreState = '$coreState',
-                            rendererState = '$rendererState',
-                            saveId = '$saveId',
-                            deviceName = '$device'
-                            WHERE userId='$userId'
-                            AND doenetId='$doenetId'
-                            AND pageNumber='$pageNumber'
-                            AND attemptNumber='$attemptNumber'
-                            ";
+                            $sql =
+                                "UPDATE page_state SET
+                                cid = '$cid',
+                                coreInfo = '$coreInfo',
+                                coreState = '$coreState',
+                                rendererState = '$rendererState',
+                                saveId = '$saveId',
+                                deviceName = '$device'
+                                WHERE userId='$userId'
+                                AND doenetId='$doenetId'
+                                AND pageNumber='$pageNumber'
+                                AND attemptNumber='$attemptNumber'";
 
-                            $conn->query($sql);
+                            //TODO: verify that this works for the following if statement
+                            Base_Model::runQuery($conn, $sql);
 
                             $modifiedDBRecord = true;
 
                             if (!($conn->affected_rows > 0)) {
                                 // something went wrong
-                                $success = false;
-                                $message = "Database error 2";
+                                http_response_code(500);
+                                throw new Exception("Database error 2");
                             }
                         }
                     }
@@ -202,15 +193,15 @@ if ($success) {
                     $stateOverwritten = true;
                     $newAttemptNumber = $attemptNumber;
 
-                    $sql = "SELECT cid, pageNumber, attemptNumber, saveId, deviceName, coreInfo, coreState, rendererState
+                    $sql =
+                        "SELECT cid, pageNumber, attemptNumber, saveId, deviceName, coreInfo, coreState, rendererState
                         FROM page_state
                         WHERE userId = '$userId'
                         AND doenetId = '$doenetId'
                         AND pageNumber = '$pageNumber'
-                        AND attemptNumber ='$attemptNumber'
-                        ";
+                        AND attemptNumber ='$attemptNumber'";
 
-                    $result = $conn->query($sql);
+                    $result = Base_Model::runQuery($conn, $sql);
 
                     if ($result->num_rows > 0) {
                         $row = $result->fetch_assoc();
@@ -223,31 +214,39 @@ if ($success) {
                         $newRendererState = $row["rendererState"];
                     } else {
                         // something strange happened (another process changed the database in between queries?)
-                        $success = false;
-                        $message = "Database error 3";
+                        http_response_code(500);
+                        throw new Exception("Database error 3");
                     }
                 }
             }
         }
     }
+
+
+    $response_arr = [
+        "success" => true,
+        "saveId" => $saveId,
+        "stateOverwritten" => $stateOverwritten,
+        "cid" => $newCid,
+        "attemptNumber" => $newAttemptNumber,
+        "coreInfo" => $newCoreInfo,
+        "coreState" => $newCoreState,
+        "rendererState" => $newRendererState,
+        "device" => $newDevice,
+        "message" => "Page state saved",
+    ];
+    // set response code - 200 OK
+    http_response_code(200);
+} catch (Exception $e) {
+    $response_arr = [
+        "success" => false,
+        "message" => $e->getMessage(),
+    ];
+    if (http_response_code() == 200) {
+        http_response_code(500);
+    }
+} finally {
+    // make it json format 
+    echo json_encode($response_arr);
+    $conn->close();
 }
-
-$response_arr = [
-    "success" => $success,
-    "saveId" => $saveId,
-    "stateOverwritten" => $stateOverwritten,
-    "cid" => $newCid,
-    "attemptNumber" => $newAttemptNumber,
-    "coreInfo" => $newCoreInfo,
-    "coreState" => $newCoreState,
-    "rendererState" => $newRendererState,
-    "device" => $newDevice,
-    "message" => $message,
-];
-
-http_response_code(200);
-
-echo json_encode($response_arr);
-
-$conn->close();
-?>

--- a/public/api/savePageState.php
+++ b/public/api/savePageState.php
@@ -126,14 +126,13 @@ try {
 
         if (!$stateOverwritten) {
             // attempt to insert a rows in page_state
-
+            //TODO: better way to deal with this conditional insert. Update the Base_Model to handle correclty
             $sql =
                 "INSERT INTO page_state
                 (userId,doenetId,cid,pageNumber,attemptNumber,deviceName,saveId,coreInfo,coreState,rendererState)
                 VALUES ('$userId','$doenetId','$cid','$pageNumber','$attemptNumber','$device','$saveId','$coreInfo','$coreState','$rendererState')";
 
-            //TODO: verify that this works for the following if statement
-            Base_Model::runQuery($conn, $sql);
+            $conn->query($sql);
 
             if ($conn->affected_rows < 1) {
                 // no rows were inserted

--- a/public/api/savePageState.php
+++ b/public/api/savePageState.php
@@ -82,7 +82,7 @@ try {
             AND saveId = '$serverSaveId'
             ";
 
-        $conn->query($sql);
+        Base_Model::runQuery($conn,$sql);
         if ($conn->affected_rows > 0) {
             $savedState = true;
         }

--- a/public/api/savePageState.php
+++ b/public/api/savePageState.php
@@ -22,7 +22,7 @@ try {
     Base_Model::checkForRequiredInputs(
         $_POST,
         [
-            "doenetId",
+            "activityId",
             "cid",
             "pageNumber",
             "attemptNumber",

--- a/src/Core/Core.js
+++ b/src/Core/Core.js
@@ -11978,7 +11978,7 @@ export default class Core {
             messageType: "sendAlert",
             coreId: this.coreId,
             args: {
-              message: `Credit not saved due to error: ${resp.data.message}`,
+              message: `${resp.data.message}`,
               alertType: "error",
               id: "creditDataError",
             },
@@ -12001,65 +12001,6 @@ export default class Core {
           });
 
           this.failedToSaveCreditForItem = false;
-
-          //TODO: need type warning (red but doesn't hang around)
-          if (data.viewedSolution) {
-            postMessage({
-              messageType: "sendAlert",
-              coreId: this.coreId,
-              args: {
-                message: "No credit awarded since solution was viewed.",
-                alertType: "info",
-                id: "solutionViewed",
-              },
-            });
-          }
-          if (data.timeExpired) {
-            postMessage({
-              messageType: "sendAlert",
-              coreId: this.coreId,
-              args: {
-                message:
-                  "No credit awarded since the time allowed has expired.",
-                alertType: "info",
-                id: "timeExpired",
-              },
-            });
-          }
-          if (data.pastDueDate) {
-            postMessage({
-              messageType: "sendAlert",
-              coreId: this.coreId,
-              args: {
-                message: "No credit awarded since the due date has passed.",
-                alertType: "info",
-                id: "pastDue",
-              },
-            });
-          }
-          if (data.exceededAttemptsAllowed) {
-            postMessage({
-              messageType: "sendAlert",
-              coreId: this.coreId,
-              args: {
-                message:
-                  "No credit awarded since no more attempts are allowed.",
-                alertType: "info",
-                id: "noMoreAttempts",
-              },
-            });
-          }
-          if (data.databaseError) {
-            postMessage({
-              messageType: "sendAlert",
-              coreId: this.coreId,
-              args: {
-                message: "Credit not saved due to database error.",
-                alertType: "error",
-                id: "creditDataError",
-              },
-            });
-          }
         }
       })
       .catch((e) => {

--- a/src/Core/Core.js
+++ b/src/Core/Core.js
@@ -11830,7 +11830,7 @@ export default class Core {
         coreId: this.coreId,
         args: {
           message:
-            "Error synchronizing data.  Changes not saved to the server.",
+          `${resp.data.message}`,
           alertType: "error",
           id: "dataError",
         },

--- a/src/Tools/_framework/ToolPanels/AssignmentViewer.jsx
+++ b/src/Tools/_framework/ToolPanels/AssignmentViewer.jsx
@@ -799,12 +799,12 @@ export default function AssignmentViewer() {
 
   const apiURLs = {
     loadActivityState: "/api/loadActivityState.php",
-    saveActivityState: "/api/saveActivityState.php",
+    saveActivityState: "/api/saveActivityState.php", //logging enabled
     initAssignmentAttempt: "/api/initAssignmentAttempt.php",
-    recordEvent: "/api/recordEvent.php",
+    recordEvent: "/api/recordEvent.php", //logging enabled
     loadPageState: "/api/loadPageState.php",
-    savePageState: "/api/savePageState.php",
-    saveCreditForItem: "/api/saveCreditForItem.php",
+    savePageState: "/api/savePageState.php", //logging enabled 
+    saveCreditForItem: "/api/saveCreditForItem.php",//logging enabled
     reportSolutionViewed: "/api/reportSolutionViewed.php",
   };
 


### PR DESCRIPTION
Used `Base_Model` to plug in logging for the touched php files. Each one has guards for http response codes in core – where they are exclusively called from. Also fixes an issue with `getQuickCheckSignedIn` polluting the error log