### PR TITLE
Move logic for popup folder browsing from client to server

### DIFF
--- a/client/src/popups/CreateContentAndPromptName.tsx
+++ b/client/src/popups/CreateContentAndPromptName.tsx
@@ -38,6 +38,7 @@ export async function createContentAndPromptNameActions({
         {
           childSourceContentIds: contentIds,
           contentType: formObj.desiredType,
+          parentId: null,
         },
       );
 

--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -24,16 +24,19 @@ import { ContentType, UserInfo } from "../types";
 import { contentTypeToName, getIconInfo } from "../utils/activity";
 
 type ActiveView = {
-  // If parentName and parentId are null, the active view is the root
-  // If grandparentId is null, then the parent of active view is the root
-  parentId: string | null;
-  parentName: string | null;
-  parentType: ContentType;
-  parentIsPublic: boolean;
-  // parentIsShared: boolean;
-  parentSharedWith: string[];
-  grandparentId: string | null;
-  grandparentType: ContentType;
+  // If parent is null, the active view is the root
+  // If parent.parent is null, then the parent of active view is the root
+  parent: {
+    id: string;
+    name: string;
+    type: ContentType;
+    isPublic: boolean;
+    sharedWith: string[];
+    parent: {
+      id: string;
+      type: ContentType;
+    } | null;
+  } | null;
   contents: {
     type: ContentType;
     canOpen: boolean;
@@ -145,13 +148,7 @@ export function MoveCopyContent({
 
   // Set whenever the user navigates to another parent
   const [activeView, setActiveView] = useState<ActiveView>({
-    parentName: null,
-    parentType: "folder",
-    parentIsPublic: false,
-    parentSharedWith: [],
-    parentId: null,
-    grandparentId: null,
-    grandparentType: "folder",
+    parent: null,
     contents: [],
   });
 
@@ -242,6 +239,37 @@ export function MoveCopyContent({
     </SimpleGrid>
   );
 
+  let shareAlert = false;
+  if (action === "Move") {
+    // Sometimes moving content to a different folder means that the visibility of that content
+    // will change. When this is going to happen, we alert users with a popup.
+    // There are two cases where this can happen:
+    // 1. Destination folder is public, but at least some source content is private
+    // 2. Destination folder is shared with someone, but at least some of the source content is not
+    //    shared with that person
+    //    (Please note that this also means the offending piece of source content is private, since if
+    //     it were public, it would be implicitly shared with everyone)
+    // In the following code, we check for either of those two cases.
+
+    if (activeView.parent?.isPublic) {
+      shareAlert = !sourceContent.every((c) => c.isPublic);
+    } else if (activeView.parent?.sharedWith) {
+      const privateSources = sourceContent.filter((c) => !c.isPublic);
+      const sourceSharedWith = privateSources.flatMap(
+        (c) => c.sharedWith?.map((user) => user.userId) ?? [],
+      );
+      const count = new Map<string, number>();
+      for (userId of sourceSharedWith) {
+        count.set(userId, (count.get(userId) || 0) + 1);
+      }
+      // If the count of that userId is the same as the length of private sources,
+      // that means each private source was shared with that userId
+      shareAlert = !activeView.parent.sharedWith.every(
+        (user) => count.get(user) === privateSources.length,
+      );
+    }
+  }
+
   const executeButtons = (
     <>
       <Button
@@ -257,29 +285,14 @@ export function MoveCopyContent({
         width="10em"
         // Is disabled if the content is already in this parent
         isDisabled={
-          (activeView.parentId === null && parentId === null) ||
-          (activeView.parentId !== null &&
+          (activeView.parent === null && parentId === null) ||
+          (activeView.parent !== null &&
             parentId !== null &&
-            activeView.parentId === parentId) ||
-          !allowedParentTypes.includes(activeView.parentType)
+            activeView.parent.id === parentId) ||
+          !allowedParentTypes.includes(activeView.parent?.type ?? "folder")
         }
         onClick={() => {
-          if (
-            action === "Move" &&
-            ((activeView.parentIsPublic &&
-              !sourceContent.every((c) => c.isPublic)) ||
-              (activeView.parentSharedWith.length > 0 &&
-                (!sourceContent.every((c) => c.isShared) ||
-                  activeView.parentSharedWith.some((parentUser) =>
-                    sourceContent.some(
-                      (c) =>
-                        !c.sharedWith ||
-                        c.sharedWith.findIndex(
-                          (u) => u.userId === parentUser,
-                        ) === -1,
-                    ),
-                  ))))
-          ) {
+          if (shareAlert) {
             // moving non-public content into a public parent
             // or moving moving content into a parent that is shared with additional users
             sharedAlertOnOpen();
@@ -291,7 +304,7 @@ export function MoveCopyContent({
         <Text noOfLines={1}>
           {action} to{" "}
           <em>
-            {activeView.parentName ??
+            {activeView.parent?.name ??
               (inCurationLibrary ? "Library Activities" : "My Activities")}
           </em>
         </Text>
@@ -303,32 +316,32 @@ export function MoveCopyContent({
   let destinationAction: string;
   let destinationUrl: string;
 
-  if (activeView.parentId) {
-    const typeName = contentTypeToName[activeView.parentType].toLowerCase();
+  if (activeView.parent) {
+    const typeName = contentTypeToName[activeView.parent.type].toLowerCase();
     destinationDescription = (
       <>
-        <strong>{activeView.parentName}</strong>
+        <strong>{activeView.parent.name}</strong>
       </>
     );
-    if (activeView.parentType === "folder") {
+    if (activeView.parent.type === "folder") {
       destinationAction = "Go to folder";
 
       if (inCurationLibrary) {
-        destinationUrl = `/libraryActivities/${activeView.parentId}`;
+        destinationUrl = `/libraryActivities/${activeView.parent.id}`;
       } else {
-        destinationUrl = `/activities/${userId}/${activeView.parentId}`;
+        destinationUrl = `/activities/${userId}/${activeView.parent.id}`;
       }
     } else if (
-      activeView.parentType === "select" &&
-      activeView.grandparentType === "sequence"
+      activeView.parent.type === "select" &&
+      activeView.parent.parent?.type === "sequence"
     ) {
       // if we have a Question Bank whose parent is a Problem Set,
       // then we don't display the Question Bank by itself, just embedded in the Problem Set
       destinationAction = `Open containing problem set`;
-      destinationUrl = `/activityEditor/${activeView.grandparentId}`;
+      destinationUrl = `/activityEditor/${activeView.parent.parent.id}`;
     } else {
       destinationAction = `Open ${typeName}`;
-      destinationUrl = `/activityEditor/${activeView.parentId}`;
+      destinationUrl = `/activityEditor/${activeView.parent.id}`;
     }
   } else if (inCurationLibrary) {
     destinationDescription = <>Library Activities</>;
@@ -346,7 +359,7 @@ export function MoveCopyContent({
         isOpen={sharedAlertIsOpen}
         onClose={sharedAlertOnClose}
         performMove={performAction}
-        parentName={activeView.parentName}
+        parentName={activeView.parent?.name ?? null}
       />
       <Modal
         isOpen={isOpen}
@@ -372,16 +385,18 @@ export function MoveCopyContent({
               <em>{contentName}</em>
             </Heading>
             <HStack hidden={actionFinished || errMsg !== ""}>
-              {activeView.parentId ? (
+              {activeView.parent ? (
                 <>
                   <IconButton
                     data-test="Back Arrow"
                     icon={<ArrowBackIcon />}
                     aria-label="Back"
-                    onClick={() => updateActiveView(activeView.grandparentId)}
+                    onClick={() =>
+                      updateActiveView(activeView.parent?.parent?.id ?? null)
+                    }
                   />
                   <Text noOfLines={1} data-test="Current destination">
-                    {activeView.parentName}
+                    {activeView.parent.name}
                   </Text>
                 </>
               ) : (
@@ -445,7 +460,7 @@ export function MoveCopyContent({
       {
         _action: "Move or copy",
         contentIds: JSON.stringify(sourceContent.map((sc) => sc.contentId)),
-        parentId: activeView.parentId,
+        parentId: activeView.parent?.id ?? null,
         desiredPosition: activeView.contents.length, // place it as the last item
         action,
       },

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -42,6 +42,7 @@ model content {
   selectByVariant     Boolean                  @default(false)
   // Assignments
   nonRootAssignmentId Bytes?                   @db.Binary(16)
+  // Relations
   nonRootAssignment   assignments?             @relation("nonRootAssignment", fields: [nonRootAssignmentId], references: [rootContentId], onDelete: SetNull, onUpdate: NoAction)
   rootAssignment      assignments?             @relation("rootAssignment")
   owner               users                    @relation(fields: [ownerId], references: [userId], onDelete: NoAction, onUpdate: NoAction)

--- a/server/src/query/copy_move.ts
+++ b/server/src/query/copy_move.ts
@@ -705,6 +705,9 @@ export async function getMoveCopyContentData({
   loggedInUserId: Uint8Array;
   inCurationLibrary?: boolean;
 }) {
+  if (allowedParentTypes.includes("singleDoc")) {
+    throw new Error("Invalid parent type: `singleDoc`");
+  }
   let userId = loggedInUserId;
   if (inCurationLibrary) {
     await mustBeEditor(loggedInUserId);
@@ -812,13 +815,7 @@ export async function getMoveCopyContentData({
   });
 
   return {
-    parentId: parent?.id ?? null,
-    parentName: parent?.name ?? null,
-    parentType: parent?.type ?? "folder",
-    parentIsPublic: parent?.isPublic,
-    parentSharedWith: parent?.sharedWith,
-    grandparentId: parent?.parent?.id ?? null,
-    grandparentType: parent?.parent?.type ?? "folder",
+    parent,
     contents,
   };
 }

--- a/server/src/routes/copyMoveRoutes.ts
+++ b/server/src/routes/copyMoveRoutes.ts
@@ -3,12 +3,14 @@ import {
   checkIfContentContains,
   copyContent,
   createContentCopyInChildren,
+  getMoveCopyContentData,
   moveContent,
 } from "../query/copy_move";
 import {
   checkIfContentContainsSchema,
   copyContentSchema,
   createContentCopyInChildrenSchema,
+  getMoveCopyContentDataSchema,
   moveContentSchema,
 } from "../schemas/copyMoveSchema";
 import { queryLoggedIn } from "../middleware/queryMiddleware";
@@ -28,6 +30,11 @@ copyMoveRouter.post(
 copyMoveRouter.post(
   "/createContentCopyInChildren",
   queryLoggedIn(createContentCopyInChildren, createContentCopyInChildrenSchema),
+);
+
+copyMoveRouter.get(
+  "/getMoveCopyContentData/:parentId?",
+  queryLoggedIn(getMoveCopyContentData, getMoveCopyContentDataSchema),
 );
 
 copyMoveRouter.get(

--- a/server/src/schemas/array.ts
+++ b/server/src/schemas/array.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { contentTypeSchema } from "./contentSchema";
+
+export const stringAsContentTypes = z
+  .string()
+  .transform((val) => val.split(","))
+  .pipe(z.array(contentTypeSchema));

--- a/server/src/schemas/copyMoveSchema.ts
+++ b/server/src/schemas/copyMoveSchema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
-import { optionalUuidSchema, uuidOrNullSchema, uuidSchema } from "./uuid";
 import { contentTypeSchema } from "./contentSchema";
+import { optionalUuidSchema, uuidOrNullSchema, uuidSchema } from "./uuid";
+import { stringAsBoolSchema } from "./boolean";
+import { stringAsContentTypes } from "./array";
 
 export const moveContentSchema = z.object({
   contentId: uuidSchema,
@@ -18,6 +20,12 @@ export const createContentCopyInChildrenSchema = z.object({
   contentType: contentTypeSchema,
   childSourceContentIds: z.array(uuidSchema),
   parentId: uuidOrNullSchema,
+});
+
+export const getMoveCopyContentDataSchema = z.object({
+  parentId: optionalUuidSchema,
+  allowedParentTypes: stringAsContentTypes,
+  inCurationLibrary: stringAsBoolSchema.optional(),
 });
 
 export const checkIfContentContainsSchema = z.object({

--- a/server/src/test/copy_move.test.ts
+++ b/server/src/test/copy_move.test.ts
@@ -4,6 +4,7 @@ import { createContent, updateContent } from "../query/activity";
 import {
   copyContent,
   createContentCopyInChildren,
+  getMoveCopyContentData,
   moveContent,
 } from "../query/copy_move";
 import { setContentIsPublic } from "../query/share";
@@ -11,6 +12,7 @@ import { getMyContent } from "../query/content_list";
 import { getContent } from "../query/activity_edit_view";
 import { isEqualUUID } from "../utils/uuid";
 import { assignActivity } from "../query/assign";
+import { ContentType } from "@prisma/client";
 
 test("copy folder", async () => {
   const { userId: ownerId } = await createTestUser();
@@ -986,4 +988,165 @@ test("cannot copy/move into assigned problem set or question bank or move out", 
       loggedInUserId: ownerId,
     }),
   ).rejects.toThrow("Cannot move content in an assigned activity");
+});
+
+test("MoveCopyContent allowed parent types", async () => {
+  const { userId: loggedInUserId } = await createTestUser();
+
+  await expect(
+    getMoveCopyContentData({
+      parentId: null,
+      allowedParentTypes: ["folder", "singleDoc"],
+      loggedInUserId,
+    }),
+  ).rejects.toThrowError("parent type");
+});
+
+test("MoveCopyContent has correct canOpen flags", async () => {
+  const { userId: loggedInUserId } = await createTestUser();
+
+  async function create(
+    name: string,
+    type: ContentType,
+    parentId: Uint8Array | null = null,
+    makePublic: boolean = false,
+  ) {
+    const { contentId } = await createContent({
+      loggedInUserId: loggedInUserId,
+      contentType: type,
+      name,
+      parentId,
+    });
+    if (makePublic) {
+      await setContentIsPublic({
+        contentId,
+        isPublic: true,
+        loggedInUserId: loggedInUserId,
+      });
+    }
+    return contentId;
+  }
+
+  let expectedNames: string[] = [];
+  let expectedOpen: boolean[] = [];
+  function expectContentsMatch(contents: { name: string; canOpen: boolean }[]) {
+    expect(contents.length).eqls(expectedNames.length);
+    for (let i = 0; i < expectedNames.length; i++) {
+      const name = expectedNames[i];
+      const open = expectedOpen[i];
+      expect(contents[i].name).eqls(name, `contents ${i} name`);
+      expect(contents[i].canOpen).eqls(open, `contents ${i} canOpen`);
+    }
+  }
+
+  // Setup
+  await create("doc1", "singleDoc", null, true);
+  const ps1 = await create("ps1", "sequence", null, true);
+  await create("psq_qb1", "select", ps1);
+  await create("ps2", "sequence");
+  const qb1 = await create("qb1", "select", null, true);
+  await create("qb1_doc1", "singleDoc", qb1);
+  const f1 = await create("f1", "folder", null, true);
+  await create("f1_doc1", "singleDoc", f1);
+  const f1_ps1 = await create("f1_ps1", "sequence", f1);
+  await create("f1_ps1_doc1", "singleDoc", f1_ps1);
+  const f1_ps1_qb1 = await create("f1_ps1_qb1", "select", f1_ps1);
+  await create("f1_ps1_qb1_doc1", "singleDoc", f1_ps1_qb1);
+  await create("f1_doc2", "singleDoc", f1);
+  const f2 = await create("f2", "folder");
+
+  // Root folder: add anywhere
+  let results = await getMoveCopyContentData({
+    parentId: null,
+    allowedParentTypes: ["folder", "sequence", "select"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls(null);
+  expectedNames = ["ps1", "ps2", "qb1", "f1", "f2", "doc1"];
+  expectedOpen = [true, true, true, true, true, false];
+
+  // Root folder: add to problem set
+  results = await getMoveCopyContentData({
+    parentId: null,
+    allowedParentTypes: ["sequence"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls(null);
+  // Folder 1 has a problem set inside it => can open
+  // Folder 2 does not have a problem set => cannot open
+  expectedNames = ["ps1", "ps2", "qb1", "f1", "f2", "doc1"];
+  expectedOpen = [true, true, false, true, false, false];
+
+  expectContentsMatch(results.contents);
+
+  // Root folder: add to question bank
+  results = await getMoveCopyContentData({
+    parentId: null,
+    allowedParentTypes: ["select"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls(null);
+  // Problem Set 1 has a question bank inside it => can open
+  // Problem Set 2 does not have a question bank => cannot open
+  // Same idea for Folder 1 and Folder 2
+  expectedNames = ["ps1", "ps2", "qb1", "f1", "f2", "doc1"];
+  expectedOpen = [true, false, true, true, false, false];
+  expectContentsMatch(results.contents);
+
+  // Folder 1: add to problem set
+  results = await getMoveCopyContentData({
+    parentId: f1,
+    allowedParentTypes: ["sequence"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls({
+    id: f1,
+    name: "f1",
+    type: "folder",
+    isPublic: true,
+    sharedWith: [],
+    parent: null,
+  });
+  expectedNames = ["f1_ps1", "f1_doc1", "f1_doc2"];
+  expectedOpen = [true, false, false];
+  expectContentsMatch(results.contents);
+
+  // Folder 1/Problem Set 1: add to question bank
+  results = await getMoveCopyContentData({
+    parentId: f1_ps1,
+    allowedParentTypes: ["select"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls({
+    id: f1_ps1,
+    name: "f1_ps1",
+    type: "sequence",
+    isPublic: true,
+    sharedWith: [],
+    parent: {
+      id: f1,
+      type: "folder",
+    },
+  });
+  expectedNames = ["f1_ps1_qb1", "f1_ps1_doc1"];
+  expectedOpen = [true, false];
+  expectContentsMatch(results.contents);
+
+  // Folder 2 (empty folder): add to problem set
+  results = await getMoveCopyContentData({
+    parentId: f2,
+    allowedParentTypes: ["sequence"],
+    loggedInUserId,
+  });
+  expect(results.parent).eqls({
+    id: f2,
+    name: "f2",
+    type: "folder",
+    isPublic: false,
+    sharedWith: [],
+    parent: null,
+  });
+  expectedNames = [];
+  expectedOpen = [];
+  expectContentsMatch(results.contents);
 });


### PR DESCRIPTION
The component `MoveCopyContent` no longer has logic about which folders/activities are navigable and which are not. This is done by a new api `getMoveCopyContentData`. It's cleaner.