### PR TITLE
remember explore current tab across site

### DIFF
--- a/client/cypress/e2e/Explore/navigateExplore.cy.ts
+++ b/client/cypress/e2e/Explore/navigateExplore.cy.ts
@@ -1,0 +1,64 @@
+describe("Navigate Explore Tests", function () {
+  it("remember explore's current tab", () => {
+    cy.loginAsTestUser({ isAdmin: true });
+
+    // make sure library contains at least one item
+    cy.createActivity({
+      activityName: "Hello!",
+      doenetML: "Initial content",
+      makePublic: true,
+      publishInLibrary: true,
+    }).then(() => {
+      cy.visit(`/explore`);
+
+      // initially curated tab is selected
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Community Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
+
+      // select community tab
+      cy.get('[data-test="Community Tab"]').click();
+      cy.get('[data-test="Community Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
+
+      cy.get('[data-test="Home"]').click();
+      cy.get('[data-test="Home"]').should("have.attr", "aria-current", "page");
+      cy.get('[data-test="Explore"]').should("not.have.attr", "aria-current");
+
+      cy.get('[data-test="Explore"]').click();
+      cy.get('[data-test="Explore"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="Home"]').should("not.have.attr", "aria-current");
+
+      // community tab is still selected
+      cy.get('[data-test="Community Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
+    });
+  });
+});

--- a/client/cypress/e2e/Explore/navigateExplore.cy.ts
+++ b/client/cypress/e2e/Explore/navigateExplore.cy.ts
@@ -59,6 +59,62 @@ describe("Navigate Explore Tests", function () {
         "aria-selected",
         "false",
       );
+
+      // search for name and select author tab
+      cy.get('[data-test="Search"]').type("Test{enter}");
+
+      cy.get('[data-test="Authors Tab"]').click();
+      cy.get('[data-test="Authors Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Community Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
+
+      cy.get('[data-test="Home"]').click();
+      cy.get('[data-test="Home"]').should("have.attr", "aria-current", "page");
+      cy.get('[data-test="Explore"]').should("not.have.attr", "aria-current");
+
+      // if go back, query is still active and authors tab is still selected
+      cy.go("back");
+      cy.get('[data-test="Explore"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="Home"]').should("not.have.attr", "aria-current");
+      cy.get('[data-test="Authors Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+
+      cy.get('[data-test="Home"]').click();
+      cy.get('[data-test="Home"]').should("have.attr", "aria-current", "page");
+      cy.get('[data-test="Explore"]').should("not.have.attr", "aria-current");
+
+      // if click on "Explore" tab, the query, and hence the author tab, is gone, which means curated tab should be open
+      cy.get('[data-test="Explore"]').click();
+      cy.get('[data-test="Explore"]').should(
+        "have.attr",
+        "aria-current",
+        "page",
+      );
+      cy.get('[data-test="Home"]').should("not.have.attr", "aria-current");
+      cy.get('[data-test="Curated Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.get('[data-test="Authors Tab"]').should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
     });
   });
 });

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -65,7 +65,7 @@ import ContributorsMenu from "../ToolPanels/ContributorsMenu";
 import { ContentInfoDrawer } from "../ToolPanels/ContentInfoDrawer";
 import { createFullName } from "../../../_utils/names";
 import { DisplayLicenseItem } from "../../../Widgets/Licenses";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 import {
   AddContentToMenu,
   addContentToMenuActions,
@@ -167,7 +167,7 @@ export function ActivityViewer() {
     addTo,
   } = data;
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const infoBtnRef = useRef<HTMLButtonElement>(null);

--- a/client/src/Tools/_framework/Paths/AssignmentViewer.tsx
+++ b/client/src/Tools/_framework/Paths/AssignmentViewer.tsx
@@ -11,7 +11,7 @@ import {
   action as enterClassCodeAction,
 } from "./EnterClassCode";
 import { ChangeName, action as changeNameAction } from "./ChangeName";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 
 export async function action({ params, request }) {
   const formData = await request.formData();
@@ -95,7 +95,7 @@ export function AssignmentViewer() {
     doenetmlVersion: string;
   };
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
 
   const navigate = useNavigate();
   const location = useLocation();

--- a/client/src/Tools/_framework/Paths/ChangeName.tsx
+++ b/client/src/Tools/_framework/Paths/ChangeName.tsx
@@ -16,7 +16,7 @@ import {
   useOutletContext,
 } from "react-router";
 import axios from "axios";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 import { createFullName } from "../../../_utils/names";
 
 export async function action({
@@ -59,7 +59,7 @@ export function ChangeName({
     redirectTo: string | undefined;
   };
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
 
   const navigate = useNavigate();
 

--- a/client/src/Tools/_framework/Paths/CodeViewer.tsx
+++ b/client/src/Tools/_framework/Paths/CodeViewer.tsx
@@ -18,7 +18,7 @@ import { WarningIcon } from "@chakra-ui/icons";
 import { BsPlayBtnFill } from "react-icons/bs";
 import { CopyContentAndReportFinish } from "../ToolPanels/CopyContentAndReportFinish";
 import axios from "axios";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 import { ContentStructure, DoenetmlVersion } from "../../../_utils/types";
 import { ContentInfoDrawer } from "../ToolPanels/ContentInfoDrawer";
 import { MdOutlineInfo } from "react-icons/md";
@@ -81,7 +81,7 @@ export function CodeViewer() {
     onClose: infoOnClose,
   } = useDisclosure();
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const label = activityData?.name ?? "Public Editor";

--- a/client/src/Tools/_framework/Paths/Explore.tsx
+++ b/client/src/Tools/_framework/Paths/Explore.tsx
@@ -58,7 +58,7 @@ import { clearQueryParameter } from "../../../_utils/explore";
 import { FilterPanel } from "../ToolPanels/FilterPanel";
 import { ExploreFilterDrawer } from "../ToolPanels/ExploreFilterDrawer";
 import { menuIcons } from "../../../_utils/activity";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 import {
   AddContentToMenu,
   addContentToMenuActions,
@@ -223,11 +223,11 @@ export function Explore() {
     addTo?: ContentDescription;
   };
 
-  const user = useOutletContext<User>();
-
-  const [currentTab, setCurrentTab] = useState(
-    !totalCount.numCurated && totalCount.numCommunity ? 1 : 0,
-  );
+  const {
+    user,
+    exploreTab: currentTab,
+    setExploreTab: setCurrentTab,
+  } = useOutletContext<SiteContext>();
 
   const [searchString, setSearchString] = useState(q || "");
 
@@ -247,7 +247,7 @@ export function Explore() {
 
   useEffect(() => {
     setSearchString(q || "");
-    if (!q && currentTab > 1) {
+    if (currentTab == null || (!q && currentTab > 1)) {
       setCurrentTab(!totalCount.numCurated && totalCount.numCommunity ? 1 : 0);
     }
   }, [q]);
@@ -884,7 +884,7 @@ export function Explore() {
         lg: `calc(100vh - ${q ? "168" : "128"}px)`,
       }}
       variant="enclosed-colored"
-      index={currentTab}
+      index={currentTab ?? 0}
       onChange={setCurrentTab}
     >
       <TabList>

--- a/client/src/Tools/_framework/Paths/SharedActivities.tsx
+++ b/client/src/Tools/_framework/Paths/SharedActivities.tsx
@@ -37,7 +37,7 @@ import {
   toggleViewButtonGroupActions,
 } from "../ToolPanels/ToggleViewButtonGroup";
 import { menuIcons } from "../../../_utils/activity";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 import {
   AddContentToMenu,
   addContentToMenuActions,
@@ -107,7 +107,7 @@ export function SharedActivities() {
       addTo?: ContentDescription;
     };
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
 
   const navigate = useNavigate();
 

--- a/client/src/Tools/_framework/Paths/SignIn.tsx
+++ b/client/src/Tools/_framework/Paths/SignIn.tsx
@@ -15,7 +15,7 @@ import {
 import { Form } from "react-router";
 import { useNavigate, useOutletContext } from "react-router";
 import "./google-signin.css";
-import { User } from "./SiteHeader";
+import { SiteContext } from "./SiteHeader";
 
 export async function action({ request }) {
   const formData = await request.formData();
@@ -31,7 +31,7 @@ export async function action({ request }) {
 }
 
 export function SignIn() {
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
 
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [email, setEmail] = useState("");

--- a/client/src/Tools/_framework/Paths/SiteHeader.tsx
+++ b/client/src/Tools/_framework/Paths/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Button,
   Center,
@@ -40,6 +40,12 @@ export type User =
       isAdmin: boolean;
     }
   | undefined;
+
+export type SiteContext = {
+  user: User;
+  exploreTab: number | null;
+  setExploreTab: (arg: number | null) => void;
+};
 
 export async function loader() {
   const {
@@ -123,6 +129,10 @@ function NavLinkDropdownTab({ to, children, dataTest }) {
 
 export function SiteHeader() {
   const { user } = useLoaderData() as { user: User };
+
+  const [exploreTab, setExploreTab] = useState<number | null>(null);
+
+  const siteContext: SiteContext = { user, exploreTab, setExploreTab };
 
   const helpMenuShouldFocusFirst = useBreakpointValue(
     { base: false, md: true },
@@ -345,7 +355,7 @@ export function SiteHeader() {
         </GridItem>
         <GridItem area="main" as="main" margin="0" overflowY="auto">
           <SkipNavContent />
-          <Outlet context={user} />
+          <Outlet context={siteContext} />
         </GridItem>
       </Grid>
     </>

--- a/client/src/Tools/_framework/ToolPanels/AddContentToMenu.tsx
+++ b/client/src/Tools/_framework/ToolPanels/AddContentToMenu.tsx
@@ -19,7 +19,7 @@ import axios from "axios";
 import { MoveCopyContent, moveCopyContentActions } from "./MoveCopyContent";
 import { CopyContentAndReportFinish } from "./CopyContentAndReportFinish";
 import { useOutletContext } from "react-router";
-import { User } from "../Paths/SiteHeader";
+import { SiteContext } from "../Paths/SiteHeader";
 import { getAllowedParentTypes, menuIcons } from "../../../_utils/activity";
 
 export async function addContentToMenuActions({
@@ -69,7 +69,7 @@ export function AddContentToMenu({
   followAllowedParents?: boolean;
   addCopyToLibraryOption?: boolean;
 }) {
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
 
   const [recentContent, setRecentContent] = useState<ContentDescription[]>([]);
   const [addToType, setAddToType] = useState<ContentType>("folder");

--- a/client/src/Tools/_framework/ToolPanels/CompoundActivityEditor.tsx
+++ b/client/src/Tools/_framework/ToolPanels/CompoundActivityEditor.tsx
@@ -35,7 +35,7 @@ import {
   useOutletContext,
 } from "react-router";
 import { MoveCopyContent, moveCopyContentActions } from "./MoveCopyContent";
-import { User } from "../Paths/SiteHeader";
+import { SiteContext } from "../Paths/SiteHeader";
 import CardList from "../../../Widgets/CardList";
 import axios from "axios";
 import { ActivitySource } from "../../../_utils/viewerTypes";
@@ -144,7 +144,7 @@ export function CompoundActivityEditor({
 
   const readOnly = asViewer || assignmentStatus !== "Unassigned";
 
-  const user = useOutletContext<User>();
+  const { user } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const [selectedCards, setSelectedCards] = useState<ContentDescription[]>([]);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -307,6 +307,7 @@ passport.serializeUser<any, any>(async (req, user: any, done) => {
     let lastNames = "";
     let firstNames: string | null = null;
     let isAnonymous = true;
+    let isAdmin = false;
 
     if (
       process.env.ALLOW_TEST_LOGIN &&
@@ -320,6 +321,9 @@ passport.serializeUser<any, any>(async (req, user: any, done) => {
         if (req.body.lastNames) {
           lastNames = req.body.lastNames;
         }
+        if (req.body.isAdmin) {
+          isAdmin = true;
+        }
         isAnonymous = false;
       }
     }
@@ -329,6 +333,7 @@ passport.serializeUser<any, any>(async (req, user: any, done) => {
       lastNames,
       firstNames,
       isAnonymous,
+      isAdmin,
     });
     return done(undefined, fromUUID(u.userId));
   }


### PR DESCRIPTION
This PR stores `currentTab` of `Explore` in the `SiteContext` so that the current tab being displayed is remembered when one navigates back to `Explore`.