### PR TITLE
Improve Copy to Activities

### DIFF
--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -20,34 +20,15 @@ import {
   Spacer,
   Text,
   Tooltip,
+  useDisclosure,
   VStack,
 } from "@chakra-ui/react";
 import axios from "axios";
 import ContributorsMenu from "../ToolPanels/ContributorsMenu";
-import { Link, useFetcher } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ContentStructure, DoenetmlVersion, License } from "./ActivityEditor";
 import { DisplayLicenseItem } from "../ToolPanels/SharingControls";
-
-export async function action({ params, request }) {
-  // TODO: it is confusing that the one "action" of this viewer is to duplicate.
-
-  const formData = await request.formData();
-  let formObj = Object.fromEntries(formData);
-
-  if (formObj._action == "copy to activities") {
-    let { data } = await axios.post(`/api/duplicateActivity`, {
-      activityId: Number(params.activityId),
-    });
-
-    const { newActivityId } = data;
-
-    // TODO: do not navigate to editor
-    // Instead, navigate to activities with newly created activity highlighted
-    return redirect(`/activityEditor/${newActivityId}`);
-  }
-
-  return null;
-}
+import { CopyActivityAndReportFinish } from "../ToolPanels/CopyActivityAndReportFinish";
 
 export async function loader({ params }) {
   //Check if signedIn
@@ -120,7 +101,11 @@ export function ActivityViewer() {
     doenetmlVersion: DoenetmlVersion;
   };
 
-  const fetcher = useFetcher();
+  const {
+    isOpen: copyDialogIsOpen,
+    onOpen: copyDialogOnOpen,
+    onClose: copyDialogOnClose,
+  } = useDisclosure();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -141,6 +126,11 @@ export function ActivityViewer() {
 
   return (
     <>
+      <CopyActivityAndReportFinish
+        isOpen={copyDialogIsOpen}
+        onClose={copyDialogOnClose}
+        activityData={activity}
+      />
       <Box background="doenet.lightBlue" height="100%">
         <Flex
           background="doenet.lightBlue"
@@ -213,12 +203,7 @@ export function ActivityViewer() {
                               size="xs"
                               colorScheme="blue"
                               onClick={() => {
-                                fetcher.submit(
-                                  {
-                                    _action: "copy to activities",
-                                  },
-                                  { method: "post" },
-                                );
+                                copyDialogOnOpen();
                               }}
                             >
                               Copy to Activities

--- a/client/src/Tools/_framework/ToolPanels/CopyActivityAndReportFinish.tsx
+++ b/client/src/Tools/_framework/ToolPanels/CopyActivityAndReportFinish.tsx
@@ -1,0 +1,107 @@
+import React, { RefObject, useEffect, useState } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  ModalFooter,
+  Button,
+} from "@chakra-ui/react";
+import { ContentStructure } from "../Paths/ActivityEditor";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * A modal that immediately upon opening copies an activity into a user's Activities.
+ *
+ * When the copy is finished, the modal allows the user to close it or navigate to their Activities list.
+ */
+export function CopyActivityAndReportFinish({
+  isOpen,
+  onClose,
+  finalFocusRef,
+  activityData,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  finalFocusRef?: RefObject<HTMLElement>;
+  activityData: ContentStructure;
+}) {
+  const [newActivityData, setNewActivityData] = useState<{
+    newActivityId: number;
+    userId: number;
+  } | null>(null);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function copyActivity() {
+      document.body.style.cursor = "wait";
+
+      const { data } = await axios.post(`/api/duplicateActivity`, {
+        activityId: activityData.id,
+      });
+
+      setNewActivityData(data);
+      document.body.style.cursor = "default";
+    }
+
+    if (isOpen) {
+      if (newActivityData === null) {
+        copyActivity();
+      }
+    } else {
+      setNewActivityData(null);
+    }
+  }, [isOpen]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      finalFocusRef={finalFocusRef}
+      size="md"
+      closeOnOverlayClick={newActivityData !== null}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader textAlign="center">
+          {newActivityData === null ? `Copying Activity` : `Activity copied`}
+        </ModalHeader>
+        {newActivityData !== null ? <ModalCloseButton /> : null}
+        <ModalBody>
+          {newActivityData === null ? (
+            `Copying...`
+          ) : (
+            <>
+              The activity <strong>{activityData.name}</strong> has been copied
+              to your activities.
+            </>
+          )}
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            marginRight="4px"
+            onClick={() => {
+              navigate(`/activities/${newActivityData?.userId}`);
+            }}
+            isDisabled={newActivityData === null}
+          >
+            Go to Activities
+          </Button>
+          <Button
+            onClick={() => {
+              onClose();
+            }}
+            isDisabled={newActivityData === null}
+          >
+            Close
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -41,7 +41,6 @@ import {
 } from "./Tools/_framework/Paths/PublicActivities";
 import {
   loader as activityViewerLoader,
-  action as activityViewerAction,
   ActivityViewer,
 } from "./Tools/_framework/Paths/ActivityViewer";
 import {
@@ -250,7 +249,6 @@ const router = createBrowserRouter([
       {
         path: "activityViewer/:activityId",
         loader: activityViewerLoader,
-        action: activityViewerAction,
         errorElement: <ErrorPage />,
         element: <ActivityViewer />,
       },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -865,7 +865,7 @@ app.post("/api/duplicateActivity", async (req: Request, res: Response) => {
     desiredParentFolderId,
   );
 
-  res.send({ newActivityId });
+  res.send({ newActivityId, userId: loggedInUserId });
 });
 
 app.post("/api/assignActivity", async (req: Request, res: Response) => {


### PR DESCRIPTION
Improve the behavior of the `Copy to Activities` button in the activity viewer and the public editor.

When a user clicks the `Copy to Activities` button, a dialog opens indicating that the copy is occurring. When the copy is finished, the dialog gives the option for the user to go to their Activities.