### PR TITLE
Fix bug in AllAssignmentScores loader

### DIFF
--- a/client/src/paths/AllAssignmentScores.tsx
+++ b/client/src/paths/AllAssignmentScores.tsx
@@ -58,9 +58,11 @@ export async function loader({
     parentId?: string;
   };
 }) {
-  const { orderedActivities, assignmentScores, folder } = (await axios.get(
+  const { data } = await axios.get(
     `/api/assign/getAllAssignmentScores/${params.parentId ?? ""}`,
-  )) as {
+  );
+
+  const { orderedActivities, assignmentScores, folder } = data as {
     orderedActivities: OrderedActivity[];
     assignmentScores: AssignmentScore[];
     folder: Folder;


### PR DESCRIPTION
The page `/allAssignmentScores/` was crashing. Fixed bug in the page's loader.