### PR TITLE
add isAuthor flag to user

### DIFF
--- a/client/src/Tools/_framework/Paths/Activities.tsx
+++ b/client/src/Tools/_framework/Paths/Activities.tsx
@@ -77,9 +77,9 @@ import {
 import { CopyContentAndReportFinish } from "../ToolPanels/CopyContentAndReportFinish";
 import { SiteContext } from "./SiteHeader";
 import {
-  DeveloperModeModal,
-  developerModeModalActions,
-} from "../ToolPanels/DeveloperModeModal";
+  AuthorModeModal,
+  authorModeModalActions,
+} from "../ToolPanels/AuthorModeModal";
 
 export async function action({ request, params }) {
   const formData = await request.formData();
@@ -124,7 +124,7 @@ export async function action({ request, params }) {
     return resultCCM;
   }
 
-  const resultDMM = await developerModeModalActions({ formObj });
+  const resultDMM = await authorModeModalActions({ formObj });
   if (resultDMM) {
     return resultDMM;
   }
@@ -637,7 +637,7 @@ export function Activities() {
   } = useDisclosure();
 
   const developerModeModal = (
-    <DeveloperModeModal
+    <AuthorModeModal
       isOpen={developerModePromptIsOpen}
       onClose={developerModePromptOnClose}
       desiredAction="create doc"
@@ -868,14 +868,14 @@ export function Activities() {
                 <MenuItem
                   data-test="Add Document Button"
                   onClick={() => {
-                    if (user?.isDeveloper) {
+                    if (user?.isAuthor) {
                       createNewDocument();
                     } else {
                       developerModePromptOnOpen();
                     }
                   }}
                 >
-                  Document {!user?.isDeveloper && <>(Code)</>}
+                  Document {!user?.isAuthor && <>(with source code)</>}
                 </MenuItem>
               </MenuList>
             </Menu>

--- a/client/src/Tools/_framework/Paths/Activities.tsx
+++ b/client/src/Tools/_framework/Paths/Activities.tsx
@@ -531,6 +531,14 @@ export function Activities() {
     }
   }
 
+  function createNewDocument() {
+    setHaveContentSpinner(true);
+    fetcher.submit(
+      { _action: "Add Activity", type: "singleDoc" },
+      { method: "post" },
+    );
+  }
+
   const settingsDrawer =
     contentData && settingsContentId ? (
       <ContentSettingsDrawer
@@ -634,13 +642,7 @@ export function Activities() {
       onClose={developerModePromptOnClose}
       desiredAction="create doc"
       user={user!}
-      proceedCallback={() => {
-        setHaveContentSpinner(true);
-        fetcher.submit(
-          { _action: "Add Activity", type: "singleDoc" },
-          { method: "post" },
-        );
-      }}
+      proceedCallback={createNewDocument}
       fetcher={fetcher}
     />
   );
@@ -833,7 +835,7 @@ export function Activities() {
               <MenuList>
                 <MenuItem
                   data-test="Add Problem Set Button"
-                  onClick={async () => {
+                  onClick={() => {
                     setHaveContentSpinner(true);
                     fetcher.submit(
                       { _action: "Add Activity", type: "sequence" },
@@ -853,7 +855,7 @@ export function Activities() {
                 </MenuItem>
                 <MenuItem
                   data-test="Add Question Bank Button"
-                  onClick={async () => {
+                  onClick={() => {
                     setHaveContentSpinner(true);
                     fetcher.submit(
                       { _action: "Add Activity", type: "select" },
@@ -865,13 +867,9 @@ export function Activities() {
                 </MenuItem>
                 <MenuItem
                   data-test="Add Document Button"
-                  onClick={async () => {
+                  onClick={() => {
                     if (user?.isDeveloper) {
-                      setHaveContentSpinner(true);
-                      fetcher.submit(
-                        { _action: "Add Activity", type: "singleDoc" },
-                        { method: "post" },
-                      );
+                      createNewDocument();
                     } else {
                       developerModePromptOnOpen();
                     }

--- a/client/src/Tools/_framework/Paths/ActivityEditor.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityEditor.tsx
@@ -67,9 +67,9 @@ import { ActivitySource } from "../../../_utils/viewerTypes";
 import { CopyContentAndReportFinish } from "../ToolPanels/CopyContentAndReportFinish";
 import { SiteContext } from "./SiteHeader";
 import {
-  DeveloperModeModal,
-  developerModeModalActions,
-} from "../ToolPanels/DeveloperModeModal";
+  AuthorModeModal,
+  authorModeModalActions,
+} from "../ToolPanels/AuthorModeModal";
 
 export async function action({ params, request }) {
   const formData = await request.formData();
@@ -111,7 +111,7 @@ export async function action({ params, request }) {
     return resultNAE;
   }
 
-  const resultDM = await developerModeModalActions({ formObj });
+  const resultDM = await authorModeModalActions({ formObj });
   if (resultDM) {
     return resultDM;
   }
@@ -300,9 +300,9 @@ export function ActivityEditor() {
   } = useDisclosure();
 
   const {
-    isOpen: developerModePromptIsOpen,
-    onOpen: developerModePromptOnOpen,
-    onClose: developerModePromptOnClose,
+    isOpen: authorModePromptIsOpen,
+    onOpen: authorModePromptOnOpen,
+    onClose: authorModePromptOnClose,
   } = useDisclosure();
 
   const { user } = useOutletContext<SiteContext>();
@@ -315,14 +315,14 @@ export function ActivityEditor() {
   const readOnlyRef = useRef(readOnly);
   readOnlyRef.current = readOnly;
 
-  const developerMode = user?.isDeveloper || data.type !== "singleDoc";
+  const authorMode = user?.isAuthor || data.type !== "singleDoc";
 
   const [mode, setMode] = useState<"Edit" | "View">(
-    developerMode ? "Edit" : "View",
+    authorMode ? "Edit" : "View",
   );
 
   useEffect(() => {
-    setMode(developerMode ? "Edit" : "View");
+    setMode(authorMode ? "Edit" : "View");
   }, [contentId]);
 
   const isLibraryActivity = Boolean(activityData.libraryActivityInfo);
@@ -344,16 +344,15 @@ export function ActivityEditor() {
 
   if (assignmentStatus === "Unassigned") {
     editIcon = <MdModeEditOutline size={20} />;
-    if (developerMode) {
-      editLabel = "Edit";
+    editLabel = "Edit";
+    if (authorMode) {
       editTooltip = "Edit activity";
     } else {
-      editLabel = "Develop";
-      editTooltip = "Turn on developer mode to edit";
+      editTooltip = "Turn on author mode to edit";
     }
   } else {
     editIcon = <MdOutlineEditOff size={20} />;
-    if (developerMode) {
+    if (authorMode) {
       if (data.type === "singleDoc") {
         editLabel = "See code";
         editTooltip = "See read-only view of code";
@@ -362,8 +361,8 @@ export function ActivityEditor() {
         editTooltip = `See read-only view of documents ${data.type === "sequence" ? "and question banks in the problem set" : "in the question bank"}`;
       }
     } else {
-      editLabel = "Developer view";
-      editTooltip = "Turn on developer mode to see read-only view of code";
+      editLabel = "Author view";
+      editTooltip = "Turn on author mode to see read-only view of code";
     }
   }
 
@@ -484,10 +483,10 @@ export function ActivityEditor() {
     />
   );
 
-  const developerModeModal = (
-    <DeveloperModeModal
-      isOpen={developerModePromptIsOpen}
-      onClose={developerModePromptOnClose}
+  const authorModeModal = (
+    <AuthorModeModal
+      isOpen={authorModePromptIsOpen}
+      onClose={authorModePromptOnClose}
       desiredAction="edit"
       assignmentStatus={assignmentStatus}
       user={user!}
@@ -528,7 +527,7 @@ export function ActivityEditor() {
       {shareDrawer}
       {assignmentDrawers}
       {copyContentModal}
-      {developerModeModal}
+      {authorModeModal}
 
       <Grid
         background="doenet.lightBlue"
@@ -603,10 +602,10 @@ export function ActivityEditor() {
                       leftIcon={editIcon}
                       onClick={() => {
                         if (mode !== "Edit") {
-                          if (developerMode) {
+                          if (authorMode) {
                             setMode("Edit");
                           } else {
-                            developerModePromptOnOpen();
+                            authorModePromptOnOpen();
                           }
                         }
                       }}

--- a/client/src/Tools/_framework/Paths/ActivityEditor.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityEditor.tsx
@@ -315,9 +315,15 @@ export function ActivityEditor() {
   const readOnlyRef = useRef(readOnly);
   readOnlyRef.current = readOnly;
 
+  const developerMode = user?.isDeveloper || data.type !== "singleDoc";
+
   const [mode, setMode] = useState<"Edit" | "View">(
-    user?.isDeveloper || data.type !== "singleDoc" ? "Edit" : "View",
+    developerMode ? "Edit" : "View",
   );
+
+  useEffect(() => {
+    setMode(developerMode ? "Edit" : "View");
+  }, [contentId]);
 
   const isLibraryActivity = Boolean(activityData.libraryActivityInfo);
 
@@ -338,7 +344,7 @@ export function ActivityEditor() {
 
   if (assignmentStatus === "Unassigned") {
     editIcon = <MdModeEditOutline size={20} />;
-    if (user?.isDeveloper) {
+    if (developerMode) {
       editLabel = "Edit";
       editTooltip = "Edit activity";
     } else {
@@ -347,9 +353,14 @@ export function ActivityEditor() {
     }
   } else {
     editIcon = <MdOutlineEditOff size={20} />;
-    if (user?.isDeveloper) {
-      editLabel = "See code";
-      editTooltip = "See read-only view of code";
+    if (developerMode) {
+      if (data.type === "singleDoc") {
+        editLabel = "See code";
+        editTooltip = "See read-only view of code";
+      } else {
+        editLabel = "See list";
+        editTooltip = `See read-only view of documents ${data.type === "sequence" ? "and question banks in the problem set" : "in the question bank"}`;
+      }
     } else {
       editLabel = "Developer view";
       editTooltip = "Turn on developer mode to see read-only view of code";
@@ -592,7 +603,7 @@ export function ActivityEditor() {
                       leftIcon={editIcon}
                       onClick={() => {
                         if (mode !== "Edit") {
-                          if (user?.isDeveloper) {
+                          if (developerMode) {
                             setMode("Edit");
                           } else {
                             developerModePromptOnOpen();

--- a/client/src/Tools/_framework/Paths/ActivityEditor.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityEditor.tsx
@@ -354,15 +354,15 @@ export function ActivityEditor() {
     editIcon = <MdOutlineEditOff size={20} />;
     if (authorMode) {
       if (data.type === "singleDoc") {
-        editLabel = "See code";
-        editTooltip = "See read-only view of code";
+        editLabel = "See source code";
+        editTooltip = "See read-only view of source code";
       } else {
         editLabel = "See list";
         editTooltip = `See read-only view of documents ${data.type === "sequence" ? "and question banks in the problem set" : "in the question bank"}`;
       }
     } else {
-      editLabel = "Author view";
-      editTooltip = "Turn on author mode to see read-only view of code";
+      editLabel = "See source code";
+      editTooltip = "Turn on author mode to see read-only view of source code";
     }
   }
 

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -153,31 +153,24 @@ export function ActivityViewer() {
       }
   );
 
-  const {
-    contentId,
-    type: contentType,
-    activityData,
-    contributorHistory,
-  } = data;
+  const { contentId, activityData, contributorHistory } = data;
 
   const { user, addTo, setAddTo } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const infoBtnRef = useRef<HTMLButtonElement>(null);
 
+  const authorMode = user?.isAuthor || data.type === "select";
+
   const [mode, setMode] = useState<"Edit" | "View">(
-    contentType === "select" ? "Edit" : "View",
+    authorMode ? "Edit" : "View",
   );
 
-  const fetcher = useFetcher();
-
   useEffect(() => {
-    if (contentType === "select") {
-      setMode("Edit");
-    } else {
-      setMode("View");
-    }
-  }, [contentType, contentId]);
+    setMode(authorMode ? "Edit" : "View");
+  }, [contentId]);
+
+  const fetcher = useFetcher();
 
   useEffect(() => {
     document.title = `${activityData.name} - Doenet`;
@@ -248,11 +241,22 @@ export function ActivityViewer() {
       />
     ) : null;
 
-  const [editLabel, editTooltip, editIcon] = [
-    "See code",
-    "See read-only view of code",
-    <MdOutlineEditOff size={20} />,
-  ];
+  let editLabel: string;
+  let editTooltip: string;
+
+  const editIcon = <MdOutlineEditOff size={20} />;
+  if (authorMode) {
+    if (data.type === "singleDoc") {
+      editLabel = "See source code";
+      editTooltip = "See read-only view of source code";
+    } else {
+      editLabel = "See list";
+      editTooltip = `See read-only view of documents ${data.type === "sequence" ? "and question banks in the problem set" : "in the question bank"}`;
+    }
+  } else {
+    editLabel = "See source code";
+    editTooltip = "Turn on author mode to see read-only view of source code";
+  }
 
   const haveClassifications = activityData.classifications.length > 0;
 

--- a/client/src/Tools/_framework/Paths/ActivityViewer.tsx
+++ b/client/src/Tools/_framework/Paths/ActivityViewer.tsx
@@ -249,8 +249,8 @@ export function ActivityViewer() {
     ) : null;
 
   const [editLabel, editTooltip, editIcon] = [
-    "See Source",
-    "See read-only view of source",
+    "See code",
+    "See read-only view of code",
     <MdOutlineEditOff size={20} />,
   ];
 

--- a/client/src/Tools/_framework/Paths/Explore.tsx
+++ b/client/src/Tools/_framework/Paths/Explore.tsx
@@ -781,7 +781,7 @@ export function Explore() {
             height="30px"
             width="100%"
             alignContent="center"
-            hidden={numSelected === 0 && addTo === undefined}
+            hidden={numSelected === 0 && addTo === null}
             backgroundColor="gray.100"
             justifyContent="center"
           >

--- a/client/src/Tools/_framework/Paths/Home.tsx
+++ b/client/src/Tools/_framework/Paths/Home.tsx
@@ -496,7 +496,7 @@ export function Home() {
                   textDecoration={"underline"}
                   href="https://www.doenet.org/public?tool=editor&doenetId=_4hcncjV6Ffabz5lhD47aL"
                 >
-                  See code
+                  See source code
                 </Link>
                 )
               </Text>

--- a/client/src/Tools/_framework/Paths/Home.tsx
+++ b/client/src/Tools/_framework/Paths/Home.tsx
@@ -496,7 +496,7 @@ export function Home() {
                   textDecoration={"underline"}
                   href="https://www.doenet.org/public?tool=editor&doenetId=_4hcncjV6Ffabz5lhD47aL"
                 >
-                  See source
+                  See code
                 </Link>
                 )
               </Text>

--- a/client/src/Tools/_framework/Paths/SharedActivities.tsx
+++ b/client/src/Tools/_framework/Paths/SharedActivities.tsx
@@ -178,11 +178,34 @@ export function SharedActivities() {
       width="100%"
       textAlign="center"
     >
+      <Flex
+        width="100%"
+        paddingRight="0.5em"
+        paddingLeft="1em"
+        alignItems="middle"
+      >
+        <Box marginTop="5px" height="24px">
+          {parent ? (
+            <Link
+              to={`/sharedActivities/${ownerId}${parent.parent ? "/" + parent.parent.contentId : ""}`}
+              style={{
+                color: "var(--mainBlue)",
+              }}
+            >
+              {" "}
+              &lt; Back to{" "}
+              {parent.parent
+                ? parent.parent.name
+                : `Shared Activities of ${createFullName(owner)}`}
+            </Link>
+          ) : null}
+        </Box>
+      </Flex>
+
       <Tooltip label={headingText}>
         <Heading
           as="h2"
           size="lg"
-          paddingTop="10px"
           noOfLines={1}
           height="46px"
           data-test="Folder Heading"
@@ -256,23 +279,6 @@ export function SharedActivities() {
             ) : null}
           </HStack>
         </Flex>
-      </Flex>
-
-      <Flex marginRight=".5em" alignItems="center" paddingLeft="15px">
-        {parent ? (
-          <Link
-            to={`/sharedActivities/${ownerId}${parent.parent ? "/" + parent.parent.contentId : ""}`}
-            style={{
-              color: "var(--mainBlue)",
-            }}
-          >
-            {" "}
-            &lt; Back to{" "}
-            {parent.parent
-              ? parent.parent.name
-              : `Shared Activities of ${createFullName(owner)}`}
-          </Link>
-        ) : null}
       </Flex>
     </Box>
   );

--- a/client/src/Tools/_framework/Paths/SiteHeader.tsx
+++ b/client/src/Tools/_framework/Paths/SiteHeader.tsx
@@ -22,6 +22,7 @@ import {
   Hide,
   Checkbox,
   Box,
+  Tooltip,
 } from "@chakra-ui/react";
 import { HiOutlineMail } from "react-icons/hi";
 import { BsDiscord } from "react-icons/bs";
@@ -41,7 +42,7 @@ export type User =
       lastNames: string;
       isAnonymous: boolean;
       isAdmin: boolean;
-      isDeveloper: boolean;
+      isAuthor: boolean;
     }
   | undefined;
 
@@ -57,9 +58,9 @@ export async function action({ request }) {
   const formData = await request.formData();
   const formObj = Object.fromEntries(formData);
 
-  if (formObj?._action == "set is developer") {
-    await axios.post("/api/user/setIsDeveloper", {
-      isDeveloper: formObj.isDeveloper === "true",
+  if (formObj?._action == "set is author") {
+    await axios.post("/api/user/setIsAuthor", {
+      isAuthor: formObj.isAuthor === "true",
     });
   }
 
@@ -311,23 +312,29 @@ export function SiteHeader() {
                               alignContent="center"
                               marginTop="20px"
                             >
-                              <label>
-                                Developer mode:{" "}
-                                <Checkbox
-                                  marginTop="3px"
-                                  isChecked={user.isDeveloper}
-                                  onChange={() => {
-                                    fetcher.submit(
-                                      {
-                                        _action: "set is developer",
-                                        userId: user.userId,
-                                        isDeveloper: !user.isDeveloper,
-                                      },
-                                      { method: "post" },
-                                    );
-                                  }}
-                                />
-                              </label>
+                              <Tooltip
+                                label="In author mode, activities default to displaying with their source code"
+                                openDelay={500}
+                                placement="bottom-end"
+                              >
+                                <label>
+                                  Author mode:{" "}
+                                  <Checkbox
+                                    marginTop="3px"
+                                    isChecked={user.isAuthor}
+                                    onChange={() => {
+                                      fetcher.submit(
+                                        {
+                                          _action: "set is author",
+                                          userId: user.userId,
+                                          isAuthor: !user.isAuthor,
+                                        },
+                                        { method: "post" },
+                                      );
+                                    }}
+                                  />
+                                </label>
+                              </Tooltip>
                             </Box>
                           ) : null}
                         </VStack>

--- a/client/src/Tools/_framework/Paths/SiteHeader.tsx
+++ b/client/src/Tools/_framework/Paths/SiteHeader.tsx
@@ -20,10 +20,12 @@ import {
   SkipNavLink,
   SkipNavContent,
   Hide,
+  Checkbox,
+  Box,
 } from "@chakra-ui/react";
 import { HiOutlineMail } from "react-icons/hi";
 import { BsDiscord } from "react-icons/bs";
-import { Outlet, useLoaderData } from "react-router";
+import { Outlet, useFetcher, useLoaderData } from "react-router";
 import { NavLink } from "react-router";
 import RouterLogo from "../RouterLogo";
 import { ExternalLinkIcon, HamburgerIcon } from "@chakra-ui/icons";
@@ -39,6 +41,7 @@ export type User =
       lastNames: string;
       isAnonymous: boolean;
       isAdmin: boolean;
+      isDeveloper: boolean;
     }
   | undefined;
 
@@ -49,6 +52,19 @@ export type SiteContext = {
   addTo: ContentDescription | null;
   setAddTo: (arg: ContentDescription | null) => void;
 };
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  const formObj = Object.fromEntries(formData);
+
+  if (formObj?._action == "set is developer") {
+    await axios.post("/api/user/setIsDeveloper", {
+      isDeveloper: formObj.isDeveloper === "true",
+    });
+  }
+
+  return null;
+}
 
 export async function loader() {
   const {
@@ -149,6 +165,8 @@ export function SiteHeader() {
     { base: false, md: true },
     { ssr: false },
   );
+
+  const fetcher = useFetcher();
 
   return (
     <>
@@ -286,6 +304,31 @@ export function SiteHeader() {
                           </Text>
                           {user.isAnonymous ? (
                             <Link href={`/signIn`}>Sign in to save work</Link>
+                          ) : null}
+                          {!user.isAnonymous ? (
+                            <Box
+                              height="30px"
+                              alignContent="center"
+                              marginTop="20px"
+                            >
+                              <label>
+                                Developer mode:{" "}
+                                <Checkbox
+                                  marginTop="3px"
+                                  isChecked={user.isDeveloper}
+                                  onChange={() => {
+                                    fetcher.submit(
+                                      {
+                                        _action: "set is developer",
+                                        userId: user.userId,
+                                        isDeveloper: !user.isDeveloper,
+                                      },
+                                      { method: "post" },
+                                    );
+                                  }}
+                                />
+                              </label>
+                            </Box>
                           ) : null}
                         </VStack>
                         <MenuItem as={Link} href="/changeName">

--- a/client/src/Tools/_framework/ToolPanels/AuthorModeModal.tsx
+++ b/client/src/Tools/_framework/ToolPanels/AuthorModeModal.tsx
@@ -8,26 +8,26 @@ import {
   ModalOverlay,
   Text,
 } from "@chakra-ui/react";
-import React, { RefObject } from "react";
+import React, { RefObject, useRef } from "react";
 import { FetcherWithComponents } from "react-router";
 import axios from "axios";
 import { AssignmentStatus, UserInfo } from "../../../_utils/types";
 
-export async function developerModeModalActions({
+export async function authorModeModalActions({
   formObj,
 }: {
   [k: string]: any;
 }) {
-  if (formObj?._action == "set is developer") {
-    await axios.post("/api/user/setIsDeveloper", {
-      isDeveloper: formObj.isDeveloper === "true",
+  if (formObj?._action == "set is author") {
+    await axios.post("/api/user/setIsAuthor", {
+      isAuthor: formObj.isAuthor === "true",
     });
   }
 
   return null;
 }
 
-export function DeveloperModeModal({
+export function AuthorModeModal({
   isOpen,
   onClose,
   desiredAction,
@@ -50,17 +50,18 @@ export function DeveloperModeModal({
 }) {
   let promptText: string;
 
+  const editVerb =
+    (assignmentStatus ?? "Unassigned") === "Unassigned" ? "edit" : "view";
+
   if (desiredAction === "edit") {
-    promptText = `You are about to ${
-      (assignmentStatus ?? "Unassigned") === "Unassigned"
-        ? "edit the source code"
-        : "view the source code"
-    }
-        of this document.  Would you like to turn on developer mode?`;
+    promptText = `You are about to ${editVerb} the source code
+        of this document.  Would you like to turn on author mode?`;
   } else {
-    promptText = `Writing document code requires developer mode.
-    Would you like to turn on developer mode?`;
+    promptText = `Writing document source code requires author mode.
+    Would you like to turn on author mode?`;
   }
+
+  const cancelRef = useRef<HTMLButtonElement>(null);
 
   return (
     <Modal
@@ -69,19 +70,21 @@ export function DeveloperModeModal({
       finalFocusRef={finalFocusRef}
       size="md"
       returnFocusOnClose={false}
+      initialFocusRef={cancelRef}
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader textAlign="center">Turn on developer mode?</ModalHeader>
+        <ModalHeader textAlign="center">Turn on author mode?</ModalHeader>
         <ModalBody>
           <Text>{promptText}</Text>
 
           <Text marginTop="20px">
-            Developer mode will make the code view be the default for documents.
+            Author mode will make the source code view be the default for
+            documents.
           </Text>
 
           <Text marginTop="20px">
-            You can turn developer mode on and off using the account menu in the
+            You can turn author mode on and off using the account menu in the
             upper right corner.
           </Text>
         </ModalBody>
@@ -92,9 +95,9 @@ export function DeveloperModeModal({
             onClick={() => {
               fetcher.submit(
                 {
-                  _action: "set is developer",
+                  _action: "set is author",
                   userId: user.userId,
-                  isDeveloper: !user.isDeveloper,
+                  isAuthor: !user.isAuthor,
                 },
                 { method: "post" },
               );
@@ -112,7 +115,7 @@ export function DeveloperModeModal({
                 onClose();
               }}
             >
-              No
+              No, {editVerb} the source code anyway
             </Button>
           )}
           <Button
@@ -120,6 +123,7 @@ export function DeveloperModeModal({
             onClick={() => {
               onClose();
             }}
+            ref={cancelRef}
           >
             Cancel
           </Button>

--- a/client/src/Tools/_framework/ToolPanels/CompoundActivityEditor.tsx
+++ b/client/src/Tools/_framework/ToolPanels/CompoundActivityEditor.tsx
@@ -61,10 +61,7 @@ import {
   CreateLocalContentModal,
   createLocalContentModalActions,
 } from "./CreateLocalContentModal";
-import {
-  DeveloperModeModal,
-  developerModeModalActions,
-} from "./DeveloperModeModal";
+import { AuthorModeModal, authorModeModalActions } from "./AuthorModeModal";
 
 export async function compoundActivityEditorActions({
   formObj,
@@ -96,7 +93,7 @@ export async function compoundActivityEditorActions({
     return resultCF;
   }
 
-  const resultDMM = await developerModeModalActions({ formObj });
+  const resultDMM = await authorModeModalActions({ formObj });
   if (resultDMM) {
     return resultDMM;
   }
@@ -317,7 +314,7 @@ export function CompoundActivityEditor({
   } = useDisclosure();
 
   const developerModeModal = (
-    <DeveloperModeModal
+    <AuthorModeModal
       isOpen={developerModePromptIsOpen}
       onClose={developerModePromptOnClose}
       desiredAction="create doc"
@@ -744,9 +741,9 @@ export function CompoundActivityEditor({
       setSelectedCards={setSelectedCards}
       disableSelectFor={addTo ? [addTo.contentId] : undefined}
       disableAsSelectedFor={disableAsSelected}
-      isDeveloper={user?.isDeveloper}
+      isAuthor={user?.isAuthor}
       addDocumentCallback={(contentId) => {
-        if (user?.isDeveloper) {
+        if (user?.isAuthor) {
           createNewDocument(contentId);
         } else {
           setCreateDocumentParentId(contentId);
@@ -887,7 +884,7 @@ export function CompoundActivityEditor({
           <MenuItem
             data-test="Add Document Button"
             onClick={() => {
-              if (user?.isDeveloper) {
+              if (user?.isAuthor) {
                 createNewDocument();
               } else {
                 setCreateDocumentParentId(activity.contentId);
@@ -895,7 +892,7 @@ export function CompoundActivityEditor({
               }
             }}
           >
-            Blank Document {!user?.isDeveloper && <>(Code)</>}
+            Blank Document {!user?.isAuthor && <>(with source code)</>}
           </MenuItem>
         </MenuList>
       </Menu>

--- a/client/src/Tools/_framework/ToolPanels/DeveloperModeModal.tsx
+++ b/client/src/Tools/_framework/ToolPanels/DeveloperModeModal.tsx
@@ -1,0 +1,130 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import React, { RefObject } from "react";
+import { FetcherWithComponents } from "react-router";
+import axios from "axios";
+import { AssignmentStatus, UserInfo } from "../../../_utils/types";
+
+export async function developerModeModalActions({
+  formObj,
+}: {
+  [k: string]: any;
+}) {
+  if (formObj?._action == "set is developer") {
+    await axios.post("/api/user/setIsDeveloper", {
+      isDeveloper: formObj.isDeveloper === "true",
+    });
+  }
+
+  return null;
+}
+
+export function DeveloperModeModal({
+  isOpen,
+  onClose,
+  desiredAction,
+  assignmentStatus,
+  user,
+  proceedCallback,
+  allowNo = false,
+  finalFocusRef,
+  fetcher,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  desiredAction: "edit" | "create doc";
+  assignmentStatus?: AssignmentStatus;
+  user: UserInfo;
+  proceedCallback: () => void;
+  allowNo?: boolean;
+  finalFocusRef?: RefObject<HTMLElement>;
+  fetcher: FetcherWithComponents<any>;
+}) {
+  let promptText: string;
+
+  if (desiredAction === "edit") {
+    promptText = `You are about to ${
+      (assignmentStatus ?? "Unassigned") === "Unassigned"
+        ? "edit the source code"
+        : "view the source code"
+    }
+        of this document.  Would you like to turn on developer mode?`;
+  } else {
+    promptText = `Writing document code requires developer mode.
+    Would you like to turn on developer mode?`;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      finalFocusRef={finalFocusRef}
+      size="md"
+      returnFocusOnClose={false}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader textAlign="center">Turn on developer mode?</ModalHeader>
+        <ModalBody>
+          <Text>{promptText}</Text>
+
+          <Text marginTop="20px">
+            Developer mode will make the code view be the default for documents.
+          </Text>
+
+          <Text marginTop="20px">
+            You can turn developer mode on and off using the account menu in the
+            upper right corner.
+          </Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            marginRight="4px"
+            onClick={() => {
+              fetcher.submit(
+                {
+                  _action: "set is developer",
+                  userId: user.userId,
+                  isDeveloper: !user.isDeveloper,
+                },
+                { method: "post" },
+              );
+              proceedCallback();
+              onClose();
+            }}
+          >
+            Yes
+          </Button>
+          {allowNo && (
+            <Button
+              marginRight="4px"
+              onClick={() => {
+                proceedCallback();
+                onClose();
+              }}
+            >
+              No
+            </Button>
+          )}
+          <Button
+            data-test="Cancel Button"
+            onClick={() => {
+              onClose();
+            }}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/client/src/Widgets/Card.tsx
+++ b/client/src/Widgets/Card.tsx
@@ -52,7 +52,7 @@ export default function Card({
   indentLevel = 0,
   selectedCards,
   selectCallback,
-  isDeveloper = false,
+  isAuthor = false,
   addDocumentCallback,
   disableSelect = false,
   disableAsSelected = false,
@@ -72,7 +72,7 @@ export default function Card({
       idx: number;
     },
   ) => void;
-  isDeveloper?: boolean;
+  isAuthor?: boolean;
   addDocumentCallback?: (contentId: string) => void;
   disableSelect?: boolean;
   disableAsSelected?: boolean;
@@ -409,7 +409,7 @@ export default function Card({
               data-test="Add Document Button"
               onClick={() => addDocumentCallback?.(contentId)}
             >
-              Blank Document {!isDeveloper && "(Code)"}
+              Blank Document {!isAuthor && "(with source code)"}
             </MenuItem>
           </MenuList>
         </Menu>

--- a/client/src/Widgets/Card.tsx
+++ b/client/src/Widgets/Card.tsx
@@ -52,6 +52,7 @@ export default function Card({
   indentLevel = 0,
   selectedCards,
   selectCallback,
+  isDeveloper = false,
   addDocumentCallback,
   disableSelect = false,
   disableAsSelected = false,
@@ -71,6 +72,7 @@ export default function Card({
       idx: number;
     },
   ) => void;
+  isDeveloper?: boolean;
   addDocumentCallback?: (contentId: string) => void;
   disableSelect?: boolean;
   disableAsSelected?: boolean;
@@ -384,12 +386,6 @@ export default function Card({
           </MenuButton>
           <MenuList>
             <MenuItem
-              data-test="Add Document Button"
-              onClick={() => addDocumentCallback?.(contentId)}
-            >
-              Blank Document
-            </MenuItem>
-            <MenuItem
               as={ReactRouterLink}
               data-test="Add Explore Items"
               to={`/explore`}
@@ -408,6 +404,12 @@ export default function Card({
               }}
             >
               Items from My Activities
+            </MenuItem>
+            <MenuItem
+              data-test="Add Document Button"
+              onClick={() => addDocumentCallback?.(contentId)}
+            >
+              Blank Document {!isDeveloper && "(Code)"}
             </MenuItem>
           </MenuList>
         </Menu>

--- a/client/src/Widgets/CardList.tsx
+++ b/client/src/Widgets/CardList.tsx
@@ -16,7 +16,7 @@ export default function CardList({
   setSelectedCards,
   disableSelectFor,
   disableAsSelectedFor,
-  isDeveloper = false,
+  isAuthor = false,
   addDocumentCallback,
 }: {
   content: (
@@ -38,7 +38,7 @@ export default function CardList({
   setSelectedCards?: React.Dispatch<React.SetStateAction<ContentDescription[]>>;
   disableSelectFor?: string[];
   disableAsSelectedFor?: string[];
-  isDeveloper?: boolean;
+  isAuthor?: boolean;
   addDocumentCallback?: (contentId: string) => void;
 }) {
   const selectedCardsFiltered = selectedCards?.filter((s) => s);
@@ -144,7 +144,7 @@ export default function CardList({
               : undefined
           }
           selectCallback={selectCallback}
-          isDeveloper={isDeveloper}
+          isAuthor={isAuthor}
           addDocumentCallback={addDocumentCallback}
           disableSelect={disableSelectFor?.includes(
             cardContent.content.contentId,

--- a/client/src/Widgets/CardList.tsx
+++ b/client/src/Widgets/CardList.tsx
@@ -16,6 +16,7 @@ export default function CardList({
   setSelectedCards,
   disableSelectFor,
   disableAsSelectedFor,
+  isDeveloper = false,
   addDocumentCallback,
 }: {
   content: (
@@ -37,6 +38,7 @@ export default function CardList({
   setSelectedCards?: React.Dispatch<React.SetStateAction<ContentDescription[]>>;
   disableSelectFor?: string[];
   disableAsSelectedFor?: string[];
+  isDeveloper?: boolean;
   addDocumentCallback?: (contentId: string) => void;
 }) {
   const selectedCardsFiltered = selectedCards?.filter((s) => s);
@@ -142,6 +144,7 @@ export default function CardList({
               : undefined
           }
           selectCallback={selectCallback}
+          isDeveloper={isDeveloper}
           addDocumentCallback={addDocumentCallback}
           disableSelect={disableSelectFor?.includes(
             cardContent.content.contentId,

--- a/client/src/_utils/types.ts
+++ b/client/src/_utils/types.ts
@@ -50,7 +50,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   email: string;
-  isDeveloper?: boolean;
+  isAuthor?: boolean;
   numLibrary?: number;
   numCommunity?: number;
 };

--- a/client/src/_utils/types.ts
+++ b/client/src/_utils/types.ts
@@ -50,6 +50,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   email: string;
+  isDeveloper?: boolean;
   numLibrary?: number;
   numCommunity?: number;
 };

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -24,6 +24,7 @@ import {
 
 import {
   loader as siteLoader,
+  action as siteAction,
   SiteHeader,
 } from "./Tools/_framework/Paths/SiteHeader";
 import {
@@ -195,6 +196,7 @@ const router = createBrowserRouter([
       {
         path: "/",
         loader: carouselLoader,
+        action: siteAction,
         // action: homeAction,
         errorElement: <ErrorPage />,
         element: <Home />,

--- a/server/prisma/migrations/20250403054146_init/migration.sql
+++ b/server/prisma/migrations/20250403054146_init/migration.sql
@@ -240,6 +240,7 @@ CREATE TABLE `users` (
     `isAdmin` BOOLEAN NOT NULL DEFAULT false,
     `isLibrary` BOOLEAN NOT NULL DEFAULT false,
     `isAnonymous` BOOLEAN NOT NULL DEFAULT false,
+    `isDeveloper` BOOLEAN NOT NULL DEFAULT false,
 
     UNIQUE INDEX `users_email_key`(`email`),
     FULLTEXT INDEX `users_firstNames_lastNames_idx`(`firstNames`, `lastNames`),

--- a/server/prisma/migrations/20250404014529_init/migration.sql
+++ b/server/prisma/migrations/20250404014529_init/migration.sql
@@ -240,7 +240,7 @@ CREATE TABLE `users` (
     `isAdmin` BOOLEAN NOT NULL DEFAULT false,
     `isLibrary` BOOLEAN NOT NULL DEFAULT false,
     `isAnonymous` BOOLEAN NOT NULL DEFAULT false,
-    `isDeveloper` BOOLEAN NOT NULL DEFAULT false,
+    `isAuthor` BOOLEAN NOT NULL DEFAULT false,
 
     UNIQUE INDEX `users_email_key`(`email`),
     FULLTEXT INDEX `users_firstNames_lastNames_idx`(`firstNames`, `lastNames`),

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -290,7 +290,7 @@ model users {
   isAdmin            Boolean              @default(false)
   isLibrary          Boolean              @default(false)
   isAnonymous        Boolean              @default(false)
-  isDeveloper        Boolean              @default(false)
+  isAuthor           Boolean              @default(false)
   content            content[]
   contentState       contentState[]
   submittedResponses submittedResponses[]

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -290,6 +290,7 @@ model users {
   isAdmin            Boolean              @default(false)
   isLibrary          Boolean              @default(false)
   isAnonymous        Boolean              @default(false)
+  isDeveloper        Boolean              @default(false)
   content            content[]
   contentState       contentState[]
   submittedResponses submittedResponses[]

--- a/server/src/query/user.ts
+++ b/server/src/query/user.ts
@@ -57,6 +57,7 @@ export async function getUserInfo({
       lastNames: true,
       isAnonymous: true,
       isAdmin: true,
+      isDeveloper: true,
     },
   });
   return { user };
@@ -119,4 +120,17 @@ export async function updateUser({
   });
   const { isLibrary: _isLibrary, ...userNoLibrary } = user;
   return userNoLibrary;
+}
+
+export async function setIsDeveloper({
+  loggedInUserId,
+  isDeveloper,
+}: {
+  loggedInUserId: Uint8Array;
+  isDeveloper: boolean;
+}) {
+  await prisma.users.update({
+    where: { userId: loggedInUserId },
+    data: { isDeveloper },
+  });
 }

--- a/server/src/query/user.ts
+++ b/server/src/query/user.ts
@@ -57,7 +57,7 @@ export async function getUserInfo({
       lastNames: true,
       isAnonymous: true,
       isAdmin: true,
-      isDeveloper: true,
+      isAuthor: true,
     },
   });
   return { user };
@@ -122,15 +122,15 @@ export async function updateUser({
   return userNoLibrary;
 }
 
-export async function setIsDeveloper({
+export async function setIsAuthor({
   loggedInUserId,
-  isDeveloper,
+  isAuthor,
 }: {
   loggedInUserId: Uint8Array;
-  isDeveloper: boolean;
+  isAuthor: boolean;
 }) {
   await prisma.users.update({
     where: { userId: loggedInUserId },
-    data: { isDeveloper },
+    data: { isAuthor },
   });
 }

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -1,11 +1,7 @@
 import express from "express";
 import { requireLoggedIn } from "../middleware/validationMiddleware";
-import {
-  getUserInfoIfLoggedIn,
-  setIsDeveloper,
-  updateUser,
-} from "../query/user";
-import { setIsDeveloperSchema, userNamesSchema } from "../schemas/userSchemas";
+import { getUserInfoIfLoggedIn, setIsAuthor, updateUser } from "../query/user";
+import { setIsAuthorSchema, userNamesSchema } from "../schemas/userSchemas";
 import {
   queryLoggedIn,
   queryOptionalLoggedInNoArguments,
@@ -25,7 +21,7 @@ userRouter.get(
 );
 
 userRouter.post(
-  "/setIsDeveloper",
+  "/setIsAuthor",
   requireLoggedIn,
-  queryLoggedIn(setIsDeveloper, setIsDeveloperSchema),
+  queryLoggedIn(setIsAuthor, setIsAuthorSchema),
 );

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -1,7 +1,11 @@
 import express from "express";
 import { requireLoggedIn } from "../middleware/validationMiddleware";
-import { getUserInfoIfLoggedIn, updateUser } from "../query/user";
-import { userNamesSchema } from "../schemas/userSchemas";
+import {
+  getUserInfoIfLoggedIn,
+  setIsDeveloper,
+  updateUser,
+} from "../query/user";
+import { setIsDeveloperSchema, userNamesSchema } from "../schemas/userSchemas";
 import {
   queryLoggedIn,
   queryOptionalLoggedInNoArguments,
@@ -18,4 +22,10 @@ userRouter.post(
 userRouter.get(
   "/getUser",
   queryOptionalLoggedInNoArguments(getUserInfoIfLoggedIn),
+);
+
+userRouter.post(
+  "/setIsDeveloper",
+  requireLoggedIn,
+  queryLoggedIn(setIsDeveloper, setIsDeveloperSchema),
 );

--- a/server/src/schemas/userSchemas.ts
+++ b/server/src/schemas/userSchemas.ts
@@ -4,3 +4,7 @@ export const userNamesSchema = z.object({
   firstNames: z.string(),
   lastNames: z.string(),
 });
+
+export const setIsDeveloperSchema = z.object({
+  isDeveloper: z.boolean(),
+});

--- a/server/src/schemas/userSchemas.ts
+++ b/server/src/schemas/userSchemas.ts
@@ -5,6 +5,6 @@ export const userNamesSchema = z.object({
   lastNames: z.string(),
 });
 
-export const setIsDeveloperSchema = z.object({
-  isDeveloper: z.boolean(),
+export const setIsAuthorSchema = z.object({
+  isAuthor: z.boolean(),
 });

--- a/server/src/test/folder.test.ts
+++ b/server/src/test/folder.test.ts
@@ -379,7 +379,7 @@ test(
     const {
       isAdmin: _isAdmin1,
       isAnonymous: _isAnonymous1,
-      isDeveloper: _isDeveloper1,
+      isAuthor: _isAuthor1,
       ...userFields1
     } = user1;
     let user2 = await createTestUser();
@@ -392,7 +392,7 @@ test(
     const {
       isAdmin: _isAdmin2,
       isAnonymous: _isAnonymous2,
-      isDeveloper: _isDeveloper2,
+      isAuthor: _isAuthor2,
       ...userFields2
     } = user2;
     const user3 = await createTestUser();

--- a/server/src/test/folder.test.ts
+++ b/server/src/test/folder.test.ts
@@ -379,6 +379,7 @@ test(
     const {
       isAdmin: _isAdmin1,
       isAnonymous: _isAnonymous1,
+      isDeveloper: _isDeveloper1,
       ...userFields1
     } = user1;
     let user2 = await createTestUser();
@@ -391,6 +392,7 @@ test(
     const {
       isAdmin: _isAdmin2,
       isAnonymous: _isAnonymous2,
+      isDeveloper: _isDeveloper2,
       ...userFields2
     } = user2;
     const user3 = await createTestUser();

--- a/server/src/test/share.test.ts
+++ b/server/src/test/share.test.ts
@@ -74,7 +74,7 @@ describe("Share tests", () => {
     const ownerId = owner.userId;
     const user = await createTestUser();
     const userId = user.userId;
-    const { isAdmin, isAnonymous, isDeveloper, ...userFields } = user;
+    const { isAdmin, isAnonymous, isAuthor, ...userFields } = user;
 
     const { contentId: publicFolderId } = await createContent({
       loggedInUserId: ownerId,
@@ -542,7 +542,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin1,
         isAnonymous: _isAnonymous1,
-        isDeveloper: _isDeveloper1,
+        isAuthor: _isAuthor1,
         ...userFields1
       } = user1;
       let user2 = await createTestUser();
@@ -555,7 +555,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin2,
         isAnonymous: _isAnonymous2,
-        isDeveloper: _isDeveloper2,
+        isAuthor: _isAuthor2,
         ...userFields2
       } = user2;
       let user3 = await createTestUser();
@@ -568,7 +568,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin3,
         isAnonymous: _isAnonymous3,
-        isDeveloper: _isDeveloper3,
+        isAuthor: _isAuthor3,
         ...userFields3
       } = user3;
 
@@ -1066,7 +1066,7 @@ describe("Share tests", () => {
     const {
       isAdmin: _isAdmin,
       isAnonymous: _isAnonymous,
-      isDeveloper: _isDeveloper,
+      isAuthor: _isAuthor,
       ...userFields
     } = user;
 

--- a/server/src/test/share.test.ts
+++ b/server/src/test/share.test.ts
@@ -74,7 +74,7 @@ describe("Share tests", () => {
     const ownerId = owner.userId;
     const user = await createTestUser();
     const userId = user.userId;
-    const { isAdmin, isAnonymous, ...userFields } = user;
+    const { isAdmin, isAnonymous, isDeveloper, ...userFields } = user;
 
     const { contentId: publicFolderId } = await createContent({
       loggedInUserId: ownerId,
@@ -542,6 +542,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin1,
         isAnonymous: _isAnonymous1,
+        isDeveloper: _isDeveloper1,
         ...userFields1
       } = user1;
       let user2 = await createTestUser();
@@ -554,6 +555,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin2,
         isAnonymous: _isAnonymous2,
+        isDeveloper: _isDeveloper2,
         ...userFields2
       } = user2;
       let user3 = await createTestUser();
@@ -566,6 +568,7 @@ describe("Share tests", () => {
       const {
         isAdmin: _isAdmin3,
         isAnonymous: _isAnonymous3,
+        isDeveloper: _isDeveloper3,
         ...userFields3
       } = user3;
 
@@ -1063,6 +1066,7 @@ describe("Share tests", () => {
     const {
       isAdmin: _isAdmin,
       isAnonymous: _isAnonymous,
+      isDeveloper: _isDeveloper,
       ...userFields
     } = user;
 

--- a/server/src/test/users.test.ts
+++ b/server/src/test/users.test.ts
@@ -4,7 +4,7 @@ import { fromUUID } from "../utils/uuid";
 import {
   findOrCreateUser,
   getUserInfo,
-  setIsDeveloper,
+  setIsAuthor,
   updateUser,
   upgradeAnonymousUser,
 } from "../query/user";
@@ -91,13 +91,13 @@ test("turn developer mode on and off", async () => {
   const { userId } = await createTestUser();
 
   let userInfo = await getUserInfo({ loggedInUserId: userId });
-  expect(userInfo.user.isDeveloper).eq(false);
+  expect(userInfo.user.isAuthor).eq(false);
 
-  await setIsDeveloper({ loggedInUserId: userId, isDeveloper: true });
+  await setIsAuthor({ loggedInUserId: userId, isAuthor: true });
   userInfo = await getUserInfo({ loggedInUserId: userId });
-  expect(userInfo.user.isDeveloper).eq(true);
+  expect(userInfo.user.isAuthor).eq(true);
 
-  await setIsDeveloper({ loggedInUserId: userId, isDeveloper: false });
+  await setIsAuthor({ loggedInUserId: userId, isAuthor: false });
   userInfo = await getUserInfo({ loggedInUserId: userId });
-  expect(userInfo.user.isDeveloper).eq(false);
+  expect(userInfo.user.isAuthor).eq(false);
 });

--- a/server/src/test/users.test.ts
+++ b/server/src/test/users.test.ts
@@ -4,6 +4,7 @@ import { fromUUID } from "../utils/uuid";
 import {
   findOrCreateUser,
   getUserInfo,
+  setIsDeveloper,
   updateUser,
   upgradeAnonymousUser,
 } from "../query/user";
@@ -84,4 +85,19 @@ test("upgrade anonymous user", async () => {
 
   expect(upgraded.isAnonymous).eq(false);
   expect(upgraded.email).eq(realEmail);
+});
+
+test("turn developer mode on and off", async () => {
+  const { userId } = await createTestUser();
+
+  let userInfo = await getUserInfo({ loggedInUserId: userId });
+  expect(userInfo.user.isDeveloper).eq(false);
+
+  await setIsDeveloper({ loggedInUserId: userId, isDeveloper: true });
+  userInfo = await getUserInfo({ loggedInUserId: userId });
+  expect(userInfo.user.isDeveloper).eq(true);
+
+  await setIsDeveloper({ loggedInUserId: userId, isDeveloper: false });
+  userInfo = await getUserInfo({ loggedInUserId: userId });
+  expect(userInfo.user.isDeveloper).eq(false);
 });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -39,7 +39,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   email: string;
-  isDeveloper?: boolean;
+  isAuthor?: boolean;
   numLibrary?: number;
   numCommunity?: number;
 };

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -39,6 +39,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   email: string;
+  isDeveloper?: boolean;
   numLibrary?: number;
   numCommunity?: number;
 };


### PR DESCRIPTION
This PR adds an `isAuthor` flag to the user record, which defaults to `false`. The idea is to insulate new users from the DoenetML source code until they turn on author mode.

If `isAuthor` is `false`, then the activity editor and viewer default to view mode for documents, and the edit button displays a message prompting to turn on author mode.  if `isAuthor` is `true`,  the activity editor and viewer default to edit mode.

If `isAuthor` is `false`,  the new document menu items in Activities and the compound activity editor display a message prompting to turn on author mode.