### PR TITLE
Answer response menu is a button

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.7",
         "@doenet/assignment-viewer": "^0.1.0-alpha8",
-        "@doenet/doenetml-iframe": "^0.7.0-alpha54",
+        "@doenet/doenetml-iframe": "^0.7.0-alpha55",
         "@fontsource/jost": "^5.2.5",
         "axios": "^1.8.4",
         "better-react-mathjax": "^2.1.0",
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@doenet/doenetml-iframe": {
-      "version": "0.7.0-alpha54",
-      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha54.tgz",
-      "integrity": "sha512-F8Rvqgu+138vTYvjtnBZSYNPHSsfBuQTvhzgr8k+Daatw+vOzOsK1XuIlD7zc+v0ZAqoDd/6HvmSc7iU68TB4w==",
+      "version": "0.7.0-alpha55",
+      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha55.tgz",
+      "integrity": "sha512-XHF5+P6B9/KdhVuK0DNS5YjMjY0ecMfcprsUa/VbfoJOYrl4VokABEOHE35Ca8BkoYIoL5hUiY7fM3DBRN6N5g==",
       "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "react": "^19.1.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.7",
         "@doenet/assignment-viewer": "^0.1.0-alpha8",
-        "@doenet/doenetml-iframe": "^0.7.0-alpha53",
+        "@doenet/doenetml-iframe": "^0.7.0-alpha54",
         "@fontsource/jost": "^5.2.5",
         "axios": "^1.8.4",
         "better-react-mathjax": "^2.1.0",
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@doenet/doenetml-iframe": {
-      "version": "0.7.0-alpha53",
-      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha53.tgz",
-      "integrity": "sha512-oYxNuqYMnBS4JDA5/A8V3uww+Qea/f9h5HXkEr0kThbIKZCu2+GY/YLfWeo7mlobs1MPJWwuCtwjyZnVYAvbwA==",
+      "version": "0.7.0-alpha54",
+      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha54.tgz",
+      "integrity": "sha512-F8Rvqgu+138vTYvjtnBZSYNPHSsfBuQTvhzgr8k+Daatw+vOzOsK1XuIlD7zc+v0ZAqoDd/6HvmSc7iU68TB4w==",
       "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "react": "^19.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.7",
     "@doenet/assignment-viewer": "^0.1.0-alpha8",
-    "@doenet/doenetml-iframe": "^0.7.0-alpha54",
+    "@doenet/doenetml-iframe": "^0.7.0-alpha55",
     "@fontsource/jost": "^5.2.5",
     "axios": "^1.8.4",
     "better-react-mathjax": "^2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.7",
     "@doenet/assignment-viewer": "^0.1.0-alpha8",
-    "@doenet/doenetml-iframe": "^0.7.0-alpha53",
+    "@doenet/doenetml-iframe": "^0.7.0-alpha54",
     "@fontsource/jost": "^5.2.5",
     "axios": "^1.8.4",
     "better-react-mathjax": "^2.1.0",

--- a/client/src/paths/Home.tsx
+++ b/client/src/paths/Home.tsx
@@ -32,7 +32,7 @@ export async function loader() {
 
 const HomeIntroVideo = lazy(() => import("../widgets/HomeIntroVideo"));
 
-const doenetmlVersion = "0.7.0-alpha53";
+const doenetmlVersion = "0.7.0-alpha54";
 const doenetML = `
 <example>
 <setup>

--- a/client/src/paths/Home.tsx
+++ b/client/src/paths/Home.tsx
@@ -32,7 +32,7 @@ export async function loader() {
 
 const HomeIntroVideo = lazy(() => import("../widgets/HomeIntroVideo"));
 
-const doenetmlVersion = "0.7.0-alpha54";
+const doenetmlVersion = "0.7.0-alpha55";
 const doenetML = `
 <example>
 <setup>

--- a/client/src/views/AssignmentItemResponseStudent.tsx
+++ b/client/src/views/AssignmentItemResponseStudent.tsx
@@ -172,7 +172,7 @@ export function AssignmentItemResponseStudent({
         viewURL: "/activityViewer",
         editURL: "/codeViewer",
       }}
-      showAnswerResponseMenu={true}
+      showAnswerResponseButton={true}
       answerResponseCounts={responseCounts}
     />
   );

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -29,7 +29,7 @@ async function seedDoenetMLVersions() {
   });
   await updateOrCreateDoenetMLVersion({
     displayedVersion: "0.7",
-    fullVersion: "0.7.0-alpha54",
+    fullVersion: "0.7.0-alpha55",
     default: true,
   });
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -29,7 +29,7 @@ async function seedDoenetMLVersions() {
   });
   await updateOrCreateDoenetMLVersion({
     displayedVersion: "0.7",
-    fullVersion: "0.7.0-alpha53",
+    fullVersion: "0.7.0-alpha54",
     default: true,
   });
 }

--- a/server/src/test/activity.test.ts
+++ b/server/src/test/activity.test.ts
@@ -46,7 +46,7 @@ import { isEqualUUID } from "../utils/uuid";
 const currentDoenetmlVersion = {
   id: 2,
   displayedVersion: "0.7",
-  fullVersion: "0.7.0-alpha54",
+  fullVersion: "0.7.0-alpha55",
   default: true,
   deprecated: false,
   removed: false,

--- a/server/src/test/activity.test.ts
+++ b/server/src/test/activity.test.ts
@@ -46,7 +46,7 @@ import { isEqualUUID } from "../utils/uuid";
 const currentDoenetmlVersion = {
   id: 2,
   displayedVersion: "0.7",
-  fullVersion: "0.7.0-alpha53",
+  fullVersion: "0.7.0-alpha54",
   default: true,
   deprecated: false,
   removed: false,

--- a/server/src/test/assign.test.ts
+++ b/server/src/test/assign.test.ts
@@ -926,7 +926,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
     },
   });
 
@@ -963,7 +963,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
     },
   });
 
@@ -1000,7 +1000,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
     },
   });
 
@@ -1075,7 +1075,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
     },
   });
 });

--- a/server/src/test/assign.test.ts
+++ b/server/src/test/assign.test.ts
@@ -926,7 +926,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha53" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
     },
   });
 
@@ -963,7 +963,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha53" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
     },
   });
 
@@ -1000,7 +1000,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha53" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
     },
   });
 
@@ -1075,7 +1075,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha53" },
+      doenetmlVersion: { fullVersion: "0.7.0-alpha54" },
     },
   });
 });


### PR DESCRIPTION
This PR changes the answer response menu to a button. Previously, the button opened a popup menu with a link that one had to click to display the answer responses. Now, the extra step of the menu is eliminated, and clicking the button immediately displays a student's responses to that answer blank.

One drawback, given that the attribute on `<DoenetViewer>` changed from `showAnswerResponseMenu` to `showAnswerResponseButton`, is that the button is no longer shown if the authors use a version of DoenetML below `0.7.0-alpha54`.