### PR TITLE
content info drawer to view classifications and more

### DIFF
--- a/client/cypress/e2e/Activities/activityEditor.cy.ts
+++ b/client/cypress/e2e/Activities/activityEditor.cy.ts
@@ -1,11 +1,14 @@
-describe("Create Folders Tests", function () {
+describe("Activity Editor Tests", function () {
   it("correctly restore editor state after clicking view", () => {
     // test bug where activity editor was not restoring itself with the correct state
     // after one switched to view mode and back
 
     cy.loginAsTestUser();
 
-    cy.createActivity("Hello!", "Initial content").then((activityId) => {
+    cy.createActivity({
+      activityName: "Hello!",
+      doenetML: "Initial content",
+    }).then((activityId) => {
       cy.visit(`/activityEditor/${activityId}`);
 
       cy.iframe()

--- a/client/cypress/e2e/Activities/activityViewer.cy.ts
+++ b/client/cypress/e2e/Activities/activityViewer.cy.ts
@@ -1,0 +1,60 @@
+describe("Activity Viewer Tests", function () {
+  it("classifications shown in activity viewer", () => {
+    cy.loginAsTestUser();
+    cy.createActivity({
+      activityName: "Classifications!",
+      doenetML: "Hi!",
+      classifications: [
+        {
+          systemShortName: "WeBWorK",
+          category: "Algebra",
+          subCategory: "Factoring",
+          code: "Alg.F.2",
+        },
+        {
+          systemShortName: "Common Core",
+          category: "HS",
+          subCategory:
+            "Seeing Structure in Expressions. Write expressions in equivalent forms to solve problems.",
+          code: "A.SSE.3 a.",
+        },
+      ],
+    }).then((activityId) => {
+      cy.visit(`/activityViewer/${activityId}`);
+
+      cy.get('[data-test="Classifications Footer"]').should(
+        "contain.text",
+        "Alg.F.2",
+      );
+      cy.get('[data-test="Classifications Footer"]').should(
+        "contain.text",
+        "A.SSE.3 a.",
+      );
+      cy.get('[data-test="Classifications Footer"]').click();
+
+      cy.get('[data-test="Classification 1"]').should(
+        "contain.text",
+        "A.SSE.3 a.",
+      );
+      cy.get('[data-test="Classification 2"]').should(
+        "contain.text",
+        "Alg.F.2",
+      );
+
+      cy.get('[data-test="Close Settings Button"]').click();
+      cy.get('[data-test="Classification 1"]').should("not.exist");
+
+      cy.get('[data-test="Activity Information"]').click();
+
+      cy.get('[data-test="Classifications"]').click();
+      cy.get('[data-test="Classification 1"]').should(
+        "contain.text",
+        "A.SSE.3 a.",
+      );
+      cy.get('[data-test="Classification 2"]').should(
+        "contain.text",
+        "Alg.F.2",
+      );
+    });
+  });
+});

--- a/client/cypress/e2e/Activities/codeViewer.cy.ts
+++ b/client/cypress/e2e/Activities/codeViewer.cy.ts
@@ -1,0 +1,38 @@
+describe("Code Viewer Tests", function () {
+  it("classifications shown in code viewer", () => {
+    cy.loginAsTestUser();
+    cy.createActivity({
+      activityName: "Classifications!",
+      doenetML: "Hi!",
+      classifications: [
+        {
+          systemShortName: "WeBWorK",
+          category: "Algebra",
+          subCategory: "Factoring",
+          code: "Alg.F.2",
+        },
+        {
+          systemShortName: "Common Core",
+          category: "HS",
+          subCategory:
+            "Seeing Structure in Expressions. Write expressions in equivalent forms to solve problems.",
+          code: "A.SSE.3 a.",
+        },
+      ],
+    }).then((activityId) => {
+      cy.visit(`/codeViewer/${activityId}`);
+
+      cy.get('[data-test="Activity Information"]').click();
+
+      cy.get('[data-test="Classifications"]').click();
+      cy.get('[data-test="Classification 1"]').should(
+        "contain.text",
+        "A.SSE.3 a.",
+      );
+      cy.get('[data-test="Classification 2"]').should(
+        "contain.text",
+        "Alg.F.2",
+      );
+    });
+  });
+});

--- a/client/cypress/e2e/Activities/sharingActivities.cy.ts
+++ b/client/cypress/e2e/Activities/sharingActivities.cy.ts
@@ -31,8 +31,8 @@ describe("Share Activities Tests", function () {
     cy.get('[data-test="Sharing Button"]').click();
     cy.get('[data-test="Public Checkbox"]').click();
     cy.get('[data-test="Status message"]').should(
-      "have.text",
-      "Successfully shared publicly",
+      "contain.text",
+      "shared publicly",
     );
 
     cy.get('[data-test="Close Share Drawer Button"]').click();

--- a/client/cypress/e2e/Search/searchResult.cy.ts
+++ b/client/cypress/e2e/Search/searchResult.cy.ts
@@ -1,0 +1,50 @@
+describe("Search results Tests", function () {
+  it("classifications shown in search", () => {
+    cy.loginAsTestUser();
+    let code = Date.now().toString();
+
+    cy.createActivity({
+      activityName: `Classifications${code}!`,
+      doenetML: "Hi!",
+      makePublic: true,
+      classifications: [
+        {
+          systemShortName: "WeBWorK",
+          category: "Algebra",
+          subCategory: "Factoring",
+          code: "Alg.F.2",
+        },
+        {
+          systemShortName: "Common Core",
+          category: "HS",
+          subCategory:
+            "Seeing Structure in Expressions. Write expressions in equivalent forms to solve problems.",
+          code: "A.SSE.3 a.",
+        },
+      ],
+    }).then((activityId) => {
+      cy.visit(`/community?q=Classifications${code}`);
+
+      cy.get('[data-test="Results All Matches"] [data-test="Card Menu Button"]')
+        .eq(0)
+        .click();
+
+      cy.get(
+        '[data-test="Results All Matches"] [data-test="Activity Information"]',
+      )
+        .eq(0)
+        .click();
+
+      cy.get('[data-test="Classifications"]').click();
+
+      cy.get('[data-test="Classification 1"]').should(
+        "contain.text",
+        "A.SSE.3 a.",
+      );
+      cy.get('[data-test="Classification 2"]').should(
+        "contain.text",
+        "Alg.F.2",
+      );
+    });
+  });
+});

--- a/client/cypress/e2e/SettingsPanels/classifications.cy.ts
+++ b/client/cypress/e2e/SettingsPanels/classifications.cy.ts
@@ -1,4 +1,4 @@
-describe("Classifications test", function () {
+describe("Classification panel tests", function () {
   it("add classifications to activity", () => {
     cy.loginAsTestUser();
 

--- a/client/cypress/e2e/SettingsPanels/classifications.cy.ts
+++ b/client/cypress/e2e/SettingsPanels/classifications.cy.ts
@@ -2,7 +2,10 @@ describe("Classifications test", function () {
   it("add classifications to activity", () => {
     cy.loginAsTestUser();
 
-    cy.createActivity("Hello!", "Initial content").then((activityId) => {
+    cy.createActivity({
+      activityName: "Hello!",
+      doenetML: "Initial content",
+    }).then((activityId) => {
       cy.visit(`/activityEditor/${activityId}`);
 
       cy.get('[data-test="Settings Button"]').click();
@@ -87,7 +90,7 @@ describe("Classifications test", function () {
 
       cy.get('[data-test="Add 9.2.3.3"]').should("not.exist");
       cy.get('[data-test="Stop Filter By System').click();
-      cy.get('[data-test="Add 9.2.3.3"]').should("be.visible");
+      cy.get('[data-test="Add 9.2.3.3"]').scrollIntoView().should("be.visible");
     });
   });
 });

--- a/client/cypress/e2e/SettingsPanels/share.cy.ts
+++ b/client/cypress/e2e/SettingsPanels/share.cy.ts
@@ -1,4 +1,4 @@
-describe("Classifications test", function () {
+describe("Share panel tests", function () {
   it("cannot select incompatible license after remix, ShareAlike", () => {
     let code = Date.now().toString();
     const scrappyEmail = `scrappy${code}@doo`;
@@ -164,6 +164,96 @@ describe("Classifications test", function () {
       cy.get('[data-test="Status message"]').should(
         "contain.text",
         "changed license",
+      );
+    });
+  });
+
+  it("Remixes shown in share panel", () => {
+    let code = Date.now().toString();
+    const scrappyEmail = `scrappy${code}@doo`;
+    const scoobyEmail = `scooby${code}@doo`;
+
+    cy.loginAsTestUser({
+      email: scoobyEmail,
+      firstNames: "Scooby",
+      lastNames: "Doo",
+    });
+
+    cy.createActivity({
+      activityName: "Original activity",
+      doenetML: "The original activity",
+    }).then((activityId) => {
+      cy.visit(`/activityEditor/${activityId}`);
+
+      cy.get('[data-test="Sharing Button"]').click();
+
+      cy.get('[data-test="Public Checkbox"]').click();
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "shared publicly",
+      );
+
+      cy.get('[data-test="Remixed From Tab"]').click();
+      cy.get('[data-test="Not Remixed"]').should("contain.text", "Not remixed");
+
+      cy.get('[data-test="Remixes Tab"]').click();
+      cy.get('[data-test="No Remixes"]').should(
+        "contain.text",
+        "No visible remixes",
+      );
+
+      cy.loginAsTestUser({
+        email: scrappyEmail,
+        firstNames: "Scrappy",
+        lastNames: "Doo",
+      });
+
+      cy.visit(`/activityViewer/${activityId}`);
+      cy.get('[data-test="Copy to Activities Button"]').click();
+      cy.get('[data-test="Go to Activities"]').click();
+
+      cy.get('[data-test="Card Menu Button"]').eq(0).click();
+      cy.get('[data-test="Share Menu Item"]').click();
+
+      cy.get('[data-test="Public Checkbox"]').click();
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "shared publicly",
+      );
+
+      cy.get('[data-test="Select License"]').select(
+        "Creative Commons Attribution-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "changed license",
+      );
+
+      cy.get('[data-test="Remixed From Tab"]').click();
+
+      cy.get('[data-test="Remixed from 1"]').should(
+        "contain.text",
+        "Original activity",
+      );
+
+      cy.get('[data-test="Remixes Tab"]').click();
+      cy.get('[data-test="No Remixes"]').should(
+        "contain.text",
+        "No visible remixes",
+      );
+
+      cy.loginAsTestUser({
+        email: scoobyEmail,
+      });
+
+      cy.visit(`/activityEditor/${activityId}`);
+
+      cy.get('[data-test="Sharing Button"]').click();
+
+      cy.get('[data-test="Remixes Tab"]').click();
+      cy.get('[data-test="Remix 1"]').should(
+        "contain.text",
+        "Copy of Original activity",
       );
     });
   });

--- a/client/cypress/e2e/SettingsPanels/share.cy.ts
+++ b/client/cypress/e2e/SettingsPanels/share.cy.ts
@@ -1,0 +1,170 @@
+describe("Classifications test", function () {
+  it("cannot select incompatible license after remix, ShareAlike", () => {
+    let code = Date.now().toString();
+    const scrappyEmail = `scrappy${code}@doo`;
+    const scoobyEmail = `scooby${code}@doo`;
+
+    cy.loginAsTestUser({
+      email: scoobyEmail,
+      firstNames: "Scooby",
+      lastNames: "Doo",
+    });
+
+    cy.createActivity({
+      activityName: "Share alike",
+      doenetML: "Shared with ShareAlike",
+    }).then((activityId) => {
+      cy.visit(`/activityEditor/${activityId}`);
+
+      cy.get('[data-test="Sharing Button"]').click();
+
+      cy.get('[data-test="Public Checkbox"]').click();
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "shared publicly",
+      );
+
+      cy.get('[data-test="Select License"]').select(
+        "Creative Commons Attribution-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "changed license",
+      );
+
+      cy.loginAsTestUser({
+        email: scrappyEmail,
+        firstNames: "Scrappy",
+        lastNames: "Doo",
+      });
+
+      cy.visit(`/activityViewer/${activityId}`);
+      cy.get('[data-test="Copy to Activities Button"]').click();
+      cy.get('[data-test="Go to Activities"]').click();
+
+      cy.get('[data-test="Card Menu Button"]').eq(0).click();
+      cy.get('[data-test="Share Menu Item"]').click();
+
+      cy.get('[data-test="Cannot Change License"]').should(
+        "contain.text",
+        "Creative Commons Attribution-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Cannot Change License"]').should(
+        "contain.text",
+        "Cannot change license",
+      );
+      cy.get('[data-test="Select License"]').should("not.exist");
+    });
+  });
+
+  it("cannot select incompatible license after remix, NonCommercial-ShareAlike", () => {
+    let code = Date.now().toString();
+    const scrappyEmail = `scrappy${code}@doo`;
+    const scoobyEmail = `scooby${code}@doo`;
+
+    cy.loginAsTestUser({
+      email: scoobyEmail,
+      firstNames: "Scooby",
+      lastNames: "Doo",
+    });
+
+    cy.createActivity({
+      activityName: "Non-commercial share alike",
+      doenetML: "Shared with NonCommercial-ShareAlike",
+    }).then((activityId) => {
+      cy.visit(`/activityEditor/${activityId}`);
+
+      cy.get('[data-test="Sharing Button"]').click();
+
+      cy.get('[data-test="Public Checkbox"]').click();
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "shared publicly",
+      );
+
+      cy.get('[data-test="Select License"]').select(
+        "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "changed license",
+      );
+
+      cy.loginAsTestUser({
+        email: scrappyEmail,
+        firstNames: "Scrappy",
+        lastNames: "Doo",
+      });
+
+      cy.visit(`/activityViewer/${activityId}`);
+      cy.get('[data-test="Copy to Activities Button"]').click();
+      cy.get('[data-test="Go to Activities"]').click();
+
+      cy.get('[data-test="Card Menu Button"]').eq(0).click();
+      cy.get('[data-test="Share Menu Item"]').click();
+
+      cy.get('[data-test="Cannot Change License"]').should(
+        "contain.text",
+        "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Cannot Change License"]').should(
+        "contain.text",
+        "Cannot change license",
+      );
+      cy.get('[data-test="Select License"]').should("not.exist");
+    });
+  });
+
+  it("can select license after remix, Dual License", () => {
+    let code = Date.now().toString();
+    const scrappyEmail = `scrappy${code}@doo`;
+    const scoobyEmail = `scooby${code}@doo`;
+
+    cy.loginAsTestUser({
+      email: scoobyEmail,
+      firstNames: "Scooby",
+      lastNames: "Doo",
+    });
+
+    cy.createActivity({
+      activityName: "Dual license",
+      doenetML: "Shared with Dual License",
+    }).then((activityId) => {
+      cy.visit(`/activityEditor/${activityId}`);
+
+      cy.get('[data-test="Sharing Button"]').click();
+
+      cy.get('[data-test="Public Checkbox"]').click();
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "shared publicly",
+      );
+
+      cy.get('[data-test="Select License"]').should(
+        "contain.text",
+        "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
+      );
+
+      cy.loginAsTestUser({
+        email: scrappyEmail,
+        firstNames: "Scrappy",
+        lastNames: "Doo",
+      });
+
+      cy.visit(`/activityViewer/${activityId}`);
+      cy.get('[data-test="Copy to Activities Button"]').click();
+      cy.get('[data-test="Go to Activities"]').click();
+
+      cy.get('[data-test="Card Menu Button"]').eq(0).click();
+      cy.get('[data-test="Share Menu Item"]').click();
+
+      cy.get('[data-test="Select License"]').select(
+        "Creative Commons Attribution-ShareAlike 4.0",
+      );
+      cy.get('[data-test="Status message"]').should(
+        "contain.text",
+        "changed license",
+      );
+    });
+  });
+});

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -51,6 +51,7 @@ declare global {
         activityName,
         doenetML,
         classifications,
+        makePublic,
       }: {
         activityName: string;
         doenetML: string;
@@ -60,6 +61,7 @@ declare global {
           subCategory: string;
           code: string;
         }[];
+        makePublic?: boolean;
       }): Chainable<string>;
     }
   }
@@ -95,6 +97,7 @@ Cypress.Commands.add(
     activityName,
     doenetML,
     classifications,
+    makePublic = false,
   }: {
     activityName: string;
     doenetML: string;
@@ -104,6 +107,7 @@ Cypress.Commands.add(
       subCategory: string;
       code: string;
     }[];
+    makePublic?: boolean;
   }) => {
     cy.request({
       method: "POST",
@@ -119,6 +123,17 @@ Cypress.Commands.add(
           body: {
             id: activityId,
             classifications,
+          },
+        });
+      }
+
+      if (makePublic) {
+        cy.request({
+          method: "POST",
+          url: "/api/makeActivityPublic",
+          body: {
+            id: activityId,
+            licenseCode: "CCDUAL",
           },
         });
       }

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -47,7 +47,20 @@ declare global {
       /**
        * Custom command to create an activity for the logged in user
        */
-      createActivity(activityName: string, doenetML: string): Chainable<string>;
+      createActivity({
+        activityName,
+        doenetML,
+        classifications,
+      }: {
+        activityName: string;
+        doenetML: string;
+        classifications?: {
+          systemShortName: string;
+          category: string;
+          subCategory: string;
+          code: string;
+        }[];
+      }): Chainable<string>;
     }
   }
 }
@@ -78,13 +91,37 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "createActivity",
-  (activityName: string, doenetML: string) => {
+  ({
+    activityName,
+    doenetML,
+    classifications,
+  }: {
+    activityName: string;
+    doenetML: string;
+    classifications?: {
+      systemShortName: string;
+      category: string;
+      subCategory: string;
+      code: string;
+    }[];
+  }) => {
     cy.request({
       method: "POST",
       url: "/api/createActivity",
     }).then((resp) => {
       let activityId: string = resp.body.activityId;
       let docId: string = resp.body.docId;
+
+      if (classifications) {
+        cy.request({
+          method: "POST",
+          url: "/api/test/addClassificationsByNames",
+          body: {
+            id: activityId,
+            classifications,
+          },
+        });
+      }
 
       cy.request({
         method: "POST",

--- a/client/src/Tools/_framework/Paths/ActivityEditor.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityEditor.tsx
@@ -97,7 +97,7 @@ export async function loader({ params }) {
 
   if (notMe) {
     return redirect(
-      `/publicEditor/${params.activityId}${params.docId ? "/" + params.docId : ""}`,
+      `/codeViewer/${params.activityId}${params.docId ? "/" + params.docId : ""}`,
     );
   }
 
@@ -661,7 +661,7 @@ export function ActivityEditor() {
                         navigate={navigate}
                         linkSettings={{
                           viewURL: "/activityViewer",
-                          editURL: "/publicEditor",
+                          editURL: "/codeViewer",
                         }}
                         includeVariantSelector={true}
                       />

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -179,7 +179,7 @@ export function ActivityViewer() {
                             colorScheme="blue"
                             data-test="See Inside"
                             onClick={() => {
-                              navigate(`/publicEditor/${activityId}/${docId}`);
+                              navigate(`/codeViewer/${activityId}/${docId}`);
                             }}
                           >
                             See Inside
@@ -240,7 +240,7 @@ export function ActivityViewer() {
                     navigate={navigate}
                     linkSettings={{
                       viewURL: "/activityViewer",
-                      editURL: "/publicEditor",
+                      editURL: "/codeViewer",
                     }}
                     includeVariantSelector={false}
                   />

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -240,6 +240,7 @@ export function ActivityViewer() {
                               colorScheme="blue"
                               icon={<MdOutlineInfo />}
                               aria-label="Activity information"
+                              data-test="Activity Information"
                               onClick={() => {
                                 setDisplayInfoTab("general");
                                 infoOnOpen();
@@ -352,7 +353,7 @@ export function ActivityViewer() {
                       }}
                     >
                       <Heading size="sm">Classifications</Heading>
-                      <List>
+                      <List data-test="Classifications Footer">
                         {activity.classifications.map((classification) => {
                           return (
                             <Tooltip label={classification.description}>

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
   useLoaderData,
   useNavigate,
@@ -13,10 +13,14 @@ import {
   Flex,
   Grid,
   GridItem,
+  Heading,
   HStack,
+  IconButton,
   List,
+  ListItem,
   Spacer,
   Text,
+  Tooltip,
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
@@ -30,13 +34,14 @@ import {
   ContentStructure,
   DocHistoryItem,
   DoenetmlVersion,
-  License,
 } from "../../../_utils/types";
 import { processContributorHistory } from "../../../_utils/processRemixes";
 import {
   DisplayLicenseItem,
   SmallLicenseBadges,
 } from "../../../Widgets/Licenses";
+import { ContentInfoDrawer } from "../ToolPanels/ContentInfoDrawer";
+import { MdOutlineInfo } from "react-icons/md";
 
 export async function loader({ params }) {
   try {
@@ -102,6 +107,16 @@ export function ActivityViewer() {
     onClose: copyDialogOnClose,
   } = useDisclosure();
 
+  const {
+    isOpen: infoIsOpen,
+    onOpen: infoOnOpen,
+    onClose: infoOnClose,
+  } = useDisclosure();
+
+  const [displayInfoTab, setDisplayInfoTab] = useState<
+    "general" | "classifications"
+  >("general");
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -111,12 +126,21 @@ export function ActivityViewer() {
     document.title = `${activity.name} - Doenet`;
   }, [activity.name]);
 
+  const haveClassifications = activity.classifications.length > 0;
+
   return (
     <>
       <CopyActivityAndReportFinish
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         activityData={activity}
+      />
+      <ContentInfoDrawer
+        isOpen={infoIsOpen}
+        onClose={infoOnClose}
+        id={activityId}
+        contentData={activity}
+        displayTab={displayInfoTab}
       />
       <Box background="doenet.lightBlue" height="100%">
         <Flex
@@ -207,6 +231,21 @@ export function ActivityViewer() {
                               Sign In To Copy to Activities
                             </Button>
                           )}
+                          <Tooltip
+                            label={`Activity information`}
+                            placement="bottom-end"
+                          >
+                            <IconButton
+                              size="xs"
+                              colorScheme="blue"
+                              icon={<MdOutlineInfo />}
+                              aria-label="Activity information"
+                              onClick={() => {
+                                setDisplayInfoTab("general");
+                                infoOnOpen();
+                              }}
+                            />
+                          </Tooltip>
                         </HStack>
                       </VStack>
                     </Flex>
@@ -252,55 +291,86 @@ export function ActivityViewer() {
                   padding="0px"
                   margin="0px"
                 />
-                <Box
+                <Flex
                   background="gray"
                   width="100%"
                   color="var(--canvas)"
                   padding="20px"
                   minHeight="20vh"
                 >
-                  {activity.license ? (
-                    activity.license.isComposition ? (
-                      <>
-                        <p>
-                          <strong>{activity.name}</strong> by{" "}
-                          {createFullName(activity.owner!)} is shared with these
-                          licenses:
-                        </p>
-                        <List spacing="20px" marginTop="10px">
-                          {activity.license.composedOf.map((comp) => (
+                  <Box width={haveClassifications ? "70%" : "100%"}>
+                    {activity.license ? (
+                      activity.license.isComposition ? (
+                        <>
+                          <p>
+                            <strong>{activity.name}</strong> by{" "}
+                            {createFullName(activity.owner!)} is shared with
+                            these licenses:
+                          </p>
+                          <List spacing="20px" marginTop="10px">
+                            {activity.license.composedOf.map((comp) => (
+                              <DisplayLicenseItem
+                                licenseItem={comp}
+                                key={comp.code}
+                              />
+                            ))}
+                          </List>
+                          <p style={{ marginTop: "10px" }}>
+                            You are free to use either license when reusing this
+                            work.
+                          </p>
+                        </>
+                      ) : (
+                        <>
+                          <p>
+                            <strong>{activity.name}</strong> by{" "}
+                            {createFullName(activity.owner!)} is shared using
+                            the license:
+                          </p>
+                          <List marginTop="10px">
                             <DisplayLicenseItem
-                              licenseItem={comp}
-                              key={comp.code}
+                              licenseItem={activity.license}
                             />
-                          ))}
-                        </List>
-                        <p style={{ marginTop: "10px" }}>
-                          You are free to use either license when reusing this
-                          work.
-                        </p>
-                      </>
+                          </List>
+                        </>
+                      )
                     ) : (
-                      <>
-                        <p>
-                          <strong>{activity.name}</strong> by{" "}
-                          {createFullName(activity.owner!)} is shared using the
-                          license:
-                        </p>
-                        <List marginTop="10px">
-                          <DisplayLicenseItem licenseItem={activity.license} />
-                        </List>
-                      </>
-                    )
-                  ) : (
-                    <p>
-                      <strong>{activity.name}</strong> by{" "}
-                      {createFullName(activity.owner!)} is shared, but a license
-                      was not specified. Contact the author to determine in what
-                      ways you can reuse this activity.
-                    </p>
-                  )}
-                </Box>
+                      <p>
+                        <strong>{activity.name}</strong> by{" "}
+                        {createFullName(activity.owner!)} is shared, but a
+                        license was not specified. Contact the author to
+                        determine in what ways you can reuse this activity.
+                      </p>
+                    )}
+                  </Box>
+                  {haveClassifications ? (
+                    <Box
+                      cursor="pointer"
+                      onClick={() => {
+                        setDisplayInfoTab("classifications");
+                        infoOnOpen();
+                      }}
+                    >
+                      <Heading size="sm">Classifications</Heading>
+                      <List>
+                        {activity.classifications.map((classification) => {
+                          return (
+                            <Tooltip label={classification.description}>
+                              <ListItem>
+                                {classification.code} (
+                                {
+                                  classification.subCategories[0].category
+                                    .system.shortName
+                                }
+                                )
+                              </ListItem>
+                            </Tooltip>
+                          );
+                        })}
+                      </List>
+                    </Box>
+                  ) : null}
+                </Flex>
               </VStack>
             </GridItem>
           </Grid>

--- a/client/src/Tools/_framework/Paths/AssignmentStudentData.tsx
+++ b/client/src/Tools/_framework/Paths/AssignmentStudentData.tsx
@@ -267,7 +267,7 @@ export function AssignmentStudentData() {
             paginate={true}
             linkSettings={{
               viewURL: "/activityViewer",
-              editURL: "/publicEditor",
+              editURL: "/codeViewer",
             }}
             apiURLs={{ postMessages: true }}
           />
@@ -298,7 +298,7 @@ export function AssignmentStudentData() {
             paginate={true}
             linkSettings={{
               viewURL: "/activityViewer",
-              editURL: "/publicEditor",
+              editURL: "/codeViewer",
             }}
             apiURLs={{ postMessages: true }}
           />

--- a/client/src/Tools/_framework/Paths/AssignmentViewer.tsx
+++ b/client/src/Tools/_framework/Paths/AssignmentViewer.tsx
@@ -296,7 +296,7 @@ export function AssignmentViewer() {
                     navigate={navigate}
                     linkSettings={{
                       viewURL: "/activityViewer",
-                      editURL: "/publicEditor",
+                      editURL: "/codeViewer",
                     }}
                     apiURLs={{ postMessages: true }}
                   />

--- a/client/src/Tools/_framework/Paths/CodeViewer.tsx
+++ b/client/src/Tools/_framework/Paths/CodeViewer.tsx
@@ -222,6 +222,7 @@ export function CodeViewer() {
                         colorScheme="blue"
                         icon={<MdOutlineInfo />}
                         aria-label="Activity information"
+                        data-test="Activity Information"
                         onClick={() => {
                           infoOnOpen();
                         }}

--- a/client/src/Tools/_framework/Paths/CodeViewer.tsx
+++ b/client/src/Tools/_framework/Paths/CodeViewer.tsx
@@ -9,7 +9,9 @@ import {
   Grid,
   GridItem,
   HStack,
+  IconButton,
   Text,
+  Tooltip,
   useDisclosure,
 } from "@chakra-ui/react";
 import { WarningIcon } from "@chakra-ui/icons";
@@ -18,6 +20,8 @@ import { CopyActivityAndReportFinish } from "../ToolPanels/CopyActivityAndReport
 import axios from "axios";
 import { User } from "./SiteHeader";
 import { ContentStructure, DoenetmlVersion } from "../../../_utils/types";
+import { ContentInfoDrawer } from "../ToolPanels/ContentInfoDrawer";
+import { MdOutlineInfo } from "react-icons/md";
 
 export async function loader({ params, request }) {
   const url = new URL(request.url);
@@ -58,7 +62,7 @@ export async function loader({ params, request }) {
   };
 }
 
-export function PublicEditor() {
+export function CodeViewer() {
   const { doenetML, doenetmlVersion, activityData } = useLoaderData() as {
     doenetML: string;
     doenetmlVersion?: DoenetmlVersion;
@@ -66,9 +70,15 @@ export function PublicEditor() {
   };
 
   const {
-    isOpen: copyActivityIsOpen,
-    onOpen: copyActivityOnOpen,
-    onClose: copyActivityOnClose,
+    isOpen: copyDialogIsOpen,
+    onOpen: copyDialogOnOpen,
+    onClose: copyDialogOnClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: infoIsOpen,
+    onOpen: infoOnOpen,
+    onClose: infoOnClose,
   } = useDisclosure();
 
   const user = useOutletContext<User>();
@@ -83,11 +93,19 @@ export function PublicEditor() {
   return (
     <>
       {activityData ? (
-        <CopyActivityAndReportFinish
-          isOpen={copyActivityIsOpen}
-          onClose={copyActivityOnClose}
-          activityData={activityData}
-        />
+        <>
+          <CopyActivityAndReportFinish
+            isOpen={copyDialogIsOpen}
+            onClose={copyDialogOnClose}
+            activityData={activityData}
+          />
+          <ContentInfoDrawer
+            isOpen={infoIsOpen}
+            onClose={infoOnClose}
+            id={activityData.id}
+            contentData={activityData}
+          />
+        </>
       ) : null}
       <Grid
         background="doenet.lightBlue"
@@ -178,7 +196,7 @@ export function PublicEditor() {
                         size="xs"
                         colorScheme="blue"
                         onClick={async () => {
-                          copyActivityOnOpen();
+                          copyDialogOnOpen();
                         }}
                       >
                         Copy to Activities
@@ -195,6 +213,20 @@ export function PublicEditor() {
                         Sign In To Copy to Activities
                       </Button>
                     )}
+                    <Tooltip
+                      label={`Activity information`}
+                      placement="bottom-end"
+                    >
+                      <IconButton
+                        size="xs"
+                        colorScheme="blue"
+                        icon={<MdOutlineInfo />}
+                        aria-label="Activity information"
+                        onClick={() => {
+                          infoOnOpen();
+                        }}
+                      />
+                    </Tooltip>
                   </>
                 )}
               </HStack>
@@ -210,6 +242,8 @@ export function PublicEditor() {
             readOnly={activityData !== undefined}
             doenetmlVersion={doenetmlVersion?.fullVersion}
             border="none"
+            showFormatter={false}
+            showErrorsWarnings={false}
           />
         </GridItem>
       </Grid>

--- a/client/src/Tools/_framework/Paths/Community.tsx
+++ b/client/src/Tools/_framework/Paths/Community.tsx
@@ -41,6 +41,7 @@ import AuthorCard from "../../../Widgets/AuthorCard";
 import { createFullName } from "../../../_utils/names";
 import ActivityTable from "../../../Widgets/ActivityTable";
 import { ContentStructure } from "../../../_utils/types";
+import { ContentInfoDrawer } from "../ToolPanels/ContentInfoDrawer";
 
 type SearchMatch =
   | (ContentStructure & { type: "content" })
@@ -425,6 +426,14 @@ export function Community() {
     document.title = `Community - Doenet`;
   }, []);
 
+  const [infoContentId, setInfoContentId] = useState<string | null>(null);
+
+  const {
+    isOpen: infoIsOpen,
+    onOpen: infoOnOpen,
+    onClose: infoOnClose,
+  } = useDisclosure();
+
   if (searchResults) {
     let contentMatches: SearchMatch[] = searchResults.content.map((c) => ({
       type: "content",
@@ -533,19 +542,35 @@ export function Community() {
                   ? `/sharedActivities/${owner.userId}/${id}`
                   : `/activityViewer/${id}`;
 
-              return {
-                id,
-                title: name,
-                ownerName: owner != undefined ? createFullName(owner) : "",
-                cardLink,
-                menuItems: isAdmin ? (
+              let menuItems = (
+                <MenuItem
+                  onClick={() => {
+                    setInfoContentId(id);
+                    infoOnOpen();
+                  }}
+                >
+                  Activity information
+                </MenuItem>
+              );
+
+              if (isAdmin) {
+                menuItems = (
                   <>
+                    {menuItems}
                     <MoveToGroupMenuItem
                       activityId={id}
                       carouselGroups={carouselGroups}
                     />
                   </>
-                ) : undefined,
+                );
+              }
+
+              return {
+                id,
+                title: name,
+                ownerName: owner != undefined ? createFullName(owner) : "",
+                cardLink,
+                menuItems,
               };
             } else if (itemObj?.type == "author") {
               const cardLink = `/sharedActivities/${itemObj.userId}`;
@@ -564,8 +589,31 @@ export function Community() {
       );
     }
 
+    let contentData: ContentStructure | undefined;
+    if (infoContentId) {
+      let index = searchResults.content.findIndex(
+        (obj) => obj.id == infoContentId,
+      );
+      if (index != -1) {
+        contentData = searchResults.content[index];
+      } else {
+        //Throw error not found
+      }
+    }
+
+    let infoDrawer =
+      contentData && infoContentId ? (
+        <ContentInfoDrawer
+          isOpen={infoIsOpen}
+          onClose={infoOnClose}
+          id={infoContentId}
+          contentData={contentData}
+        />
+      ) : null;
+
     return (
       <>
+        {infoDrawer}
         <Flex
           flexDirection="column"
           p={4}

--- a/client/src/Tools/_framework/Paths/Community.tsx
+++ b/client/src/Tools/_framework/Paths/Community.tsx
@@ -544,6 +544,7 @@ export function Community() {
 
               let menuItems = (
                 <MenuItem
+                  data-test="Activity Information"
                   onClick={() => {
                     setInfoContentId(id);
                     infoOnOpen();

--- a/client/src/Tools/_framework/Paths/Home.tsx
+++ b/client/src/Tools/_framework/Paths/Home.tsx
@@ -511,7 +511,7 @@ export function Home() {
                 addBottomPadding={false}
                 linkSettings={{
                   viewURL: "/activityViewer",
-                  editURL: "/publicEditor",
+                  editURL: "/codeViewer",
                 }}
               />
             </Flex>

--- a/client/src/Tools/_framework/ToolPanels/AssignmentPreview.tsx
+++ b/client/src/Tools/_framework/ToolPanels/AssignmentPreview.tsx
@@ -53,7 +53,7 @@ export default function AssignmentPreview({
           navigate={navigate}
           linkSettings={{
             viewURL: "/activityViewer",
-            editURL: "/publicEditor",
+            editURL: "/codeViewer",
           }}
           showAnswerTitles={true}
         />

--- a/client/src/Tools/_framework/ToolPanels/ClassificationInfo.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ClassificationInfo.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import {
+  Text,
+  Flex,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  HStack,
+} from "@chakra-ui/react";
+import { ContentClassification, ContentStructure } from "../../../_utils/types";
+
+export function ClassificationInfo({
+  contentData,
+}: {
+  contentData: ContentStructure;
+}) {
+  return (
+    <>
+      {!contentData.isFolder ? (
+        <Flex
+          flexDirection="column"
+          width="100%"
+          rowGap={6}
+          height="100%"
+          overflowY="auto"
+        >
+          <Text>Classifications</Text>
+
+          {contentData.classifications.length === 0 ? (
+            <Text as="i" mt="-5" ml="3">
+              None added yet.
+            </Text>
+          ) : (
+            <Accordion allowMultiple>
+              {contentData.classifications.map((classification, i) => {
+                const {
+                  code,
+                  systemName,
+                  categoryLabel,
+                  category,
+                  subCategoryLabel,
+                  subCategory,
+                  description,
+                  descriptionLabel,
+                } = extraClassificationData(classification);
+                return (
+                  <AccordionItem key={`classification${i}`}>
+                    <HStack>
+                      <h2>
+                        <AccordionButton>
+                          <HStack flex="1" textAlign="left" direction={"row"}>
+                            <Text as="b" data-test={`Classification ${i + 1}`}>
+                              {code}
+                            </Text>
+                            <Text pt="2px">{systemName}</Text>
+                          </HStack>
+                          <AccordionIcon marginLeft="7px" />
+                        </AccordionButton>
+                      </h2>
+                    </HStack>
+                    <AccordionPanel>
+                      <Text>
+                        <Text as="i">{categoryLabel}: </Text>
+                        {category}
+                      </Text>
+                      <Text>
+                        <Text as="i">{subCategoryLabel}: </Text>
+                        {subCategory}
+                      </Text>
+                      <Text>
+                        <Text as="i">{descriptionLabel}: </Text>
+                        {description}
+                      </Text>
+                    </AccordionPanel>
+                  </AccordionItem>
+                );
+              })}
+            </Accordion>
+          )}
+        </Flex>
+      ) : null}
+    </>
+  );
+}
+
+function extraClassificationData(classification: ContentClassification) {
+  // For now, we don't have a classification that shares multiple system.
+  // If we add one that does, we need a better system than concatenating their names,
+  // but this concatenation will at least show that this combination occurred and a change is needed.
+  const systemName = classification.subCategories
+    .map((sc) => sc.category.system.name)
+    .reduce((acc: string[], c) => (acc.includes(c) ? acc : [...acc, c]), [])
+    .join(" / ");
+
+  const categories = classification.subCategories
+    .map((sc) => sc.category.category)
+    .reduce((acc: string[], c) => (acc.includes(c) ? acc : [...acc, c]), []);
+  let categoryLabel =
+    classification.subCategories[0].category.system.categoryLabel;
+  if (categories.length > 1) {
+    // for now, all our category labels are pluralized by adding an s...
+    categoryLabel += "s";
+  }
+  const category = categories.join(" / ");
+
+  const subCategories = classification.subCategories
+    .map((sc) => sc.subCategory)
+    .reduce((acc: string[], c) => (acc.includes(c) ? acc : [...acc, c]), []);
+  let subCategoryLabel =
+    classification.subCategories[0].category.system.subCategoryLabel;
+  if (subCategories.length > 1) {
+    // for now, all our sub-category labels are pluralized by adding an s...
+    subCategoryLabel += "s";
+  }
+  const subCategory = subCategories.join(" / ");
+
+  const descriptionLabel =
+    classification.subCategories[0].category.system.descriptionLabel;
+
+  return {
+    code: classification.code,
+    systemName,
+    categoryLabel,
+    category,
+    subCategoryLabel,
+    subCategory,
+    description: classification.description,
+    descriptionLabel,
+  };
+}

--- a/client/src/Tools/_framework/ToolPanels/ContentInfoDrawer.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ContentInfoDrawer.tsx
@@ -1,0 +1,198 @@
+import React, { RefObject, useEffect, useState } from "react";
+import {
+  Box,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import {
+  ContentStructure,
+  DocHistoryItem,
+  DocRemixItem,
+} from "../../../_utils/types";
+import { GeneralContentInfo } from "./GeneralContentInfo";
+import { ClassificationInfo } from "./ClassificationInfo";
+import axios from "axios";
+import {
+  processContributorHistory,
+  processRemixes,
+} from "../../../_utils/processRemixes";
+import { cidFromText } from "../../../_utils/cid";
+import { RemixedFrom } from "./RemixedFrom";
+import { Remixes } from "./Remixes";
+
+export function ContentInfoDrawer({
+  isOpen,
+  onClose,
+  finalFocusRef,
+  id,
+  contentData,
+  displayTab = "general",
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  finalFocusRef?: RefObject<HTMLElement>;
+  id: string;
+  contentData: ContentStructure;
+  displayTab?: "general" | "classifications";
+}) {
+  let initialTabIndex: number;
+  switch (displayTab) {
+    case "general": {
+      initialTabIndex = 0;
+      break;
+    }
+    case "classifications": {
+      initialTabIndex = 1;
+      break;
+    }
+  }
+
+  const [tabIndex, setTabIndex] = useState(initialTabIndex);
+
+  useEffect(() => {
+    setTabIndex(initialTabIndex);
+  }, [displayTab, isOpen]);
+
+  // TODO: this next section (through recalculateThisCid()) is copied almost verbatim from ShareDrawer.tsx
+  // Refactor to avoid code duplication
+
+  const [contributorHistory, setContributorHistory] = useState<
+    DocHistoryItem[] | null
+  >(null);
+  const [haveChangedHistoryItem, setHaveChangedHistoryItem] = useState(false);
+  const [remixes, setRemixes] = useState<DocRemixItem[] | null>(null);
+  const [thisCid, setThisCid] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function getHistoryAndRemixes() {
+      const { data } = await axios.get(
+        `/api/getContributorHistory/${contentData.id}`,
+      );
+
+      const hist = await processContributorHistory(data.docHistories[0]);
+      setContributorHistory(hist);
+
+      let haveChanged = hist.some((dhi) => dhi.prevChanged);
+
+      setHaveChangedHistoryItem(haveChanged);
+
+      const { data: data2 } = await axios.get(
+        `/api/getRemixes/${contentData.id}`,
+      );
+
+      const doc0Remixes = processRemixes(data2.docRemixes[0]);
+      setRemixes(doc0Remixes);
+    }
+
+    if (!contentData.isFolder) {
+      getHistoryAndRemixes();
+    }
+  }, [contentData]);
+
+  useEffect(() => {
+    async function recalculateThisCid() {
+      let cid: string | null = null;
+      if (haveChangedHistoryItem) {
+        let thisSource = contentData.documents[0].source;
+
+        if (thisSource === undefined) {
+          const { data: sourceData } = await axios.get(
+            `/api/getDocumentSource/${contentData.documents[0].id}`,
+          );
+
+          thisSource = sourceData.source as string;
+        }
+        cid = await cidFromText(thisSource);
+      }
+
+      setThisCid(cid);
+    }
+
+    recalculateThisCid();
+  }, [haveChangedHistoryItem]);
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={onClose}
+      finalFocusRef={finalFocusRef}
+      size="lg"
+    >
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerCloseButton data-test="Close Settings Button" />
+        <DrawerHeader textAlign="center" height="70px">
+          {contentData.isFolder ? "Folder" : "Activity"} Information
+          <Tooltip label={contentData.name}>
+            <Text fontSize="smaller" noOfLines={1}>
+              {contentData.name}
+            </Text>
+          </Tooltip>
+        </DrawerHeader>
+
+        <DrawerBody>
+          <Tabs index={tabIndex} onChange={(index) => setTabIndex(index)}>
+            <TabList>
+              <Tab data-test="General Tab">General</Tab>
+
+              {!contentData.isFolder ? (
+                <>
+                  <Tab data-test="Classifications">
+                    Classifications ({contentData.classifications.length})
+                  </Tab>
+                  <Tab data-test="Remixed From Tab">
+                    Remixed From{" "}
+                    {contributorHistory !== null
+                      ? `(${contributorHistory.length})`
+                      : null}
+                    {haveChangedHistoryItem ? "*" : null}
+                  </Tab>
+                  <Tab data-test="Remixes Tab">
+                    Remixes {remixes !== null ? `(${remixes.length})` : null}
+                  </Tab>
+                </>
+              ) : null}
+            </TabList>
+            <Box height="calc(100vh - 130px)">
+              <TabPanels height="100%">
+                <TabPanel height="100%">
+                  <GeneralContentInfo contentData={contentData} />
+                </TabPanel>
+                {!contentData.isFolder ? (
+                  <TabPanel overflowY="hidden" height="100%">
+                    <ClassificationInfo contentData={contentData} />
+                  </TabPanel>
+                ) : null}
+                {!contentData.isFolder ? (
+                  <TabPanel>
+                    <RemixedFrom
+                      contributorHistory={contributorHistory}
+                      thisCid={thisCid}
+                    />
+                  </TabPanel>
+                ) : null}
+                {!contentData.isFolder ? (
+                  <TabPanel>
+                    <Remixes remixes={remixes} />
+                  </TabPanel>
+                ) : null}
+              </TabPanels>
+            </Box>
+          </Tabs>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/client/src/Tools/_framework/ToolPanels/ContributorsMenu.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ContributorsMenu.tsx
@@ -59,7 +59,7 @@ export default function ContributorsMenu({
             to={`/activityViewer/${contributorHistory[0].prevActivityId}`}
             aria-label={`Go to ${contributorHistory[0].prevActivityName}`}
           >
-            {contributorHistory[0].prevActivityName} by
+            {contributorHistory[0].prevActivityName} by{" "}
             {createFullName(contributorHistory[0].prevOwner)}
           </ChakraLink>
         </Tooltip>

--- a/client/src/Tools/_framework/ToolPanels/GeneralContentInfo.tsx
+++ b/client/src/Tools/_framework/ToolPanels/GeneralContentInfo.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Box, List } from "@chakra-ui/react";
+import { ContentStructure } from "../../../_utils/types";
+import { InfoIcon } from "@chakra-ui/icons";
+import { DisplayLicenseItem } from "../../../Widgets/Licenses";
+import { createFullName } from "../../../_utils/names";
+
+export function GeneralContentInfo({
+  contentData,
+}: {
+  contentData: ContentStructure;
+}) {
+  let license = contentData.license;
+  let contentType = contentData.isFolder ? "Folder" : "Activity";
+
+  return (
+    <Box>
+      <Box borderBottom="2px" marginBottom={4} paddingBottom={4}>
+        {license === null ? (
+          <Box
+            marginTop="10px"
+            border="2px solid black"
+            background="orange.100"
+            padding="5px"
+          >
+            <InfoIcon color="orange.500" mr="2px" /> {contentType} is shared
+            without specifying a license. Please select a license below to
+            inform other how they can use your content.
+          </Box>
+        ) : license.isComposition ? (
+          <>
+            <p>
+              <em>{contentData.name}</em> by{" "}
+              {createFullName(contentData.owner!)} is shared with these
+              licenses:
+            </p>
+            <List spacing="20px" marginTop="10px">
+              {license.composedOf.map((comp) => (
+                <DisplayLicenseItem licenseItem={comp} key={comp.code} />
+              ))}
+            </List>
+            <p style={{ marginTop: "10px" }}>
+              (You are free to use either of these licenses when reusing this
+              work.)
+            </p>
+          </>
+        ) : (
+          <>
+            <p>
+              <em>{contentData.name}</em> by{" "}
+              {createFullName(contentData.owner!)} is shared with the license:
+            </p>
+            <List marginTop="10px">
+              <DisplayLicenseItem licenseItem={license} />
+            </List>
+          </>
+        )}
+      </Box>
+
+      {!contentData.isFolder
+        ? `DoenetML version: ${contentData.documents[0].doenetmlVersion.fullVersion}`
+        : null}
+    </Box>
+  );
+}

--- a/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
+++ b/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Flex,
   Hide,
+  Link as ChakraLink,
   Show,
   Spinner,
   Table,
@@ -13,7 +14,9 @@ import {
   Thead,
   Tr,
   VStack,
+  Box,
 } from "@chakra-ui/react";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { createFullName } from "../../../_utils/names";
 import { DateTime } from "luxon";
 import { DocHistoryItem } from "../../../_utils/types";
@@ -53,20 +56,20 @@ export function RemixedFrom({
         <Thead position="sticky" top={0} backgroundColor="var(--canvas)">
           <Tr>
             <Show above="sm">
-              <Th textTransform="none">Activity Name</Th>
+              <Th textTransform="none">Remixed Activity</Th>
               <Th textTransform="none">Owner</Th>
             </Show>
             <Hide above="sm">
-              <Th>
+              <Th textTransform="none">
                 <VStack alignItems="left">
-                  <Text>Activity Name</Text>
+                  <Text>Remixed Activity</Text>
                   <Text>Owner</Text>
                 </VStack>
               </Th>
             </Hide>
             <Th textTransform="none">License</Th>
             <Show above="sm">
-              <Th>Date copied</Th>
+              <Th textTransform="none">Date copied</Th>
             </Show>
           </Tr>
         </Thead>
@@ -75,29 +78,56 @@ export function RemixedFrom({
             let changeText = "";
             if (ch.prevChanged) {
               // The previous doc changed since it was remixed.
-              // Check if this activity's doc change since then
-              let thisActivityDocChanged = thisCid !== ch.prevCid;
-              if (thisActivityDocChanged) {
-                changeText =
-                  "The original doc changed and so did this one, so would have to merge changes";
-              } else {
-                changeText =
-                  "The original doc changed but this one did not, so could just copy over changes.";
-              }
+              changeText = "*Changed since copied";
+              // // Check if this activity's doc change since then
+              // let thisActivityDocChanged = thisCid !== ch.prevCid;
+              // if (thisActivityDocChanged) {
+              //   changeText =
+              //     "The original doc changed and so did this one, so would have to merge changes";
+              // } else {
+              //   changeText =
+              //     "The original doc changed but this one did not, so could just copy over changes.";
+              // }
             } else {
-              changeText = "The original doc is unchanged";
+              changeText = "";
             }
             return (
               <Tr key={`ch${i}`}>
                 <Show above="sm">
-                  <Td>{ch.prevActivityName}</Td>
-                  <Td>{createFullName(ch.prevOwner)}</Td>
+                  <Td>
+                    <ChakraLink
+                      as={ReactRouterLink}
+                      to={`/activityViewer/${ch.prevActivityId}`}
+                    >
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {ch.prevActivityName}
+                      </Text>
+                    </ChakraLink>
+                  </Td>
+                  <Td>
+                    <ChakraLink
+                      as={ReactRouterLink}
+                      to={`/sharedActivities/${ch.prevOwner.userId}`}
+                    >
+                      <Text
+                        wordBreak="break-word"
+                        whiteSpace="normal"
+                        minWidth="50px"
+                      >
+                        {createFullName(ch.prevOwner)}
+                      </Text>
+                    </ChakraLink>
+                  </Td>
                 </Show>
                 <Hide above="sm">
                   <Td>
                     <VStack alignItems="left">
-                      <Text>{ch.prevActivityName}</Text>
-                      <Text>{createFullName(ch.prevOwner)}</Text>
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {ch.prevActivityName}
+                      </Text>
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {createFullName(ch.prevOwner)}
+                      </Text>
                     </VStack>
                   </Td>
                 </Hide>
@@ -108,10 +138,9 @@ export function RemixedFrom({
                     {ch.timestampPrevDoc.toLocaleString(DateTime.DATE_MED)}
                   </Td>
                 </Show>
-                <Td width="100px">
+                <Td>
                   <Text
                     width="100px"
-                    flexWrap="wrap"
                     wordBreak="break-word"
                     whiteSpace="normal"
                   >

--- a/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
+++ b/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
@@ -41,7 +41,9 @@ export function RemixedFrom({
   }
 
   if (contributorHistory.length === 0) {
-    return <Text>Not remixed from other activities</Text>;
+    return (
+      <Text data-test="Not Remixed">Not remixed from other activities</Text>
+    );
   }
 
   let historyTable = (
@@ -92,7 +94,7 @@ export function RemixedFrom({
               changeText = "";
             }
             return (
-              <Tr key={`ch${i}`}>
+              <Tr key={`ch${i}`} data-test={`Remixed from ${i + 1}`}>
                 <Show above="sm">
                   <Td>
                     <ChakraLink

--- a/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
+++ b/client/src/Tools/_framework/ToolPanels/RemixedFrom.tsx
@@ -81,15 +81,10 @@ export function RemixedFrom({
             if (ch.prevChanged) {
               // The previous doc changed since it was remixed.
               changeText = "*Changed since copied";
-              // // Check if this activity's doc change since then
-              // let thisActivityDocChanged = thisCid !== ch.prevCid;
-              // if (thisActivityDocChanged) {
-              //   changeText =
-              //     "The original doc changed and so did this one, so would have to merge changes";
-              // } else {
-              //   changeText =
-              //     "The original doc changed but this one did not, so could just copy over changes.";
-              // }
+
+              // TODO: do we want want to prompt to copy over changes if this activity's doc
+              // has not changed since remixing?
+              // I.e., if thisCid === ch.prevCid;
             } else {
               changeText = "";
             }

--- a/client/src/Tools/_framework/ToolPanels/Remixes.tsx
+++ b/client/src/Tools/_framework/ToolPanels/Remixes.tsx
@@ -34,7 +34,11 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
   }
 
   if (remixes.length === 0) {
-    return <Text>No visible remixes of this activity (yet!)</Text>;
+    return (
+      <Text data-test="No Remixes">
+        No visible remixes of this activity (yet!)
+      </Text>
+    );
   }
 
   let remixTable = (
@@ -69,7 +73,7 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
         <Tbody>
           {remixes.map((ch, i) => {
             return (
-              <Tr key={`ch${i}`}>
+              <Tr key={`ch${i}`} data-test={`Remix ${i + 1}`}>
                 <Show above="sm">
                   <Td>
                     <ChakraLink

--- a/client/src/Tools/_framework/ToolPanels/Remixes.tsx
+++ b/client/src/Tools/_framework/ToolPanels/Remixes.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Flex,
   Hide,
+  Link as ChakraLink,
   Show,
   Spinner,
   Table,
@@ -14,6 +15,7 @@ import {
   Tr,
   VStack,
 } from "@chakra-ui/react";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { createFullName } from "../../../_utils/names";
 import { DateTime } from "luxon";
 import { DocRemixItem } from "../../../_utils/types";
@@ -32,7 +34,7 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
   }
 
   if (remixes.length === 0) {
-    return <Text>No remixes of this activity (yet!)</Text>;
+    return <Text>No visible remixes of this activity (yet!)</Text>;
   }
 
   let remixTable = (
@@ -51,7 +53,7 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
               <Th textTransform="none">Owner</Th>
             </Show>
             <Hide above="sm">
-              <Th>
+              <Th textTransform="none">
                 <VStack alignItems="left">
                   <Text>Activity Name</Text>
                   <Text>Owner</Text>
@@ -60,7 +62,7 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
             </Hide>
             <Th textTransform="none">License</Th>
             <Show above="sm">
-              <Th>Date copied</Th>
+              <Th textTransform="none">Date copied</Th>
             </Show>
           </Tr>
         </Thead>
@@ -69,14 +71,40 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
             return (
               <Tr key={`ch${i}`}>
                 <Show above="sm">
-                  <Td>{ch.activityName}</Td>
-                  <Td>{createFullName(ch.owner)}</Td>
+                  <Td>
+                    <ChakraLink
+                      as={ReactRouterLink}
+                      to={`/activityViewer/${ch.activityId}`}
+                    >
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {ch.activityName}
+                      </Text>
+                    </ChakraLink>
+                  </Td>
+                  <Td>
+                    <ChakraLink
+                      as={ReactRouterLink}
+                      to={`/sharedActivities/${ch.owner.userId}`}
+                    >
+                      <Text
+                        wordBreak="break-word"
+                        whiteSpace="normal"
+                        minWidth="50px"
+                      >
+                        {createFullName(ch.owner)}
+                      </Text>
+                    </ChakraLink>
+                  </Td>
                 </Show>
                 <Hide above="sm">
                   <Td>
                     <VStack alignItems="left">
-                      <Text>{ch.activityName}</Text>
-                      <Text>{createFullName(ch.owner)}</Text>
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {ch.activityName}
+                      </Text>
+                      <Text wordBreak="break-word" whiteSpace="normal">
+                        {createFullName(ch.owner)}
+                      </Text>
                     </VStack>
                   </Td>
                 </Hide>
@@ -86,7 +114,7 @@ export function Remixes({ remixes }: { remixes: DocRemixItem[] | null }) {
                   <Td>
                     {ch.timestampPrevDoc.toLocaleString(DateTime.DATE_MED)}
                   </Td>
-                  <Td>{ch.isDirect.toString()}</Td>
+                  <Td>{ch.isDirect ? "direct copy" : ""}</Td>
                 </Show>
               </Tr>
             );

--- a/client/src/Tools/_framework/ToolPanels/ShareDrawer.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ShareDrawer.tsx
@@ -24,6 +24,7 @@ import {
   DocHistoryItem,
   DocRemixItem,
   License,
+  LicenseCode,
 } from "../../../_utils/types";
 import axios from "axios";
 import { cidFromText } from "../../../_utils/cid";
@@ -69,6 +70,8 @@ export function ShareDrawer({
   const [haveChangedHistoryItem, setHaveChangedHistoryItem] = useState(false);
   const [remixes, setRemixes] = useState<DocRemixItem[] | null>(null);
   const [thisCid, setThisCid] = useState<string | null>(null);
+  const [remixedWithLicense, setRemixedWithLicense] =
+    useState<LicenseCode | null>(null);
 
   useEffect(() => {
     async function getHistoryAndRemixes() {
@@ -83,6 +86,8 @@ export function ShareDrawer({
 
       setHaveChangedHistoryItem(haveChanged);
 
+      setRemixedWithLicense(hist[0].withLicenseCode || null);
+
       const { data: data2 } = await axios.get(
         `/api/getRemixes/${contentData.id}`,
       );
@@ -95,12 +100,6 @@ export function ShareDrawer({
       getHistoryAndRemixes();
     }
   }, [contentData]);
-
-  useEffect(() => {
-    async function getRemixes() {}
-
-    getRemixes();
-  }, [contentData.id]);
 
   useEffect(() => {
     async function recalculateThisCid() {
@@ -171,6 +170,7 @@ export function ShareDrawer({
                     fetcher={fetcher}
                     contentData={contentData}
                     allLicenses={allLicenses}
+                    remixedWithLicense={remixedWithLicense}
                   />
                 </TabPanel>
                 {!contentData.isFolder ? (

--- a/client/src/Tools/_framework/ToolPanels/ShareDrawer.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ShareDrawer.tsx
@@ -86,7 +86,7 @@ export function ShareDrawer({
 
       setHaveChangedHistoryItem(haveChanged);
 
-      setRemixedWithLicense(hist[0].withLicenseCode || null);
+      setRemixedWithLicense(hist[0]?.withLicenseCode || null);
 
       const { data: data2 } = await axios.get(
         `/api/getRemixes/${contentData.id}`,

--- a/client/src/Tools/_framework/ToolPanels/ShareSettings.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ShareSettings.tsx
@@ -249,7 +249,7 @@ export function ShareSettings({
       (l) => l.code === remixedWithLicense,
     )?.name;
     chooseLicenseForm = (
-      <Box marginTop="20px">
+      <Box marginTop="20px" data-test="Cannot Change License">
         <p>License: {licenseName} </p>
         <p>
           (Cannot change license since remixed from activity with this license.)
@@ -265,6 +265,7 @@ export function ShareSettings({
         <HStack gap={5}>
           <Select
             width="90%"
+            data-test="Select License"
             placeholder={placeholder}
             value={selectedLicenseCode}
             onChange={(e) => {
@@ -546,7 +547,7 @@ export function ShareSettings({
           method="post"
           onSubmit={() => {
             setShowSpinner({ type: "emailShare" });
-            nextStatusText.current = `Successfully shared with ${shareWithEmail}`;
+            nextStatusText.current = `Successfully shared with ${shareWithEmail}.`;
           }}
         >
           <FormControl isInvalid={errorMessage !== ""} marginTop="20px">
@@ -608,7 +609,7 @@ export function ShareSettings({
                     );
                     setSelectedIsPublic(false);
                   } else {
-                    nextStatusText.current = "Successfully shared publicly";
+                    nextStatusText.current = "Successfully shared publicly.";
                     fetcher.submit(
                       {
                         _action: "make content public",

--- a/client/src/Tools/_framework/ToolPanels/ShareSettings.tsx
+++ b/client/src/Tools/_framework/ToolPanels/ShareSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import {
   FetcherWithComponents,
   Form,
@@ -31,7 +31,7 @@ import {
   Hide,
   Button,
 } from "@chakra-ui/react";
-import { InfoIcon } from "@chakra-ui/icons";
+import { InfoIcon, WarningIcon } from "@chakra-ui/icons";
 import axios from "axios";
 import { createFullName } from "../../../_utils/names";
 import { ContentStructure, License, LicenseCode } from "../../../_utils/types";
@@ -128,10 +128,12 @@ export function ShareSettings({
   fetcher,
   contentData,
   allLicenses,
+  remixedWithLicense,
 }: {
   fetcher: FetcherWithComponents<any>;
   contentData: ContentStructure;
   allLicenses: License[];
+  remixedWithLicense: LicenseCode | null;
 }) {
   let license = contentData.license;
 
@@ -201,6 +203,101 @@ export function ShareSettings({
     setShowSpinner(null);
     setStatusText(nextStatusText.current);
   }, [contentData]);
+
+  let licenseDeterminedFromRemix =
+    selectedLicenseCode === remixedWithLicense &&
+    remixedWithLicense !== "CCDUAL";
+
+  let licenseNotMatchRemix =
+    remixedWithLicense !== null &&
+    remixedWithLicense !== "CCDUAL" &&
+    selectedLicenseCode !== remixedWithLicense;
+
+  let licenseWarning: ReactElement | null = null;
+  if (licenseNotMatchRemix) {
+    let remixedWithLicenseName = allLicenses.find(
+      (l) => l.code === remixedWithLicense,
+    )?.name;
+
+    let selectedLicenseName = allLicenses.find(
+      (l) => l.code === selectedLicenseCode,
+    )?.name;
+
+    licenseWarning = (
+      <Box background="orange.100" marginTop="20px">
+        <WarningIcon color="orange.500" mr="6px" />
+        Selected license {selectedLicenseName} is not compatible with the
+        license that this activity was remixed from: {remixedWithLicenseName}.{" "}
+        <Link
+          to="https://creativecommons.org/share-your-work/licensing-considerations/compatible-licenses/"
+          target="_blank"
+        >
+          (More information)
+        </Link>
+      </Box>
+    );
+  }
+
+  <Text size="xs" pl="4px" pr="4px">
+    Your code is not being saved in this view. Copy to one of your activities to
+    save changes.
+  </Text>;
+
+  let chooseLicenseForm: ReactElement | null = null;
+  if (licenseDeterminedFromRemix) {
+    let licenseName = allLicenses.find(
+      (l) => l.code === remixedWithLicense,
+    )?.name;
+    chooseLicenseForm = (
+      <Box marginTop="20px">
+        <p>License: {licenseName} </p>
+        <p>
+          (Cannot change license since remixed from activity with this license.)
+        </p>
+      </Box>
+    );
+  } else if (
+    !(contentData.parentFolder?.isPublic || contentData.parentFolder?.isShared)
+  ) {
+    chooseLicenseForm = (
+      <FormControl isInvalid={missingLicense}>
+        <FormLabel mt="20px">Change license</FormLabel>
+        <HStack gap={5}>
+          <Select
+            width="90%"
+            placeholder={placeholder}
+            value={selectedLicenseCode}
+            onChange={(e) => {
+              setShowSpinner({ type: "license" });
+              setStatusText("");
+              nextStatusText.current = "Successfully changed license.";
+              let newLicenseCode = e.target.value as LicenseCode;
+              setSelectedLicenseCode(newLicenseCode);
+              fetcher.submit(
+                {
+                  _action: "set license",
+                  id: contentData.id,
+                  licenseCode: newLicenseCode,
+                  isFolder: Boolean(contentData.isFolder),
+                },
+                { method: "post" },
+              );
+            }}
+          >
+            {allLicenses.map((license) => (
+              <option value={license.code} key={license.code}>
+                {license.name}
+              </option>
+            ))}
+          </Select>
+          <Spinner hidden={showSpinner?.type !== "license"} />
+        </HStack>
+        <FormErrorMessage>
+          A license is required to make public.
+        </FormErrorMessage>
+      </FormControl>
+    );
+  }
 
   return (
     <>
@@ -535,45 +632,8 @@ export function ShareSettings({
           </>
         )}
 
-        {contentData.parentFolder?.isPublic ||
-        contentData.parentFolder?.isShared ? null : (
-          <FormControl isInvalid={missingLicense}>
-            <FormLabel mt="20px">Change license</FormLabel>
-            <HStack gap={5}>
-              <Select
-                width="90%"
-                placeholder={placeholder}
-                value={selectedLicenseCode}
-                onChange={(e) => {
-                  setShowSpinner({ type: "license" });
-                  setStatusText("");
-                  nextStatusText.current = "Successfully changed license.";
-                  let newLicenseCode = e.target.value as LicenseCode;
-                  setSelectedLicenseCode(newLicenseCode);
-                  fetcher.submit(
-                    {
-                      _action: "set license",
-                      id: contentData.id,
-                      licenseCode: newLicenseCode,
-                      isFolder: Boolean(contentData.isFolder),
-                    },
-                    { method: "post" },
-                  );
-                }}
-              >
-                {allLicenses.map((license) => (
-                  <option value={license.code} key={license.code}>
-                    {license.name}
-                  </option>
-                ))}
-              </Select>
-              <Spinner hidden={showSpinner?.type !== "license"} />
-            </HStack>
-            <FormErrorMessage>
-              A license is required to make public.
-            </FormErrorMessage>
-          </FormControl>
-        )}
+        {chooseLicenseForm}
+        {licenseWarning}
       </Box>
     </>
   );

--- a/client/src/Widgets/Licenses.tsx
+++ b/client/src/Widgets/Licenses.tsx
@@ -3,7 +3,6 @@ import { License } from "../_utils/types";
 import {
   HStack,
   Image,
-  ListIcon,
   ListItem,
   Text,
   Tooltip,
@@ -104,10 +103,7 @@ export function DisplayLicenseItem({
 
   return (
     <ListItem>
-      <HStack>
-        <ListIcon as={MdCircle} margin="0px" />
-        {item}
-      </HStack>
+      <HStack>{item}</HStack>
     </ListItem>
   );
 }

--- a/client/src/_utils/processRemixes.ts
+++ b/client/src/_utils/processRemixes.ts
@@ -28,19 +28,21 @@ export async function processContributorHistory(hist: {
   return historyItems;
 }
 
-export function processRemixes(remixes: {
-  documentVersions: { contributorHistory: any[] }[];
+export function processRemixes(docRemixes: {
+  documentVersions: { versionNumber: number; remixes: any[] }[];
+  id: string;
 }): DocRemixItem[] {
-  let items = remixes.documentVersions
+  let items = docRemixes.documentVersions
     .flatMap((dv) =>
-      dv.contributorHistory.map((ch) => {
-        const { document, ...item } = ch;
-        const activity = document.activity;
+      dv.remixes.map((remix) => {
+        const activity = remix.activity;
         const remixItem: DocRemixItem = {
-          ...item,
-          isDirect: ch.timestampDoc === ch.timestampPrevDoc,
-          timestampDoc: DateTime.fromISO(ch.timestampDoc),
-          timestampPrevDoc: DateTime.fromISO(ch.timestampPrevDoc),
+          ...remix,
+          prevDocId: docRemixes.id,
+          prevDocVersionNum: dv.versionNumber,
+          isDirect: remix.timestampDoc === remix.timestampPrevDoc,
+          timestampDoc: DateTime.fromISO(remix.timestampDoc),
+          timestampPrevDoc: DateTime.fromISO(remix.timestampPrevDoc),
           activityId: activity.id,
           activityName: activity.name,
           owner: activity.owner,

--- a/client/src/_utils/types.ts
+++ b/client/src/_utils/types.ts
@@ -52,6 +52,7 @@ export type ContentClassification = {
       system: {
         id: number;
         name: string;
+        shortName: string;
         categoryLabel: string;
         subCategoryLabel: string;
         descriptionLabel: string;
@@ -96,7 +97,7 @@ export type DocHistoryItem = {
   docId: string;
   prevDocId: string;
   prevDocVersionNum: number;
-  withLicenseCode: string | null;
+  withLicenseCode: LicenseCode | null;
   timestampDoc: DateTime;
   timestampPrevDoc: DateTime;
   prevActivityId: string;
@@ -110,7 +111,7 @@ export type DocRemixItem = {
   docId: string;
   prevDocId: string;
   prevDocVersionNum: number;
-  withLicenseCode: string | null;
+  withLicenseCode: LicenseCode | null;
   isDirect: boolean;
   timestampDoc: DateTime;
   timestampPrevDoc: DateTime;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -98,9 +98,9 @@ import {
   action as activityEditorAction,
 } from "./Tools/_framework/Paths/ActivityEditor";
 import {
-  PublicEditor,
-  loader as publicEditorLoader,
-} from "./Tools/_framework/Paths/PublicEditor";
+  CodeViewer,
+  loader as codeViewerLoader,
+} from "./Tools/_framework/Paths/CodeViewer";
 import { mathjaxConfig } from "@doenet/doenetml-iframe";
 import {
   SignIn,
@@ -277,22 +277,22 @@ const router = createBrowserRouter([
         errorElement: <ErrorPage />,
       },
       {
-        path: "publicEditor",
-        loader: publicEditorLoader,
+        path: "codeViewer",
+        loader: codeViewerLoader,
         errorElement: <ErrorPage />,
-        element: <PublicEditor />,
+        element: <CodeViewer />,
       },
       {
-        path: "publicEditor/:activityId",
-        loader: publicEditorLoader,
+        path: "codeViewer/:activityId",
+        loader: codeViewerLoader,
         errorElement: <ErrorPage />,
-        element: <PublicEditor />,
+        element: <CodeViewer />,
       },
       {
-        path: "publicEditor/:activityId/:docId",
-        loader: publicEditorLoader,
+        path: "codeViewer/:activityId/:docId",
+        loader: codeViewerLoader,
         errorElement: <ErrorPage />,
-        element: <PublicEditor />,
+        element: <CodeViewer />,
       },
       {
         path: "assigned",

--- a/server/prisma/migrations/20241219013935_classification_system_short_name/migration.sql
+++ b/server/prisma/migrations/20241219013935_classification_system_short_name/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[shortName]` on the table `classificationSystems` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `shortName` to the `classificationSystems` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `classificationSystems` ADD COLUMN `shortName` VARCHAR(191) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `classificationSystems_shortName_key` ON `classificationSystems`(`shortName`);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -247,6 +247,7 @@ model contentClassifications {
 model classificationSystems {
   id                     Int                        @id @default(autoincrement())
   name                   String                     @unique
+  shortName              String                     @unique
   categoryLabel          String
   subCategoryLabel       String
   descriptionLabel       String

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -87,6 +87,7 @@ async function main() {
   // Classifications
   async function upsertClassificationSystem(
     name: string,
+    shortName: string,
     categoryLabel: string,
     subCategoryLabel: string,
     descriptionLabel: string,
@@ -96,6 +97,7 @@ async function main() {
       where: { name },
       update: {
         name,
+        shortName,
         categoryLabel,
         subCategoryLabel,
         descriptionLabel,
@@ -103,6 +105,7 @@ async function main() {
       },
       create: {
         name,
+        shortName,
         categoryLabel,
         subCategoryLabel,
         descriptionLabel,
@@ -188,6 +191,7 @@ async function main() {
 
   async function addClassificationFromData({
     name,
+    shortName,
     categoryLabel,
     subCategoryLabel,
     descriptionLabel,
@@ -195,6 +199,7 @@ async function main() {
     sortIndex,
   }: {
     name: string;
+    shortName: string;
     categoryLabel: string;
     subCategoryLabel: string;
     descriptionLabel: string;
@@ -203,6 +208,7 @@ async function main() {
   }) {
     const systemId = await upsertClassificationSystem(
       name,
+      shortName,
       categoryLabel,
       subCategoryLabel,
       descriptionLabel,
@@ -315,6 +321,7 @@ async function main() {
 
   await addClassificationFromData({
     name: "Common Core",
+    shortName: "Common Core",
     categoryLabel: "Grade",
     subCategoryLabel: "Cluster",
     descriptionLabel: "Standard",
@@ -324,6 +331,7 @@ async function main() {
 
   await addClassificationFromData({
     name: "Minnesota Academic Standards in Math",
+    shortName: "MN Math",
     categoryLabel: "Grade",
     subCategoryLabel: "Standard",
     descriptionLabel: "Benchmark",
@@ -333,6 +341,7 @@ async function main() {
 
   await addClassificationFromData({
     name: "WeBWorK taxonomy",
+    shortName: "WeBWorK",
     categoryLabel: "Subject",
     subCategoryLabel: "Chapter",
     descriptionLabel: "Section",
@@ -343,7 +352,7 @@ async function main() {
   await prisma.licenses.upsert({
     where: { code: "CCBYSA" },
     update: {
-      name: "Creative Commons Attribution-ShareAlike",
+      name: "Creative Commons Attribution-ShareAlike 4.0",
       description:
         "This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes. If others remix, adapt, or build upon the material, they must license the modified material under identical terms.",
       imageURL: "/creative_commons_by_sa.png",
@@ -353,7 +362,7 @@ async function main() {
     },
     create: {
       code: "CCBYSA",
-      name: "Creative Commons Attribution-ShareAlike",
+      name: "Creative Commons Attribution-ShareAlike 4.0",
       description:
         "This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes. If others remix, adapt, or build upon the material, they must license the modified material under identical terms.",
       imageURL: "/creative_commons_by_sa.png",
@@ -366,7 +375,7 @@ async function main() {
   await prisma.licenses.upsert({
     where: { code: "CCBYNCSA" },
     update: {
-      name: "Creative Commons Attribution-NonCommercial-ShareAlike",
+      name: "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
       description:
         "This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, for noncommercial purposes only. If others modify or adapt the material, they must license the modified material under identical terms.",
       imageURL: "/creative_commons_by_nc_sa.png",
@@ -376,7 +385,7 @@ async function main() {
     },
     create: {
       code: "CCBYNCSA",
-      name: "Creative Commons Attribution-NonCommercial-ShareAlike",
+      name: "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
       description:
         "This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, for noncommercial purposes only. If others modify or adapt the material, they must license the modified material under identical terms.",
       imageURL: "/creative_commons_by_nc_sa.png",
@@ -389,16 +398,16 @@ async function main() {
   await prisma.licenses.upsert({
     where: { code: "CCDUAL" },
     update: {
-      name: "Dual license Creative Commons Attribution-ShareAlike OR Attribution-NonCommercial-ShareAlike",
+      name: "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
       description:
-        "Allow reusers to use either the Creative Commons Attribution-ShareAlike license or the Creative Commons Attribution-NonCommercial-ShareAlike license.",
+        "Allow reusers to use either the Creative Commons Attribution-ShareAlike 4.0 license or the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 license.",
       sortIndex: 1,
     },
     create: {
       code: "CCDUAL",
-      name: "Dual license Creative Commons Attribution-ShareAlike OR Attribution-NonCommercial-ShareAlike",
+      name: "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
       description:
-        "Allow reusers to use either the Creative Commons Attribution-ShareAlike license or the Creative Commons Attribution-NonCommercial-ShareAlike license.",
+        "Allow reusers to use either the Creative Commons Attribution-ShareAlike 4.0 license or the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 license.",
       sortIndex: 1,
     },
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -106,6 +106,7 @@ import {
   allAssignmentScoresConvertUUID,
   studentDataConvertUUID,
   isEqualUUID,
+  docRemixesConvertUUID,
 } from "./utils/uuid";
 import { LicenseCode, UserInfo } from "./types";
 
@@ -1440,12 +1441,11 @@ app.get(
     const activityId = toUUID(req.params.activityId);
 
     try {
-      const data = await getActivityRemixes({
+      const { docRemixes } = await getActivityRemixes({
         activityId,
         loggedInUserId,
       });
-      // TODO: process to convert UUIDs
-      res.send(data);
+      res.send({ docRemixes: docRemixes.map(docRemixesConvertUUID) });
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError) {
         res.sendStatus(404);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -109,6 +109,7 @@ import {
   docRemixesConvertUUID,
 } from "./utils/uuid";
 import { LicenseCode, UserInfo } from "./types";
+import { add_test_apis } from "./test_apis";
 
 const client = new SESClient({ region: "us-east-2" });
 
@@ -2558,6 +2559,13 @@ app.get(
     }
   },
 );
+
+if (
+  process.env.ADD_TEST_APIS &&
+  process.env.ADD_TEST_APIS.toLocaleLowerCase() !== "false"
+) {
+  add_test_apis(app);
+}
 
 // handle every other route with index.html, which will contain
 // a script tag to your application's JavaScript file(s).

--- a/server/src/model.test.ts
+++ b/server/src/model.test.ts
@@ -2658,13 +2658,13 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId1,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(2);
   expect(docRemixes[0].docId).eqls(docId5);
-  expect(docRemixes[0].document.activity.id).eqls(activityId5);
+  expect(docRemixes[0].activity.id).eqls(activityId5);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[1].docId).eqls(docId4);
-  expect(docRemixes[1].document.activity.id).eqls(activityId4);
+  expect(docRemixes[1].activity.id).eqls(activityId4);
   expect(docRemixes[1].withLicenseCode).eq("CCDUAL");
 
   // owner 1 just sees direct remix from activity 1 into activity 5
@@ -2673,10 +2673,10 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId1,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(1);
   expect(docRemixes[0].docId).eqls(docId5);
-  expect(docRemixes[0].document.activity.id).eqls(activityId5);
+  expect(docRemixes[0].activity.id).eqls(activityId5);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
 
   // owner2 just sees activity 1 and 2 in history of activity 4
@@ -2700,13 +2700,13 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId2,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(2);
   expect(docRemixes[0].docId).eqls(docId4);
-  expect(docRemixes[0].document.activity.id).eqls(activityId4);
+  expect(docRemixes[0].activity.id).eqls(activityId4);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[1].docId).eqls(docId2);
-  expect(docRemixes[1].document.activity.id).eqls(activityId2);
+  expect(docRemixes[1].activity.id).eqls(activityId2);
   expect(docRemixes[1].withLicenseCode).eq("CCDUAL");
 
   // owner 2 sees direct remix of activity 1 into 2
@@ -2715,10 +2715,10 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId2,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(1);
   expect(docRemixes[0].docId).eqls(docId2);
-  expect(docRemixes[0].document.activity.id).eqls(activityId2);
+  expect(docRemixes[0].activity.id).eqls(activityId2);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
 
   // owner3 sees activity 1, 2 and 3 in history of activity 4
@@ -2745,19 +2745,19 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId3,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(4);
   expect(docRemixes[0].docId).eqls(docId5);
-  expect(docRemixes[0].document.activity.id).eqls(activityId5);
+  expect(docRemixes[0].activity.id).eqls(activityId5);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[1].docId).eqls(docId4);
-  expect(docRemixes[1].document.activity.id).eqls(activityId4);
+  expect(docRemixes[1].activity.id).eqls(activityId4);
   expect(docRemixes[1].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[2].docId).eqls(docId3);
-  expect(docRemixes[2].document.activity.id).eqls(activityId3);
+  expect(docRemixes[2].activity.id).eqls(activityId3);
   expect(docRemixes[2].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[3].docId).eqls(docId2);
-  expect(docRemixes[3].document.activity.id).eqls(activityId2);
+  expect(docRemixes[3].activity.id).eqls(activityId2);
   expect(docRemixes[3].withLicenseCode).eq("CCDUAL");
 
   // owner 3 sees direct remixes of activity 1 into 2 and 5
@@ -2766,13 +2766,13 @@ test("contributor history shows only documents user can view", async () => {
       docIds: [docId1],
       loggedInUserId: ownerId3,
     })
-  )[0].documentVersions.flatMap((v) => v.contributorHistory);
+  )[0].documentVersions.flatMap((v) => v.remixes);
   expect(docRemixes.length).eq(2);
   expect(docRemixes[0].docId).eqls(docId5);
-  expect(docRemixes[0].document.activity.id).eqls(activityId5);
+  expect(docRemixes[0].activity.id).eqls(activityId5);
   expect(docRemixes[0].withLicenseCode).eq("CCDUAL");
   expect(docRemixes[1].docId).eqls(docId2);
-  expect(docRemixes[1].document.activity.id).eqls(activityId2);
+  expect(docRemixes[1].activity.id).eqls(activityId2);
   expect(docRemixes[1].withLicenseCode).eq("CCDUAL");
 });
 

--- a/server/src/model.test.ts
+++ b/server/src/model.test.ts
@@ -2627,7 +2627,7 @@ test("contributor history shows only documents user can view", async () => {
   await makeActivityPublic({
     id: activityId4,
     ownerId: ownerId3,
-    licenseCode: "CCBYNCSA",
+    licenseCode: "CCBYSA",
   });
 
   // owner 3 copies activity 1 to activity 5 and shares it with owner 1
@@ -2636,7 +2636,7 @@ test("contributor history shows only documents user can view", async () => {
   await shareActivity({
     id: activityId5,
     ownerId: ownerId3,
-    licenseCode: "CCBYSA",
+    licenseCode: "CCBYNCSA",
     users: [ownerId1],
   });
 
@@ -2731,7 +2731,7 @@ test("contributor history shows only documents user can view", async () => {
   expect(docHistory.length).eq(3);
   expect(docHistory[0].prevDocId).eqls(docId3);
   expect(docHistory[0].prevDoc.document.activity.id).eqls(activityId3);
-  expect(docHistory[0].withLicenseCode).eq("CCDUAL");
+  expect(docHistory[0].withLicenseCode).eq("CCBYSA");
   expect(docHistory[1].prevDocId).eqls(docId2);
   expect(docHistory[1].prevDoc.document.activity.id).eqls(activityId2);
   expect(docHistory[1].withLicenseCode).eq("CCBYSA");
@@ -7551,7 +7551,7 @@ test("searchMyFolderContent, handle tags in search", async () => {
 
 test("get licenses", async () => {
   const cc_by_sa = await getLicense("CCBYSA");
-  expect(cc_by_sa.name).eq("Creative Commons Attribution-ShareAlike");
+  expect(cc_by_sa.name).eq("Creative Commons Attribution-ShareAlike 4.0");
   expect(cc_by_sa.imageURL).eq("/creative_commons_by_sa.png");
   expect(cc_by_sa.smallImageURL).eq("/creative_commons_by_sa_small.png");
   expect(cc_by_sa.licenseURL).eq(
@@ -7560,7 +7560,7 @@ test("get licenses", async () => {
 
   const cc_by_nc_sa = await getLicense("CCBYNCSA");
   expect(cc_by_nc_sa.name).eq(
-    "Creative Commons Attribution-NonCommercial-ShareAlike",
+    "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
   );
   expect(cc_by_nc_sa.imageURL).eq("/creative_commons_by_nc_sa.png");
   expect(cc_by_nc_sa.smallImageURL).eq("/creative_commons_by_nc_sa_small.png");
@@ -7570,11 +7570,11 @@ test("get licenses", async () => {
 
   const cc_dual = await getLicense("CCDUAL");
   expect(cc_dual.name).eq(
-    "Dual license Creative Commons Attribution-ShareAlike OR Attribution-NonCommercial-ShareAlike",
+    "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
   );
 
   expect(cc_dual.composedOf[0].name).eq(
-    "Creative Commons Attribution-ShareAlike",
+    "Creative Commons Attribution-ShareAlike 4.0",
   );
   expect(cc_dual.composedOf[0].imageURL).eq("/creative_commons_by_sa.png");
   expect(cc_dual.composedOf[0].smallImageURL).eq(
@@ -7584,7 +7584,7 @@ test("get licenses", async () => {
     "https://creativecommons.org/licenses/by-sa/4.0/",
   );
   expect(cc_dual.composedOf[1].name).eq(
-    "Creative Commons Attribution-NonCommercial-ShareAlike",
+    "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
   );
   expect(cc_dual.composedOf[1].imageURL).eq("/creative_commons_by_nc_sa.png");
   expect(cc_dual.composedOf[1].smallImageURL).eq(
@@ -7617,7 +7617,7 @@ test("set license to make public", async () => {
 
   expect(activityData.license?.code).eq("CCBYSA");
   expect(activityData.license?.name).eq(
-    "Creative Commons Attribution-ShareAlike",
+    "Creative Commons Attribution-ShareAlike 4.0",
   );
   expect(activityData.license?.licenseURL).eq(
     "https://creativecommons.org/licenses/by-sa/4.0/",
@@ -7646,7 +7646,7 @@ test("set license to make public", async () => {
 
   expect(activityData.license?.code).eq("CCBYNCSA");
   expect(activityData.license?.name).eq(
-    "Creative Commons Attribution-NonCommercial-ShareAlike",
+    "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
   );
   expect(activityData.license?.licenseURL).eq(
     "https://creativecommons.org/licenses/by-nc-sa/4.0/",
@@ -7668,12 +7668,12 @@ test("set license to make public", async () => {
 
   expect(activityData.license?.code).eq("CCDUAL");
   expect(activityData.license?.name).eq(
-    "Dual license Creative Commons Attribution-ShareAlike OR Attribution-NonCommercial-ShareAlike",
+    "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
   );
 
   expect(activityData.license?.composedOf[0].code).eq("CCBYSA");
   expect(activityData.license?.composedOf[0].name).eq(
-    "Creative Commons Attribution-ShareAlike",
+    "Creative Commons Attribution-ShareAlike 4.0",
   );
   expect(activityData.license?.composedOf[0].licenseURL).eq(
     "https://creativecommons.org/licenses/by-sa/4.0/",
@@ -7684,7 +7684,7 @@ test("set license to make public", async () => {
 
   expect(activityData.license?.composedOf[1].code).eq("CCBYNCSA");
   expect(activityData.license?.composedOf[1].name).eq(
-    "Creative Commons Attribution-NonCommercial-ShareAlike",
+    "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
   );
   expect(activityData.license?.composedOf[1].licenseURL).eq(
     "https://creativecommons.org/licenses/by-nc-sa/4.0/",

--- a/server/src/test_apis.ts
+++ b/server/src/test_apis.ts
@@ -1,0 +1,58 @@
+import { Express, NextFunction, Request, Response } from "express";
+import { prisma } from "./model";
+import { toUUID } from "./utils/uuid";
+
+type ClassificationByNames = {
+  systemShortName: string;
+  category: string;
+  subCategory: string;
+  code: string;
+};
+
+export function add_test_apis(app: Express) {
+  app.post(
+    "/api/test/addClassificationsByNames",
+    async (req: Request, res: Response, next: NextFunction) => {
+      const body = req.body;
+      const classificationsByNames =
+        body.classifications as ClassificationByNames[];
+      const activityId = toUUID(body.id);
+
+      try {
+        for (const classification of classificationsByNames) {
+          const classificationId = (
+            await prisma.classifications.findFirstOrThrow({
+              select: {
+                id: true,
+              },
+              where: {
+                code: classification.code,
+                subCategories: {
+                  some: {
+                    subCategory: classification.subCategory,
+                    category: {
+                      category: classification.category,
+                      system: {
+                        shortName: classification.systemShortName,
+                      },
+                    },
+                  },
+                },
+              },
+            })
+          ).id;
+
+          await prisma.contentClassifications.create({
+            data: {
+              contentId: activityId,
+              classificationId,
+            },
+          });
+        }
+        res.send({});
+      } catch (e) {
+        next(e);
+      }
+    },
+  );
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -115,6 +115,30 @@ export type DocHistory = {
   }[];
 };
 
+export type DocRemixes = {
+  id: Uint8Array;
+  documentVersions: {
+    versionNumber: number;
+    remixes: {
+      activity: {
+        id: Uint8Array;
+        name: string;
+        owner: {
+          userId: Uint8Array;
+          email: string;
+          firstNames: string | null;
+          lastNames: string;
+        };
+      };
+
+      docId: Uint8Array;
+      withLicenseCode: string | null;
+      timestampDoc: Date;
+      timestampPrevDoc: Date;
+    }[];
+  }[];
+};
+
 export type ClassificationCategoryTree = {
   id: number;
   name: string;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -30,6 +30,7 @@ export type ContentClassification = {
       system: {
         id: number;
         name: string;
+        shortName: string;
         categoryLabel: string;
         subCategoryLabel: string;
         descriptionLabel: string;

--- a/server/src/utils/uuid.ts
+++ b/server/src/utils/uuid.ts
@@ -1,4 +1,4 @@
-import { ContentStructure, DocHistory, UserInfo } from "../types";
+import { ContentStructure, DocHistory, DocRemixes, UserInfo } from "../types";
 import { fromBinaryUUID, toBinaryUUID } from "./binary-uuid";
 import short from "short-uuid";
 
@@ -87,6 +87,24 @@ export function docHistoryConvertUUID(docHistory: DocHistory) {
         },
       };
     }),
+  };
+}
+
+export function docRemixesConvertUUID(docRemixes: DocRemixes) {
+  return {
+    id: fromUUID(docRemixes.id),
+    documentVersions: docRemixes.documentVersions.map((docVersion) => ({
+      versionNumber: docVersion.versionNumber,
+      remixes: docVersion.remixes.map((remix) => ({
+        ...remix,
+        docId: fromUUID(remix.docId),
+        activity: {
+          name: remix.activity.name,
+          id: fromUUID(remix.activity.id),
+          owner: userConvertUUID(remix.activity.owner),
+        },
+      })),
+    })),
   };
 }
 


### PR DESCRIPTION
This PR adds a content info drawer to view of shared and public activities (the activity viewer, code viewer, and community pages).

The content info drawer displays
- license and DoenetML version
- classifications
- remixes

The PR also reworks the remix settings panels that are included in the content info drawer and share settings. The share settings now only allow one to select a license that is compatible with the license the activity was remixed under.
