### PR TITLE
Fix regression in magic link login

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -155,11 +155,11 @@ passport.use(
 
       sendEmail();
     },
-    async (user: { email: string; fromAnonymous: string | number }) => {
+    async (user: { email: string; fromAnonymous: string }) => {
       return {
         provider: "magiclink",
         email: user.email as string,
-        fromAnonymous: user.fromAnonymous || "",
+        fromAnonymous: user.fromAnonymous,
       };
     },
   ),
@@ -175,7 +175,7 @@ passport.serializeUser<any, any>(async (req, user: any, done) => {
 
     let u;
 
-    if (fromAnonymous !== "") {
+    if (fromAnonymous !== " ") {
       try {
         u = await upgradeAnonymousUser({
           userId: toUUID(fromAnonymous),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -345,6 +345,8 @@ app.post(
     if (req.user?.isAnonymous) {
       // req.user.userId is the string you serialized in serializeUser
       req.body.fromAnonymous = fromUUID(req.user.userId);
+    } else {
+      req.body.fromAnonymous = " ";
     }
     next();
   },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -346,6 +346,7 @@ app.post(
       // req.user.userId is the string you serialized in serializeUser
       req.body.fromAnonymous = fromUUID(req.user.userId);
     } else {
+      // add blank `fromAnonymous` field as magic link is configured to expect `userFields: ["email", "fromAnonymous"]`
       req.body.fromAnonymous = " ";
     }
     next();


### PR DESCRIPTION
Fix a regression from #2555 where non-anonymous login using magic link was unauthorized due to missing fields.