### PR TITLE
Refactor license APIs and widgets

### DIFF
--- a/client/src/RouterLogo.tsx
+++ b/client/src/RouterLogo.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
 
-const LogoButton = styled.button<{ hasLink: boolean }>`
+const LogoButton = styled.button`
   background-image:
     linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0)),
     url("/Doenet_Logo_Frontpage_color_small_text.png");
@@ -21,23 +21,20 @@ const LogoButton = styled.button<{ hasLink: boolean }>`
   // border-radius: 50%;
   margin-top: 2px;
   margin-left: 10px;
-  cursor: ${(props) => (props.hasLink ? "pointer" : "default")};
+  cursor: pointer;
   &:focus {
     outline: 2px solid var(--canvastext);
     outline-offset: 2px;
   }
 `;
 
-export default function RouterLogo({ hasLink = true }: { hasLink?: boolean }) {
+export default function RouterLogo() {
   const navigate = useNavigate();
 
   return (
     <LogoButton
-      hasLink={hasLink}
       onClick={() => {
-        if (hasLink) {
-          navigate("/");
-        }
+        navigate("/");
       }}
     />
   );

--- a/client/src/drawerTabs/CurateSettings.tsx
+++ b/client/src/drawerTabs/CurateSettings.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { FetcherWithComponents } from "react-router";
 import {
-  Box,
-  List,
   Button,
   UnorderedList,
   ListItem,
@@ -11,8 +9,8 @@ import {
   Heading,
 } from "@chakra-ui/react";
 import axios from "axios";
-import { Content, LibraryComment, LibraryRelations } from "../types";
-import { DisplayLicenseItem } from "../widgets/Licenses";
+import { Content, LibraryComment, LibraryRelations, License } from "../types";
+import { LicenseDrawerBox, LicenseDescription } from "../widgets/Licenses";
 import { createNameCheckIsMeTag, createNameNoTag } from "../utils/names";
 import { ChatConversation } from "../widgets/ChatConversation";
 import { DateTime } from "luxon";
@@ -55,15 +53,17 @@ export function CurateSettings({
   contentData,
   libraryRelations,
   libraryComments,
+  allLicenses,
   onClose,
 }: {
   fetcher: FetcherWithComponents<any>;
   contentData: Content;
   libraryRelations: LibraryRelations;
   libraryComments: LibraryComment[];
+  allLicenses: License[];
   onClose: () => void;
 }) {
-  const license = contentData.license!;
+  const licenseCode = contentData.licenseCode!;
 
   // Must have library source if in library
   const librarySource = libraryRelations.source!;
@@ -195,35 +195,13 @@ export function CurateSettings({
         />
       )}
 
-      <Box
-        marginTop="30px"
-        border="2px solid lightgray"
-        background="lightgray"
-        padding="10px"
-      >
-        <>
-          {license.isComposition ? (
-            <>
-              <p>Activity is shared with these licenses:</p>
-              <List spacing="20px" marginTop="10px">
-                {license.composedOf.map((comp) => (
-                  <DisplayLicenseItem licenseItem={comp} key={comp.code} />
-                ))}
-              </List>
-              <p style={{ marginTop: "10px" }}>
-                (You authorize reuse under any of these licenses.)
-              </p>
-            </>
-          ) : (
-            <>
-              <p>Activity is shared using the license:</p>
-              <List marginTop="10px">
-                <DisplayLicenseItem licenseItem={license} />
-              </List>
-            </>
-          )}
-        </>
-      </Box>
+      <LicenseDrawerBox>
+        <LicenseDescription
+          code={licenseCode}
+          contentType={contentData.type}
+          allLicenses={allLicenses}
+        />
+      </LicenseDrawerBox>
     </>
   );
 }

--- a/client/src/drawerTabs/GeneralContentInfo.tsx
+++ b/client/src/drawerTabs/GeneralContentInfo.tsx
@@ -3,28 +3,27 @@ import {
   Box,
   Heading,
   Icon,
-  List,
   ListItem,
+  Text,
   Tooltip,
   UnorderedList,
 } from "@chakra-ui/react";
-import { Content } from "../types";
-import { InfoIcon } from "@chakra-ui/icons";
-import { DisplayLicenseItem } from "../widgets/Licenses";
-import { createNameCheckCurateTag } from "../utils/names";
+import { Content, License } from "../types";
+import { LicenseDrawerBox, LicenseDescription } from "../widgets/Licenses";
 import { activityFeatureIcons } from "../utils/activity";
 
-export function GeneralContentInfo({ contentData }: { contentData: Content }) {
-  const license = contentData.license;
-  const contentType = contentData.type === "folder" ? "Folder" : "Activity";
-
+export function GeneralContentInfo({
+  contentData,
+  allLicenses,
+}: {
+  contentData: Content;
+  allLicenses: License[];
+}) {
   const containsFeatures = contentData.contentFeatures.length > 0;
-
-  const ownerName = createNameCheckCurateTag(contentData.owner!);
 
   return (
     <Box>
-      {contentData.type !== "folder" && containsFeatures ? (
+      {contentData.type !== "folder" && containsFeatures && (
         <Box borderBottom="2px" marginBottom={4} paddingBottom={4}>
           <Heading size="sm">Activity features</Heading>
           <UnorderedList>
@@ -50,59 +49,30 @@ export function GeneralContentInfo({ contentData }: { contentData: Content }) {
             })}
           </UnorderedList>
         </Box>
-      ) : null}
+      )}
 
-      <Box borderBottom="2px" marginBottom={4} paddingBottom={4}>
-        {license === null ? (
-          <Box
-            marginTop="10px"
-            border="2px solid black"
-            background="orange.100"
-            padding="5px"
-          >
-            <InfoIcon color="orange.500" mr="2px" /> {contentType} is shared
-            without specifying a license. Please select a license below to
-            inform other how they can use your content.
-          </Box>
-        ) : license.isComposition ? (
-          <>
-            <p>
-              <em>{contentData.name}</em> by {ownerName} is shared with these
-              licenses:
-            </p>
-            <List spacing="20px" marginTop="10px">
-              {license.composedOf.map((comp) => (
-                <DisplayLicenseItem licenseItem={comp} key={comp.code} />
-              ))}
-            </List>
-            <p style={{ marginTop: "10px" }}>
-              (You are free to use either of these licenses when reusing this
-              work.)
-            </p>
-          </>
-        ) : (
-          <>
-            <p>
-              <em>{contentData.name}</em> by {ownerName} is shared with the
-              license:
-            </p>
-            <List marginTop="10px">
-              <DisplayLicenseItem licenseItem={license} />
-            </List>
-          </>
-        )}
-      </Box>
+      <LicenseDrawerBox>
+        <LicenseDescription
+          code={contentData.licenseCode}
+          contentType={contentData.type}
+          allLicenses={allLicenses}
+          title={contentData.name}
+          author={contentData.owner}
+        />
+      </LicenseDrawerBox>
 
       {contentData.type === "singleDoc" &&
-      (contentData.numVariants ?? 1) > 1 ? (
-        <Box marginBottom="20px">
-          This document has {contentData.numVariants} variants.
-        </Box>
-      ) : null}
+        (contentData.numVariants ?? 1) > 1 && (
+          <Text marginTop="20px">
+            This document has {contentData.numVariants} variants.
+          </Text>
+        )}
 
-      {contentData.type === "singleDoc"
-        ? `DoenetML version: ${contentData.doenetmlVersion.fullVersion}`
-        : null}
+      {contentData.type === "singleDoc" && (
+        <Text marginTop="20px">
+          DoenetML version: {contentData.doenetmlVersion.fullVersion}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/client/src/drawerTabs/ShareSettings.tsx
+++ b/client/src/drawerTabs/ShareSettings.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   Text,
   HStack,
-  List,
   Input,
   Spinner,
   TableContainer,
@@ -26,11 +25,11 @@ import {
   Hide,
   Button,
 } from "@chakra-ui/react";
-import { InfoIcon, WarningIcon } from "@chakra-ui/icons";
+import { WarningIcon } from "@chakra-ui/icons";
 import axios, { AxiosError } from "axios";
 import { createNameNoTag } from "../utils/names";
 import { Content, License, LicenseCode } from "../types";
-import { DisplayLicenseItem } from "../widgets/Licenses";
+import { LicenseDrawerBox, LicenseDescription } from "../widgets/Licenses";
 import { contentTypeToName } from "../utils/activity";
 
 export async function sharingActions({ formObj }: { [k: string]: any }) {
@@ -107,12 +106,16 @@ export function ShareSettings({
   allLicenses: License[];
   remixedWithLicense: LicenseCode | null;
 }) {
-  const license = contentData.license;
+  const licenseCode = contentData.licenseCode;
 
   const [selectedIsPublic, setSelectedIsPublic] = useState(
     contentData.isPublic,
   );
-  const [selectedLicenseCode, setSelectedLicenseCode] = useState(license?.code);
+
+  // TO REVIEW: Is this logic ok?
+  const [selectedLicenseCode, setSelectedLicenseCode] = useState(
+    licenseCode ?? "CCDUAL",
+  );
 
   const [shareWithEmail, setShareWithEmail] = useState("");
   const [showSpinner, setShowSpinner] = useState<{
@@ -128,8 +131,9 @@ export function ShareSettings({
   const shareSubmitButton = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    setSelectedLicenseCode(license?.code);
-  }, [license?.code]);
+    // TO REVIEW: Is this logic ok?
+    setSelectedLicenseCode(licenseCode ?? "CCDUAL");
+  }, [licenseCode]);
 
   useEffect(() => {
     setSelectedIsPublic(contentData.isPublic);
@@ -540,69 +544,30 @@ export function ShareSettings({
         {licenseWarning}
       </Box>
 
-      <Box>
-        <Box
-          marginTop="20px"
-          border="2px solid lightgray"
-          background="lightgray"
-          padding="10px"
-        >
-          {!(contentData.isPublic || contentData.isShared) ? (
-            contentData.type === "folder" ? (
-              <p>
-                Folder is private. However, shared items within the folder can
-                still be found.
-              </p>
-            ) : contentData.type === "singleDoc" ? (
-              <p>Activity is private.</p>
-            ) : (
-              <p>
-                This {contentTypeNameLower} is private. However, shared items
-                within the {contentTypeNameLower} can still be found.
-              </p>
-            )
-          ) : license === null ? (
-            <Box
-              marginTop="10px"
-              border="2px solid black"
-              background="orange.100"
-              padding="5px"
-            >
-              <InfoIcon color="orange.500" mr="2px" /> This{" "}
-              {contentTypeNameLower} is shared without specifying a license.
-              Please select a license below to inform other how they can use
-              your content.
-            </Box>
+      <LicenseDrawerBox>
+        {!(contentData.isPublic || contentData.isShared) ? (
+          contentData.type === "folder" ? (
+            <p>
+              Folder is private. However, shared items within the folder can
+              still be found.
+            </p>
+          ) : contentData.type === "singleDoc" ? (
+            <p>Activity is private.</p>
           ) : (
-            <>
-              {license.isComposition ? (
-                <>
-                  <p>
-                    This {contentTypeNameLower} is shared with these licenses:
-                  </p>
-                  <List spacing="20px" marginTop="10px">
-                    {license.composedOf.map((comp) => (
-                      <DisplayLicenseItem licenseItem={comp} key={comp.code} />
-                    ))}
-                  </List>
-                  <p style={{ marginTop: "10px" }}>
-                    (You authorize reuse under any of these licenses.)
-                  </p>
-                </>
-              ) : (
-                <>
-                  <p>
-                    This {contentTypeNameLower} is shared using the license:
-                  </p>
-                  <List marginTop="10px">
-                    <DisplayLicenseItem licenseItem={license} />
-                  </List>
-                </>
-              )}
-            </>
-          )}
-        </Box>
-      </Box>
+            <p>
+              This {contentTypeNameLower} is private. However, shared items
+              within the {contentTypeNameLower} can still be found.
+            </p>
+          )
+        ) : (
+          <LicenseDescription
+            code={licenseCode}
+            allLicenses={allLicenses}
+            contentType={contentData.type}
+            audience="author"
+          />
+        )}
+      </LicenseDrawerBox>
     </>
   );
 }

--- a/client/src/drawers/ContentInfoDrawer.tsx
+++ b/client/src/drawers/ContentInfoDrawer.tsx
@@ -15,7 +15,12 @@ import {
   Text,
   Tooltip,
 } from "@chakra-ui/react";
-import { ActivityRemixItem, Content, LibraryRelations } from "../types";
+import {
+  ActivityRemixItem,
+  Content,
+  LibraryRelations,
+  License,
+} from "../types";
 import { GeneralContentInfo } from "../drawerTabs/GeneralContentInfo";
 import { ClassificationInfo } from "../drawerTabs/ClassificationInfo";
 import axios from "axios";
@@ -29,6 +34,7 @@ export function ContentInfoDrawer({
   finalFocusRef,
   contentData,
   displayTab = "general",
+  allLicenses,
 }: {
   isOpen: boolean;
   onClose: () => void;
@@ -36,6 +42,7 @@ export function ContentInfoDrawer({
   contentData: Content;
   libraryRelations?: LibraryRelations;
   displayTab?: "general" | "classifications";
+  allLicenses: License[];
 }) {
   let initialTabIndex: number;
   switch (displayTab) {
@@ -138,7 +145,10 @@ export function ContentInfoDrawer({
             <Box height="calc(100vh - 130px)">
               <TabPanels height="100%">
                 <TabPanel height="100%">
-                  <GeneralContentInfo contentData={contentData} />
+                  <GeneralContentInfo
+                    contentData={contentData}
+                    allLicenses={allLicenses}
+                  />
                 </TabPanel>
                 {contentData.type !== "folder" ? (
                   <TabPanel overflowY="hidden" height="100%">

--- a/client/src/drawers/ShareDrawer.tsx
+++ b/client/src/drawers/ShareDrawer.tsx
@@ -157,6 +157,7 @@ export function ShareDrawer({
       contentData={contentData}
       libraryRelations={libraryRelations}
       libraryComments={libraryComments}
+      allLicenses={allLicenses}
       onClose={onClose}
     />
   ) : (

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -57,7 +57,6 @@ import {
   UserInfo,
   LibraryRelations,
   DoenetmlVersion,
-  License,
   ContentFeature,
 } from "../types";
 import { MdClose, MdOutlineSearch } from "react-icons/md";
@@ -188,7 +187,6 @@ export async function loader({ params, request }: any) {
     content: data.content,
     libraryRelations: data.libraryRelations,
     allDoenetmlVersions: data.allDoenetmlVersions,
-    allLicenses: data.allLicenses,
     availableFeatures: data.availableFeatures,
     userId: params.userId,
     parent: data.parent,
@@ -202,7 +200,6 @@ export function Activities() {
     content,
     libraryRelations,
     allDoenetmlVersions,
-    allLicenses,
     availableFeatures,
     userId,
     parent,
@@ -212,7 +209,6 @@ export function Activities() {
     content: Content[];
     libraryRelations: LibraryRelations[];
     allDoenetmlVersions: DoenetmlVersion[];
-    allLicenses: License[];
     availableFeatures: ContentFeature[];
     userId: string;
     parent: Content | null;
@@ -251,7 +247,8 @@ export function Activities() {
     onClose: deleteContentOnClose,
   } = useDisclosure();
 
-  const { addTo, setAddTo, user } = useOutletContext<SiteContext>();
+  const { addTo, setAddTo, user, allLicenses } =
+    useOutletContext<SiteContext>();
 
   // refs to the menu button of each content card,
   // which should be given focus when drawers are closed
@@ -978,7 +975,7 @@ export function Activities() {
         isPublic: activity.isPublic,
         isShared: activity.isShared,
         sharedWith: activity.sharedWith,
-        licenseCode: activity.license?.code ?? null,
+        licenseCode: activity.licenseCode ?? null,
         parentId: activity.parent?.contentId ?? null,
       }),
       cardLink:
@@ -996,6 +993,7 @@ export function Activities() {
       showActivityFeatures={true}
       emptyMessage={emptyMessage}
       content={cardContent}
+      allLicenses={allLicenses}
       selectedCards={selectedCards}
       setSelectedCards={setSelectedCards}
       disableSelectFor={addTo ? [addTo.contentId] : undefined}

--- a/client/src/paths/ActivityEditor.tsx
+++ b/client/src/paths/ActivityEditor.tsx
@@ -55,7 +55,6 @@ import {
   Content,
   ContentFeature,
   DoenetmlVersion,
-  License,
   ContentDescription,
   LibraryRelations,
   ContentRevision,
@@ -168,10 +167,6 @@ export async function loader({ params }: { params: any }) {
   // }
 
   const {
-    data: { allLicenses },
-  } = await axios.get("/api/info/getAllLicenses");
-
-  const {
     data: { allDoenetmlVersions },
   } = await axios.get("/api/info/getAllDoenetmlVersions");
 
@@ -188,7 +183,6 @@ export async function loader({ params }: { params: any }) {
       contentId,
       // supportingFileData,
       allDoenetmlVersions,
-      allLicenses,
       availableFeatures,
       libraryRelations,
       revisions,
@@ -204,7 +198,6 @@ export async function loader({ params }: { params: any }) {
       contentId,
       // supportingFileData,
       allDoenetmlVersions,
-      allLicenses,
       availableFeatures,
       libraryRelations,
       revisions,
@@ -263,7 +256,6 @@ export function ActivityEditor() {
   const data = useLoaderData() as {
     contentId: string;
     allDoenetmlVersions: DoenetmlVersion[];
-    allLicenses: License[];
     availableFeatures: ContentFeature[];
     activityData: Content;
     addTo: ContentDescription | undefined;
@@ -285,11 +277,12 @@ export function ActivityEditor() {
     contentId,
     activityData,
     allDoenetmlVersions,
-    allLicenses,
     availableFeatures,
     libraryRelations,
     revisions,
   } = data;
+
+  const { allLicenses } = useOutletContext<SiteContext>();
 
   const finalFocusRef = useRef<HTMLElement | null>(null);
   const curateBtnRef = useRef<HTMLButtonElement>(null);

--- a/client/src/paths/ActivityViewer.tsx
+++ b/client/src/paths/ActivityViewer.tsx
@@ -64,8 +64,7 @@ import { ActivitySource, isActivitySource } from "../viewerTypes";
 import { processRemixes } from "../utils/processRemixes";
 import ContributorsMenu from "../dropdowns/ContributorsMenu";
 import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
-import { createNameCheckCurateTag } from "../utils/names";
-import { DisplayLicenseItem } from "../widgets/Licenses";
+import { LicenseDescription } from "../widgets/Licenses";
 import { SiteContext } from "./SiteHeader";
 import {
   AddContentToMenu,
@@ -161,7 +160,8 @@ export function ActivityViewer() {
   const { contentId, activityData, contributorHistory, libraryRelations } =
     data;
 
-  const { user, addTo, setAddTo } = useOutletContext<SiteContext>();
+  const { user, allLicenses, addTo, setAddTo } =
+    useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const infoBtnRef = useRef<HTMLButtonElement>(null);
@@ -228,6 +228,7 @@ export function ActivityViewer() {
       contentData={contentData}
       libraryRelations={libraryRelations}
       displayTab={displayInfoTab}
+      allLicenses={allLicenses}
     />
   ) : null;
 
@@ -298,7 +299,6 @@ export function ActivityViewer() {
   }
 
   const contentTypeName = contentTypeToName[data.type];
-  const ownerName = createNameCheckCurateTag(activityData.owner!);
 
   const { iconImage, iconColor } = getIconInfo(data.type);
 
@@ -636,46 +636,13 @@ export function ActivityViewer() {
               minHeight="20vh"
             >
               <Box width={haveClassifications ? "70%" : "100%"}>
-                {activityData.license ? (
-                  activityData.license.isComposition ? (
-                    <>
-                      <p>
-                        <strong>{activityData.name}</strong> by {ownerName} is
-                        shared with these licenses:
-                      </p>
-                      <List spacing="20px" marginTop="10px">
-                        {activityData.license.composedOf.map((comp) => (
-                          <DisplayLicenseItem
-                            licenseItem={comp}
-                            key={comp.code}
-                          />
-                        ))}
-                      </List>
-                      <p style={{ marginTop: "10px" }}>
-                        You are free to use either license when reusing this
-                        work.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p>
-                        <strong>{activityData.name}</strong> by {ownerName} is
-                        shared using the license:
-                      </p>
-                      <List marginTop="10px">
-                        <DisplayLicenseItem
-                          licenseItem={activityData.license}
-                        />
-                      </List>
-                    </>
-                  )
-                ) : (
-                  <p>
-                    <strong>{activityData.name}</strong> by {ownerName} is
-                    shared, but a license was not specified. Contact the author
-                    to determine in what ways you can reuse this activity.
-                  </p>
-                )}
+                <LicenseDescription
+                  code={activityData.licenseCode}
+                  contentType={activityData.type}
+                  allLicenses={allLicenses}
+                  title={activityData.name}
+                  author={activityData.owner}
+                />
               </Box>
               {haveClassifications ? (
                 <Box

--- a/client/src/paths/CodeViewer.tsx
+++ b/client/src/paths/CodeViewer.tsx
@@ -93,7 +93,7 @@ export function CodeViewer() {
     onClose: infoOnClose,
   } = useDisclosure();
 
-  const { user } = useOutletContext<SiteContext>();
+  const { user, allLicenses } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const label = activityData?.name ?? "Public Editor";
@@ -118,6 +118,7 @@ export function CodeViewer() {
             isOpen={infoIsOpen}
             onClose={infoOnClose}
             contentData={activityData}
+            allLicenses={allLicenses}
           />
         </>
       ) : null}

--- a/client/src/paths/Curate.tsx
+++ b/client/src/paths/Curate.tsx
@@ -21,6 +21,7 @@ import {
   Link,
   useFetcher,
   ActionFunctionArgs,
+  useOutletContext,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
@@ -31,7 +32,6 @@ import {
   ContentFeature,
   DoenetmlVersion,
   LibraryRelations,
-  License,
 } from "../types";
 import { createNameCheckIsMeTag, createNameNoTag } from "../utils/names";
 import { intWithCommas } from "../utils/formatting";
@@ -41,6 +41,7 @@ import {
 } from "../drawers/ContentSettingsDrawer";
 import { ShareDrawer, shareDrawerActions } from "../drawers/ShareDrawer";
 import { DateTime } from "luxon";
+import { SiteContext } from "./SiteHeader";
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
@@ -78,7 +79,6 @@ export function Curate() {
     publishedLibraryRelations,
     allDoenetmlVersions,
     availableFeatures,
-    allLicenses,
   } = useLoaderData() as {
     pendingContent: Content[];
     pendingLibraryRelations: LibraryRelations[];
@@ -90,8 +90,9 @@ export function Curate() {
     publishedLibraryRelations: LibraryRelations[];
     allDoenetmlVersions: DoenetmlVersion[];
     availableFeatures: ContentFeature[];
-    allLicenses: License[];
   };
+
+  const { allLicenses } = useOutletContext<SiteContext>();
 
   useEffect(() => {
     document.title = `Curate - Doenet`;
@@ -187,6 +188,7 @@ export function Curate() {
           showOwnerName={true}
           showLibraryEditor={showLibraryEditor}
           content={cardContent}
+          allLicenses={allLicenses}
           emptyMessage={"No Activities Found!"}
         />
       </Box>

--- a/client/src/paths/Explore.tsx
+++ b/client/src/paths/Explore.tsx
@@ -223,6 +223,7 @@ export function Explore() {
 
   const {
     user,
+    allLicenses,
     exploreTab: currentTab,
     setExploreTab: setCurrentTab,
     addTo,
@@ -270,6 +271,7 @@ export function Explore() {
       isOpen={infoIsOpen}
       onClose={infoOnClose}
       contentData={infoContentData}
+      allLicenses={allLicenses}
     />
   ) : null;
 
@@ -411,6 +413,7 @@ export function Explore() {
           showActivityFeatures={true}
           showOwnerName={true}
           content={cardContent}
+          allLicenses={allLicenses}
           emptyMessage={"No Matches Found!"}
           selectedCards={user ? selectedCards : undefined}
           setSelectedCards={setSelectedCards}

--- a/client/src/paths/Home.tsx
+++ b/client/src/paths/Home.tsx
@@ -24,6 +24,8 @@ import { HiOutlineMail } from "react-icons/hi";
 import { BsGithub, BsDiscord } from "react-icons/bs";
 import { Content } from "../types";
 import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
+import { useOutletContext } from "react-router";
+import { SiteContext } from "./SiteHeader";
 
 export async function loader() {
   return {};
@@ -92,6 +94,8 @@ export function Home() {
     document.title = `Home - Doenet`;
   }, []);
 
+  const { allLicenses } = useOutletContext<SiteContext>();
+
   const grayColor = useColorModeValue("doenet.mainGray", "doenet.lightGray");
   const blueColor = useColorModeValue("doenet.lightBlue", "doenet.mainBlue");
   const blackColor = "black";
@@ -110,6 +114,7 @@ export function Home() {
       isOpen={infoIsOpen}
       onClose={infoOnClose}
       contentData={infoContentData}
+      allLicenses={allLicenses}
     />
   ) : null;
 

--- a/client/src/paths/LibraryActivities.tsx
+++ b/client/src/paths/LibraryActivities.tsx
@@ -25,6 +25,7 @@ import {
   Link,
   Form,
   ActionFunctionArgs,
+  useOutletContext,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
@@ -45,7 +46,6 @@ import {
   UserInfo,
   ContentType,
   DoenetmlVersion,
-  License,
   LibraryRelations,
 } from "../types";
 import { MdClose, MdOutlineSearch } from "react-icons/md";
@@ -55,6 +55,7 @@ import {
   createLocalContentActions,
 } from "../popups/CreateLocalContent";
 import { ShareDrawer, shareDrawerActions } from "../drawers/ShareDrawer";
+import { SiteContext } from "./SiteHeader";
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
@@ -135,7 +136,6 @@ export async function loader({
     content: data.content,
     libraryRelations: data.libraryRelations,
     allDoenetmlVersions: data.allDoenetmlVersions,
-    allLicenses: data.allLicenses,
     availableFeatures: data.availableFeatures,
     userId: params.userId,
     parent: data.parent,
@@ -149,7 +149,6 @@ export function LibraryActivities() {
     content,
     libraryRelations,
     allDoenetmlVersions,
-    allLicenses,
     availableFeatures,
     userId,
     parent,
@@ -159,12 +158,13 @@ export function LibraryActivities() {
     content: Content[];
     libraryRelations: LibraryRelations[];
     allDoenetmlVersions: DoenetmlVersion[];
-    allLicenses: License[];
     availableFeatures: ContentFeature[];
     userId: string;
     parent: Content | null;
     query: string | null;
   };
+
+  const { allLicenses } = useOutletContext<SiteContext>();
 
   const [settingsContentId, setSettingsContentId] = useState<string | null>(
     null,
@@ -667,7 +667,7 @@ export function LibraryActivities() {
         isPublic: activity.isPublic,
         isShared: activity.isShared,
         sharedWith: activity.sharedWith,
-        licenseCode: activity.license?.code ?? null,
+        licenseCode: activity.licenseCode ?? null,
         parentId: activity.parent?.contentId ?? null,
         isFolder: activity.type === "folder",
       }),
@@ -686,6 +686,7 @@ export function LibraryActivities() {
       showActivityFeatures={true}
       emptyMessage={emptyMessage}
       content={cardContent}
+      allLicenses={allLicenses}
     />
   );
 

--- a/client/src/paths/SharedActivities.tsx
+++ b/client/src/paths/SharedActivities.tsx
@@ -3,7 +3,6 @@ import {
   Flex,
   Heading,
   Tooltip,
-  List,
   MenuItem,
   useDisclosure,
   HStack,
@@ -24,7 +23,7 @@ import { CardContent } from "../widgets/Card";
 import axios from "axios";
 import { createNameNoTag } from "../utils/names";
 import { ContentDescription, Content } from "../types";
-import { DisplayLicenseItem } from "../widgets/Licenses";
+import { LicenseDescription } from "../widgets/Licenses";
 import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
 import CardList from "../widgets/CardList";
 import { menuIcons } from "../utils/activity";
@@ -88,7 +87,8 @@ export function SharedActivities() {
     parent: Content | null;
   };
 
-  const { user, addTo, setAddTo } = useOutletContext<SiteContext>();
+  const { user, allLicenses, addTo, setAddTo } =
+    useOutletContext<SiteContext>();
 
   const [selectedCards, setSelectedCards] = useState<ContentDescription[]>([]);
   const selectedCardsFiltered = selectedCards.filter((c) => c);
@@ -144,6 +144,7 @@ export function SharedActivities() {
         isOpen={infoIsOpen}
         onClose={infoOnClose}
         contentData={contentData}
+        allLicenses={allLicenses}
       />
     ) : null;
 
@@ -317,6 +318,7 @@ export function SharedActivities() {
       showActivityFeatures={true}
       emptyMessage={"No Activities Yet"}
       content={cardContent}
+      allLicenses={allLicenses}
       selectedCards={user ? selectedCards : undefined}
       setSelectedCards={setSelectedCards}
       disableSelectFor={addTo ? [addTo.contentId] : undefined}
@@ -346,43 +348,13 @@ export function SharedActivities() {
         padding="20px"
         minHeight="20vh"
       >
-        {parent ? (
-          parent.license ? (
-            parent.license.isComposition ? (
-              <>
-                <p>
-                  <strong>{parent.name}</strong> by {owner.firstNames}{" "}
-                  {owner.lastNames} is shared with these licenses:
-                </p>
-                <List spacing="20px" marginTop="10px">
-                  {parent.license.composedOf.map((comp) => (
-                    <DisplayLicenseItem licenseItem={comp} key={comp.code} />
-                  ))}
-                </List>
-                <p style={{ marginTop: "10px" }}>
-                  You are free to use either license when reusing this work.
-                </p>
-              </>
-            ) : (
-              <>
-                <p>
-                  <strong>{parent.name}</strong> by {owner.firstNames}{" "}
-                  {owner.lastNames} is shared using the license:
-                </p>
-                <List marginTop="10px">
-                  <DisplayLicenseItem licenseItem={parent.license} />
-                </List>
-              </>
-            )
-          ) : (
-            <p>
-              <strong>{parent.name}</strong> by {owner.firstNames}{" "}
-              {owner.lastNames} is shared, but a license was not specified.
-              Contact the author to determine in what ways you can reuse this
-              activity.
-            </p>
-          )
-        ) : null}
+        {parent && (
+          <LicenseDescription
+            code={parent.licenseCode}
+            contentType={parent.type}
+            allLicenses={allLicenses}
+          />
+        )}
       </Box>
     </>
   );

--- a/client/src/paths/SiteHeader.tsx
+++ b/client/src/paths/SiteHeader.tsx
@@ -32,7 +32,7 @@ import RouterLogo from "../RouterLogo";
 import { ExternalLinkIcon, HamburgerIcon } from "@chakra-ui/icons";
 import axios from "axios";
 import { createNameNoTag } from "../utils/names";
-import { ContentDescription } from "../types";
+import { ContentDescription, License } from "../types";
 
 export type User =
   | {
@@ -48,6 +48,7 @@ export type User =
 
 export type SiteContext = {
   user?: User;
+  allLicenses: License[];
   exploreTab: number | null;
   setExploreTab: (arg: number | null) => void;
   addTo: ContentDescription | null;
@@ -72,7 +73,11 @@ export async function loader() {
     data: { user },
   } = await axios.get("/api/user/getUser");
 
-  return { user };
+  const {
+    data: { allLicenses },
+  } = await axios.get("/api/info/getAllLicenses");
+
+  return { user, allLicenses };
 }
 
 function NavLinkTab({
@@ -164,7 +169,10 @@ function NavLinkDropdownTab({
 }
 
 export function SiteHeader() {
-  const { user } = useLoaderData() as { user?: User };
+  const { user, allLicenses } = useLoaderData() as {
+    user?: User;
+    allLicenses: License[];
+  };
 
   const [exploreTab, setExploreTab] = useState<number | null>(null);
 
@@ -172,6 +180,7 @@ export function SiteHeader() {
 
   const siteContext: SiteContext = {
     user,
+    allLicenses,
     exploreTab,
     setExploreTab,
     addTo,

--- a/client/src/paths/Trash.tsx
+++ b/client/src/paths/Trash.tsx
@@ -13,6 +13,7 @@ import {
   useFetcher,
   Link as ReactRouterLink,
   ActionFunctionArgs,
+  useOutletContext,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
@@ -21,6 +22,7 @@ import axios from "axios";
 import {} from "../popups/MoveCopyContent";
 import { DateTime } from "luxon";
 import { Content } from "../types";
+import { SiteContext } from "./SiteHeader";
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
@@ -49,6 +51,8 @@ export function Trash() {
     content: Content[];
     deletionDates: string[];
   };
+
+  const { allLicenses } = useOutletContext<SiteContext>();
 
   useEffect(() => {
     document.title = `My Trash - Doenet`;
@@ -146,6 +150,7 @@ export function Trash() {
       showActivityFeatures={true}
       emptyMessage={emptyMessage}
       content={cardContent}
+      allLicenses={allLicenses}
     />
   );
 

--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -176,7 +176,7 @@ export function MoveCopyContent({
     const parentIsPublic: boolean = parent?.isPublic ?? false;
     const parentIsShared: boolean = parent?.isShared ?? false;
     const parentSharedWith: UserInfo[] = parent?.sharedWith ?? [];
-    const parentLicenseCode: LicenseCode | null = parent?.license?.code ?? null;
+    const parentLicenseCode: LicenseCode | null = parent?.licenseCode ?? null;
     const grandparentId: string | null = parent?.parent?.contentId ?? null;
     const grandparentType: ContentType = parent?.parent?.type ?? "folder";
     const contentFromApi: Content[] = data.content;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -163,7 +163,7 @@ export type ContentBase = {
   sharedWith: UserInfo[];
   // Content should ~almost always~ have a license.
   // The exception: content without license from old doenet website
-  license: License | null;
+  licenseCode: LicenseCode | null;
   contentFeatures: {
     id: number;
     code: string;

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -188,7 +188,7 @@ export function CompoundActivityEditor({
   const readOnly = asViewer || isAssigned;
   const readOnlyStructure = readOnly || inLibrary;
 
-  const { user, addTo, setAddTo } = useOutletContext<SiteContext>();
+  const { user, allLicenses, addTo, setAddTo } = useOutletContext<SiteContext>();
   const navigate = useNavigate();
 
   const [selectedCards, setSelectedCards] = useState<ContentDescription[]>([]);
@@ -670,7 +670,7 @@ export function CompoundActivityEditor({
               isPublic: content.isPublic,
               isShared: content.isShared,
               sharedWith: content.sharedWith,
-              licenseCode: content.license?.code ?? null,
+              licenseCode: content.licenseCode ?? null,
             });
             moveCopyContentOnOpen();
           }}
@@ -763,6 +763,7 @@ export function CompoundActivityEditor({
       showAddButton={!readOnlyStructure}
       emptyMessage={`${contentTypeName} is empty. Add documents ${activity.type === "sequence" ? "or question banks " : ""}here to begin.`}
       content={cardContent}
+      allLicenses={allLicenses}
       selectedCards={user ? selectedCards : undefined}
       setSelectedCards={setSelectedCards}
       disableSelectFor={addTo ? [addTo.contentId] : undefined}

--- a/client/src/widgets/Card.tsx
+++ b/client/src/widgets/Card.tsx
@@ -20,7 +20,7 @@ import {
   Hide,
 } from "@chakra-ui/react";
 import { Link as ReactRouterLink, useOutletContext } from "react-router";
-import { Content, ContentDescription } from "../types";
+import { Content, ContentDescription, License } from "../types";
 import { FaEllipsisVertical } from "react-icons/fa6";
 import { BsPeople } from "react-icons/bs";
 import {
@@ -49,6 +49,7 @@ export type CardContent = {
 
 export default function Card({
   cardContent,
+  allLicenses,
   showOwnerName = false,
   showBlurb = false,
   showPublicStatus = false,
@@ -65,6 +66,7 @@ export default function Card({
   idx = 1,
 }: {
   cardContent: CardContent;
+  allLicenses: License[];
   showOwnerName?: boolean;
   showBlurb?: boolean;
   showPublicStatus?: boolean;
@@ -90,7 +92,7 @@ export default function Card({
     name: title,
     isPublic,
     isShared,
-    license,
+    licenseCode,
     contentFeatures,
     type: contentType,
     parent,
@@ -168,10 +170,10 @@ export default function Card({
     )) {
       const id = contentFeatures.findIndex((f) => f.code === featureCode);
       if (id === -1) {
-        featureIcons.push(<Flex width={featureIconSize} />);
+        featureIcons.push(<Flex width={featureIconSize} key={featureCode} />);
       } else {
         featureIcons.push(
-          <Tooltip label={contentFeatures[id].description}>
+          <Tooltip label={contentFeatures[id].description} key={featureCode}>
             <Flex alignItems="center">
               <Icon
                 as={featureIcon}
@@ -287,12 +289,17 @@ export default function Card({
   // We'll show a particular if:
   // 1. it's public or shared
   // 2. `showLibraryEditor` is true -- we're assuming editors want to see license
-  const showThisBage = license && (isPublic || isShared || showLibraryEditor);
+  const showThisBage =
+    licenseCode && (isPublic || isShared || showLibraryEditor);
 
   const licenseBadges = (
     <Flex alignItems="center" marginLeft="3rem">
       {showThisBage ? (
-        <SmallLicenseBadges license={license} suppressLink={true} />
+        <SmallLicenseBadges
+          code={licenseCode}
+          suppressLink={true}
+          allLicenses={allLicenses}
+        />
       ) : (
         // Same width as `SmallLicenseBadges`
         <Flex width="80px" />

--- a/client/src/widgets/CardList.tsx
+++ b/client/src/widgets/CardList.tsx
@@ -2,10 +2,11 @@ import React, { ReactElement } from "react";
 import { Text, Icon, Box, Flex } from "@chakra-ui/react";
 import Card, { CardContent } from "./Card";
 import { MdInfoOutline } from "react-icons/md";
-import { ContentDescription } from "../types";
+import { ContentDescription, License } from "../types";
 
 export default function CardList({
   content,
+  allLicenses,
   showOwnerName = false,
   showBlurb = false,
   showPublicStatus = false,
@@ -29,6 +30,7 @@ export default function CardList({
         empty: boolean;
       }
   )[];
+  allLicenses: License[];
   showOwnerName?: boolean;
   showBlurb?: boolean;
   showPublicStatus?: boolean;
@@ -134,6 +136,7 @@ export default function CardList({
         <Card
           key={`Card${cardContent.content.contentId}`}
           cardContent={cardContent}
+          allLicenses={allLicenses}
           showOwnerName={showOwnerName}
           showBlurb={showBlurb}
           showPublicStatus={showPublicStatus}

--- a/server/src/query/content_list.ts
+++ b/server/src/query/content_list.ts
@@ -19,7 +19,6 @@ import {
 } from "../utils/classificationsFeatures";
 import { fromUUID, isEqualUUID } from "../utils/uuid";
 import { getAllDoenetmlVersions } from "./activity";
-import { getAllLicenses } from "./share";
 import { recordContentView, recordRecentContent } from "./stats";
 
 export async function getMyContent({
@@ -111,7 +110,6 @@ export async function getMyContentOrLibraryContent({
   //TODO: Does this API need to provide this extra data?
   const { availableFeatures } = await getAvailableContentFeatures();
   const { allDoenetmlVersions } = await getAllDoenetmlVersions();
-  const { allLicenses } = await getAllLicenses();
 
   if (parentId !== null && !isLibrary) {
     await recordRecentContent(loggedInUserId, "edit", parentId);
@@ -123,7 +121,6 @@ export async function getMyContentOrLibraryContent({
     libraryRelations,
     availableFeatures,
     allDoenetmlVersions,
-    allLicenses,
     notMe: false as const,
   };
 }
@@ -268,7 +265,6 @@ export async function searchMyContentOrLibraryContent({
   //TODO: Do we need this extra data in this API?
   const { availableFeatures } = await getAvailableContentFeatures();
   const { allDoenetmlVersions } = await getAllDoenetmlVersions();
-  const { allLicenses } = await getAllLicenses();
 
   return {
     content,
@@ -276,7 +272,6 @@ export async function searchMyContentOrLibraryContent({
     libraryRelations,
     availableFeatures,
     allDoenetmlVersions,
-    allLicenses,
     notMe: false as const,
   };
 }

--- a/server/src/query/curate.ts
+++ b/server/src/query/curate.ts
@@ -16,7 +16,6 @@ import {
 } from "./content_list";
 import { processContent, returnContentSelect } from "../utils/contentStructure";
 import { getAvailableContentFeatures } from "./classification";
-import { getAllLicenses } from "./share";
 
 export async function mustBeEditor(
   userId: Uint8Array,
@@ -857,7 +856,6 @@ export async function getCurationQueue({
 
   const { availableFeatures } = await getAvailableContentFeatures();
   const { allDoenetmlVersions } = await getAllDoenetmlVersions();
-  const { allLicenses } = await getAllLicenses();
 
   return {
     pendingContent,
@@ -870,6 +868,5 @@ export async function getCurationQueue({
     publishedLibraryRelations,
     availableFeatures,
     allDoenetmlVersions,
-    allLicenses,
   };
 }

--- a/server/src/test/activity.test.ts
+++ b/server/src/test/activity.test.ts
@@ -77,7 +77,7 @@ test("New activity starts out private, then delete it", async () => {
     contentFeatures: [],
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -85,10 +85,10 @@ test("New activity starts out private, then delete it", async () => {
     parent: null,
   };
 
-  expect(activityContent.license?.code).eq("CCDUAL");
+  expect(activityContent.licenseCode).eq("CCDUAL");
 
   // set license to null as it is too long to compare in its entirety.
-  activityContent.license = null;
+  activityContent.licenseCode = null;
 
   expect(activityContent).toStrictEqual(expectedContent);
 
@@ -783,7 +783,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -793,7 +793,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (preAssignedData === undefined) {
     throw Error("shouldn't happen");
   }
-  preAssignedData.license = null; // skip trying to check big license object
+  preAssignedData.licenseCode = null; // skip trying to check big license object
   expect(preAssignedData).eqls(expectedData);
 
   // get my folder content returns same data
@@ -805,7 +805,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // Opening assignment also assigns the activity
@@ -829,7 +829,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -849,7 +849,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (openedData === undefined) {
     throw Error("shouldn't happen");
   }
-  openedData.license = null; // skip trying to check big license object
+  openedData.licenseCode = null; // skip trying to check big license object
   expect(openedData).eqls(expectedData);
 
   // get my folder content returns same data, with differences in some optional fields
@@ -862,7 +862,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // closing the assignment without data also unassigns it
@@ -883,7 +883,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -902,7 +902,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (closedData === undefined) {
     throw Error("shouldn't happen");
   }
-  closedData.license = null; // skip trying to check big license object
+  closedData.licenseCode = null; // skip trying to check big license object
   expect(closedData).eqls(expectedData);
 
   // get my folder content returns same data
@@ -914,7 +914,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // re-opening, re-assigns with same code
@@ -940,7 +940,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -960,7 +960,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (openedData2 === undefined) {
     throw Error("shouldn't happen");
   }
-  openedData2.license = null; // skip trying to check big license object
+  openedData2.licenseCode = null; // skip trying to check big license object
   expect(openedData2).eqls(expectedData);
 
   // get my folder content returns same data, with differences in some optional fields
@@ -973,7 +973,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // create initial attempt
@@ -1008,7 +1008,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -1027,7 +1027,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (openedData3 === undefined) {
     throw Error("shouldn't happen");
   }
-  openedData3.license = null; // skip trying to check big license object
+  openedData3.licenseCode = null; // skip trying to check big license object
   expect(openedData3).eqls(expectedData);
 
   // get my folder content returns same data, with differences in some optional fields
@@ -1040,7 +1040,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // now closing does not unassign
@@ -1061,7 +1061,7 @@ test("activity editor data and my folder contents before and after assigned", as
     isShared: false,
     sharedWith: [],
     numVariants: 1,
-    license: null,
+    licenseCode: null,
     type: "singleDoc",
     classifications: [],
     doenetML: "",
@@ -1081,7 +1081,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (closedData2 === undefined) {
     throw Error("shouldn't happen");
   }
-  closedData2.license = null; // skip trying to check big license object
+  closedData2.licenseCode = null; // skip trying to check big license object
   expect(closedData2).eqls(expectedData);
 
   // get my folder content returns same data, with differences in some optional fields
@@ -1094,7 +1094,7 @@ test("activity editor data and my folder contents before and after assigned", as
   if (folderData.notMe) {
     throw Error("shouldn't happen");
   }
-  folderData.content[0].license = null; // skip trying to check big license object
+  folderData.content[0].licenseCode = null; // skip trying to check big license object
   expect(folderData.content).eqls([expectedData]);
 
   // explicitly unassigning fails due to the presence of data
@@ -1141,7 +1141,7 @@ test("activity editor data shows its parent folder is public", async () => {
     throw Error("shouldn't happen");
   }
   expect(data.isPublic).eq(true);
-  expect(data.license?.code).eq("CCBYSA");
+  expect(data.licenseCode).eq("CCBYSA");
   expect(data.parent).eq(null);
 
   const { contentId: folderId } = await createContent({
@@ -1164,7 +1164,7 @@ test("activity editor data shows its parent folder is public", async () => {
     throw Error("shouldn't happen");
   }
   expect(data.isPublic).eq(true);
-  expect(data.license?.code).eq("CCBYSA");
+  expect(data.licenseCode).eq("CCBYSA");
   expect(data.parent?.isPublic).eq(false);
 
   await setContentLicense({
@@ -1187,7 +1187,7 @@ test("activity editor data shows its parent folder is public", async () => {
   // setting folder public also sets children to be public
   expect(data.isPublic).eq(true);
   // changing license of folder does not change license of content
-  expect(data.license?.code).eq("CCBYSA");
+  expect(data.licenseCode).eq("CCBYSA");
   expect(data.parent?.isPublic).eq(true);
 
   await setContentIsPublic({
@@ -1225,7 +1225,7 @@ test("activity editor data shows its parent folder is public", async () => {
   }
   expect(data.isPublic).eq(true);
   // changing license of folder does not change license of content
-  expect(data.license?.code).eq("CCBYSA");
+  expect(data.licenseCode).eq("CCBYSA");
   expect(data.parent?.isPublic).eq(true);
 });
 

--- a/server/src/test/share.test.ts
+++ b/server/src/test/share.test.ts
@@ -62,11 +62,11 @@ describe("Share tests", () => {
 
     expect(content[0].contentId).eqls(contentId);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCBYSA");
+    expect(content[0].licenseCode).eq("CCBYSA");
 
     expect(content[1].contentId).eqls(folderId);
     expect(content[1].isPublic).eq(true);
-    expect(content[1].license?.code).eq("CCBYSA");
+    expect(content[1].licenseCode).eq("CCBYSA");
   });
 
   test("content in shared folder is created shared", async () => {
@@ -120,12 +120,12 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(contentId);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCBYSA");
+    expect(content[0].licenseCode).eq("CCBYSA");
 
     expect(content[1].contentId).eqls(folderId);
     expect(content[1].isShared).eq(true);
     expect(content[1].sharedWith).eqls([userFields]);
-    expect(content[1].license?.code).eq("CCBYSA");
+    expect(content[1].licenseCode).eq("CCBYSA");
   });
 
   test("if content has a public parent, cannot make it private", async () => {
@@ -158,7 +158,7 @@ describe("Share tests", () => {
       loggedInUserId: ownerId,
     });
     expect(activity.isPublic).eq(true);
-    expect(activity.license!.code).eq("CCBYNCSA");
+    expect(activity.licenseCode).eq("CCBYNCSA");
 
     // change license of content is OK
     await setContentLicense({
@@ -171,7 +171,7 @@ describe("Share tests", () => {
       loggedInUserId: ownerId,
     });
     expect(activity.isPublic).eq(true);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
 
     // since have public parent, cannot make child private
     await expect(
@@ -256,7 +256,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(true);
-    expect(activity.license!.code).eq("CCBYNCSA");
+    expect(activity.licenseCode).eq("CCBYNCSA");
     expect(activity.sharedWith.map((s) => s.userId)).eqls([userId1]);
 
     // change license of content is OK
@@ -271,7 +271,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(true);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith.map((s) => s.userId)).eqls([userId1]);
 
     // since have parent is shared with userId1, cannot unshare it with userId1
@@ -297,7 +297,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(true);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith.map((s) => s.userId)).eqls([userId1, userId2]);
 
     await modifyContentSharedWith({
@@ -312,7 +312,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(true);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith.map((s) => s.userId)).eqls([userId1]);
 
     // unshare parent with userId1, activity is unshared with userId1
@@ -328,7 +328,7 @@ describe("Share tests", () => {
       loggedInUserId: ownerId,
     });
     expect(activity.isShared).eq(false);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith).eqls([]);
 
     // share the content with userId1
@@ -344,7 +344,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(true);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith.map((s) => s.userId)).eqls([userId1]);
 
     // can now unshare it with userId1
@@ -360,7 +360,7 @@ describe("Share tests", () => {
       includeShareDetails: true,
     });
     expect(activity.isShared).eq(false);
-    expect(activity.license!.code).eq("CCDUAL");
+    expect(activity.licenseCode).eq("CCDUAL");
     expect(activity.sharedWith).eqls([]);
   });
 
@@ -904,10 +904,10 @@ describe("Share tests", () => {
 
     expect(content[1].contentId).eqls(activity1Id);
     expect(content[1].isPublic).eq(false);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
     expect(content[2].contentId).eqls(folder1Id);
     expect(content[2].isPublic).eq(false);
-    expect(content[2].license?.code).eq("CCDUAL");
+    expect(content[2].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -920,7 +920,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isPublic).eq(false);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -933,7 +933,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isPublic).eq(false);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     // move content into public folder
     await moveContent({
@@ -961,10 +961,10 @@ describe("Share tests", () => {
 
     expect(content[0].contentId).eqls(activity1Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
     expect(content[1].contentId).eqls(folder1Id);
     expect(content[1].isPublic).eq(true);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -977,7 +977,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -990,7 +990,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     // Create a private folder and move content into that folder.
     // The content stays public.
@@ -1026,10 +1026,10 @@ describe("Share tests", () => {
 
     expect(content[0].contentId).eqls(activity1Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
     expect(content[1].contentId).eqls(folder1Id);
     expect(content[1].isPublic).eq(true);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1042,7 +1042,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1055,7 +1055,7 @@ describe("Share tests", () => {
     content = results.content;
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isPublic).eq(true);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
   });
 
   test("moving content into shared folder shares it", async () => {
@@ -1117,11 +1117,11 @@ describe("Share tests", () => {
     expect(content[1].contentId).eqls(activity1Id);
     expect(content[1].isShared).eq(false);
     expect(content[1].sharedWith).eqls([]);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
     expect(content[2].contentId).eqls(folder1Id);
     expect(content[2].isShared).eq(false);
     expect(content[2].sharedWith).eqls([]);
-    expect(content[2].license?.code).eq("CCDUAL");
+    expect(content[2].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1135,7 +1135,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isShared).eq(false);
     expect(content[0].sharedWith).eqls([]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1149,7 +1149,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isShared).eq(false);
     expect(content[0].sharedWith).eqls([]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     // move content into shared folder
     await moveContent({
@@ -1178,11 +1178,11 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(activity1Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
     expect(content[1].contentId).eqls(folder1Id);
     expect(content[1].isShared).eq(true);
     expect(content[1].sharedWith).eqls([userFields]);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1196,7 +1196,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1210,7 +1210,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     // Create a private folder and move content into that folder.
     // The content stays shared.
@@ -1247,11 +1247,11 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(activity1Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
     expect(content[1].contentId).eqls(folder1Id);
     expect(content[1].isShared).eq(true);
     expect(content[1].sharedWith).eqls([userFields]);
-    expect(content[1].license?.code).eq("CCDUAL");
+    expect(content[1].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1265,7 +1265,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(folder2Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
 
     results = await getMyContent({
       ownerId,
@@ -1279,7 +1279,7 @@ describe("Share tests", () => {
     expect(content[0].contentId).eqls(activity2Id);
     expect(content[0].isShared).eq(true);
     expect(content[0].sharedWith).eqls([userFields]);
-    expect(content[0].license?.code).eq("CCDUAL");
+    expect(content[0].licenseCode).eq("CCDUAL");
   });
 
   test("share with email throws error when no match", async () => {
@@ -1486,14 +1486,7 @@ describe("Share tests", () => {
     expect(activityData).toBeDefined();
     expect(activityData!.isPublic).eq(true);
 
-    expect(activityData!.license?.code).eq("CCBYSA");
-    expect(activityData!.license?.name).eq(
-      "Creative Commons Attribution-ShareAlike 4.0",
-    );
-    expect(activityData!.license?.licenseURL).eq(
-      "https://creativecommons.org/licenses/by-sa/4.0/",
-    );
-    expect(activityData!.license?.imageURL).eq("/creative_commons_by_sa.png");
+    expect(activityData!.licenseCode).eq("CCBYSA");
 
     // make private
     await setContentIsPublic({
@@ -1526,16 +1519,8 @@ describe("Share tests", () => {
     expect(activityData).toBeDefined();
     expect(activityData!.isPublic).eq(true);
 
-    expect(activityData!.license?.code).eq("CCBYNCSA");
-    expect(activityData!.license?.name).eq(
-      "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
-    );
-    expect(activityData!.license?.licenseURL).eq(
-      "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-    );
-    expect(activityData!.license?.imageURL).eq(
-      "/creative_commons_by_nc_sa.png",
-    );
+    expect(activityData!.licenseCode).eq("CCBYNCSA");
+
 
     // switch license to dual
     await setContentLicense({
@@ -1550,31 +1535,6 @@ describe("Share tests", () => {
     }));
     expect(activityData!.isPublic).eq(true);
 
-    expect(activityData!.license?.code).eq("CCDUAL");
-    expect(activityData!.license?.name).eq(
-      "Dual license Creative Commons Attribution-ShareAlike 4.0 OR Attribution-NonCommercial-ShareAlike 4.0",
-    );
-
-    expect(activityData!.license?.composedOf[0].code).eq("CCBYSA");
-    expect(activityData!.license?.composedOf[0].name).eq(
-      "Creative Commons Attribution-ShareAlike 4.0",
-    );
-    expect(activityData!.license?.composedOf[0].licenseURL).eq(
-      "https://creativecommons.org/licenses/by-sa/4.0/",
-    );
-    expect(activityData!.license?.composedOf[0].imageURL).eq(
-      "/creative_commons_by_sa.png",
-    );
-
-    expect(activityData!.license?.composedOf[1].code).eq("CCBYNCSA");
-    expect(activityData!.license?.composedOf[1].name).eq(
-      "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
-    );
-    expect(activityData!.license?.composedOf[1].licenseURL).eq(
-      "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-    );
-    expect(activityData!.license?.composedOf[1].imageURL).eq(
-      "/creative_commons_by_nc_sa.png",
-    );
+    expect(activityData!.licenseCode).eq("CCDUAL");
   });
 });

--- a/server/src/test/users.test.ts
+++ b/server/src/test/users.test.ts
@@ -21,13 +21,7 @@ test("New user has no content", async () => {
   if (docs.notMe) {
     throw Error("shouldn't happen");
   }
-  const {
-    availableFeatures,
-    allDoenetmlVersions,
-    allLicenses,
-    notMe,
-    ...docs2
-  } = docs;
+  const { availableFeatures, allDoenetmlVersions, notMe, ...docs2 } = docs;
   expect(docs2).toStrictEqual({
     content: [],
     libraryRelations: [],

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -148,7 +148,7 @@ export type ContentBase = {
   sharedWith: UserInfo[];
   // Content should ~almost always~ have a license.
   // The exception: content without license from old doenet website
-  license: License | null;
+  licenseCode: LicenseCode | null;
   contentFeatures: {
     id: number;
     code: string;
@@ -235,7 +235,7 @@ export async function createContentInfo({
     isPublic: false,
     isShared: false,
     sharedWith: [],
-    license: null,
+    licenseCode: null,
     parent: null,
     contentFeatures: [],
     classifications: [],

--- a/server/src/utils/contentStructure.ts
+++ b/server/src/utils/contentStructure.ts
@@ -195,14 +195,7 @@ export function returnContentSelect({
     isPublic: true,
     contentFeatures: true,
     sharedWith,
-    license: {
-      include: {
-        composedOf: {
-          select: { composedOf: true },
-          orderBy: { composedOf: { sortIndex: "asc" as const } },
-        },
-      },
-    },
+    licenseCode: true,
     parent: {
       select: {
         id: true,
@@ -328,7 +321,7 @@ type PreliminaryContent = {
     sortIndex: number;
   }[];
   sharedWith: { userId: Uint8Array }[] | { user: UserInfo }[];
-  license: PreliminaryLicense | null;
+  licenseCode: LicenseCode | null;
   parent?: {
     id: Uint8Array;
     name: string;
@@ -400,7 +393,7 @@ export function processContent(
     activityLevelAttempts,
     itemLevelAttempts,
     sharedWith: sharedWithOrig,
-    license,
+    licenseCode,
     parent,
     classifications,
     rootAssignment,
@@ -493,7 +486,7 @@ export function processContent(
     ...assignmentInfoObj,
     isShared,
     sharedWith,
-    license: license ? processLicense(license) : null,
+    licenseCode,
     classifications: sortClassifications(
       (classifications ?? []).map((c) => c.classification),
     ),


### PR DESCRIPTION
Before, most api endpoints passed the full license information for every content. This makes pages like `Explore` send much more to the client than they need to.

Changes
* All but 1 api endpoint simply provide the license code
*  `getAllLicenses` provides the full information, which is loaded by SiteHeader and used by all other components through SiteHeader's context
* Refactor duplicated code into single widget: `LicenseDescription`

To-do:
* Write test to ensure endpoints only provide license code