### PR TITLE
Small CSS fix - restore link to the planet animation tutorial

### DIFF
--- a/src/Tools/_framework/Paths/HomeIntroVideo.jsx
+++ b/src/Tools/_framework/Paths/HomeIntroVideo.jsx
@@ -52,15 +52,15 @@ export default function HomeIntroVideo() {
         >
           <source src="/planet_orbits_smooth.webm" type="video/webm" />
         </HPVideo>
-        <Show above="sm">
-          <Link
-            color={"white"}
-            href="https://www.doenet.org/portfolioviewer/_IDTeopxcrVV2EzMEA4Cg9"
-          >
-            How to Make this Animation
-          </Link>
-        </Show>
       </Box>
+      <Show above="sm">
+        <Link
+          color={"white"}
+          href="https://www.doenet.org/portfolioviewer/_IDTeopxcrVV2EzMEA4Cg9"
+        >
+          How to Make this Animation
+        </Link>
+      </Show>
     </Box>
   );
 }


### PR DESCRIPTION
- this is unintinutive, but the video for the planets orbiting is not a square it has black bars on the margins, because I did some light editing in a video editor and it just exported it in a standard 9:16 aspect ratio
- I decided to just fix how I wanted it displayed using CSS, but the recent changes accidentally put this text in the invisible overlapping space where I'm hiding the margin of the video, this just moves it outside of that inner div to the outer container