### PR TITLE
Responsive change name screen

### DIFF
--- a/client/src/paths/ChangeName.tsx
+++ b/client/src/paths/ChangeName.tsx
@@ -106,14 +106,14 @@ export function ChangeName({
           setSubmitted(true);
         }}
       >
-        <Flex width="400px" maxWidth="100%">
-          <FormControl>
+        <Flex wrap="wrap">
+          <FormControl width="13rem">
             <FormLabel mt="16px">First name(s):</FormLabel>
             <Input
               placeholder="First Name(s)"
               name="firstNames"
               size="sm"
-              width={40}
+              width="11rem"
               marginRight="5px"
               value={firstNames ?? ""}
               onChange={(e) => {
@@ -121,13 +121,13 @@ export function ChangeName({
               }}
             />
           </FormControl>
-          <FormControl isRequired>
+          <FormControl isRequired width="13rem">
             <FormLabel mt="16px">Last name(s):</FormLabel>
             <Input
               placeholder="Last Names"
               name="lastNames"
               size="sm"
-              width={40}
+              width="11rem"
               value={lastNames}
               onChange={(e) => {
                 setLastNames(e.target.value);

--- a/client/src/views/AssignmentInvitation.tsx
+++ b/client/src/views/AssignmentInvitation.tsx
@@ -11,6 +11,7 @@ import {
   Center,
   Box,
   Flex,
+  Text,
 } from "@chakra-ui/react";
 import { QRCode } from "react-qrcode-logo";
 // import { CopyToClipboard } from "react-copy-to-clipboard";
@@ -57,15 +58,15 @@ export function AssignmentInvitation({
           {assignmentStatus === "Open" ? (
             <Flex justifyContent="center">
               <Box width="500px">
-                <p>To view this assignment, go to </p>
-                <Center marginTop="10px" fontSize={40}>
-                  <code>{baseUrl}/code</code>
+                <Text mt="0">To view this assignment, go to </Text>
+                <Center fontSize={40} mt="15px">
+                  <code>
+                    {baseUrl}/code/{classCode}
+                  </code>
                 </Center>
-                <p>and enter the code</p>
-                <Center marginTop="10px" fontSize={40}>
-                  <code>{classCode}</code>
-                </Center>
-                <p>or scan the QR code.</p>
+                <Text mt="15px" mb="5px">
+                  or scan the QR code.
+                </Text>
                 <Center>
                   <QRCode
                     value={`https://${baseUrl}/code/${classCode}`}
@@ -74,7 +75,7 @@ export function AssignmentInvitation({
                     logoPaddingStyle="circle"
                     logoWidth={100}
                     size={300}
-                    style={{ maxWidth: "100%", marginTop: "30px" }}
+                    style={{ maxWidth: "100%" }}
                     ecLevel="Q"
                   />
                 </Center>


### PR DESCRIPTION
Smail front-end tweaks
* Made change name screen responsive
* Invite students page displays link in one line. Ex: `doenet.org/code/01234` rather than `doenet.org/code and type in 01234`