### PR TITLE
Types parity between server and client

### DIFF
--- a/client/src/drawerTabs/RemixSources.tsx
+++ b/client/src/drawerTabs/RemixSources.tsx
@@ -132,9 +132,9 @@ export function RemixSources({
                 <Show above="sm">
                   {/* Note: use timestampOriginContent as what the timestamp from when the previous was mixed, not when this doc was created */}
                   <Td>
-                    {ch.originContent.timestamp.toLocaleString(
-                      DateTime.DATE_MED,
-                    )}
+                    {DateTime.fromISO(
+                      ch.originContent.timestamp,
+                    ).toLocaleString(DateTime.DATE_MED)}
                   </Td>
                 </Show>
                 <Td>

--- a/client/src/drawerTabs/Remixes.tsx
+++ b/client/src/drawerTabs/Remixes.tsx
@@ -111,7 +111,9 @@ export function Remixes({
               <Show above="sm">
                 {/* Note: use timestampOriginContent as what the timestamp from when the previous was mixed, not when this doc was created */}
                 <Td>
-                  {ch.originContent.timestamp.toLocaleString(DateTime.DATE_MED)}
+                  {DateTime.fromISO(ch.originContent.timestamp).toLocaleString(
+                    DateTime.DATE_MED,
+                  )}
                 </Td>
               </Show>
               <Td>

--- a/client/src/popups/ConfirmAssignModal.tsx
+++ b/client/src/popups/ConfirmAssignModal.tsx
@@ -175,7 +175,7 @@ export function ConfirmAssignModal({
         action={"Copy"}
         createAssignment={true}
         createAssignmentCallback={(parentId) => {
-          const closeAtDateTime =
+          const closeAtDateTime: DateTime =
             duration === "custom"
               ? customCloseAt
                 ? DateTime.fromISO(customCloseAt).set({
@@ -187,9 +187,8 @@ export function ConfirmAssignModal({
                   .set({ second: 0, millisecond: 0 })
                   .plus(JSON.parse(duration));
 
-          const closeAt = closeAtDateTime.toISO({
-            suppressSeconds: true,
-            suppressMilliseconds: true,
+          const closeAt = closeAtDateTime.toUTC().toISO({
+            precision: "minutes",
           });
 
           submitFetcher.submit(

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -9,8 +9,7 @@
  * =====================================================================================
  */
 
-import { DateTime } from "luxon";
-import { isUuid, Uuid } from "./types_module_specific";
+import { DoenetDateTime, isUuid, Uuid } from "./types_module_specific";
 
 export type DoenetmlVersion = {
   id: number;
@@ -46,12 +45,12 @@ export type LibraryRelations = {
   activity?: {
     status: LibraryStatus;
     activityContentId: Uuid | null;
-    reviewRequestDate?: Date;
+    reviewRequestDate?: DoenetDateTime;
   };
   source?: {
     status: LibraryStatus;
     sourceContentId: Uuid | null;
-    reviewRequestDate?: DateTime;
+    reviewRequestDate?: DoenetDateTime;
     ownerRequested?: boolean;
     primaryEditor?: UserInfo;
     iAmPrimaryEditor?: boolean;
@@ -60,7 +59,7 @@ export type LibraryRelations = {
 
 export type LibraryComment = {
   user: UserInfo;
-  dateTime: DateTime;
+  dateTime: DoenetDateTime;
   comment: string;
   isMe: boolean;
 };
@@ -70,6 +69,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   isAuthor?: boolean;
+  isAnonymous?: boolean;
   numLibrary?: number;
   numCommunity?: number;
   isMaskForLibrary?: boolean;
@@ -243,7 +243,7 @@ export type Content = Doc | QuestionBank | ProblemSet | Folder;
 export type AssignmentInfo = {
   assignmentStatus: AssignmentStatus;
   classCode: string;
-  codeValidUntil: DateTime;
+  codeValidUntil: DoenetDateTime;
   hasScoreData: boolean;
   mode: AssignmentMode;
   individualizeByStudent: boolean;
@@ -280,7 +280,7 @@ export type ActivityRemixItem = {
 export type RemixContent = {
   contentId: Uuid;
   revisionNum: number;
-  timestamp: DateTime;
+  timestamp: DoenetDateTime;
   name: string;
   owner: UserInfo;
   cidAtLastUpdate: string;
@@ -337,5 +337,5 @@ export type ContentRevision = {
   source: string;
   doenetmlVersion: string | null;
   cid: string;
-  createdAt: DateTime;
+  createdAt: DoenetDateTime;
 };

--- a/client/src/types_module_specific.ts
+++ b/client/src/types_module_specific.ts
@@ -1,0 +1,5 @@
+export type Uuid = string;
+
+export function isUuid(obj: unknown): obj is Uuid {
+  return typeof obj === "string";
+}

--- a/client/src/types_module_specific.ts
+++ b/client/src/types_module_specific.ts
@@ -1,5 +1,11 @@
+/**
+ * Use this file for types are defined differently for the server and the client
+ */
+
 export type Uuid = string;
 
 export function isUuid(obj: unknown): obj is Uuid {
   return typeof obj === "string";
 }
+
+export type DoenetDateTime = string;

--- a/server/src/test/remix.test.ts
+++ b/server/src/test/remix.test.ts
@@ -663,7 +663,7 @@ describe("Remix tests", () => {
 
   test(
     "Update remixed chain of three to changed content, test all 12 orders",
-    { timeout: 30000 },
+    { timeout: 35000 },
     async () => {
       for (let firstUpdated = 0; firstUpdated < 3; firstUpdated++) {
         for (let secondUpdated = 0; secondUpdated < 3; secondUpdated++) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,16 @@
-import { ContentType, LibraryStatus, AssignmentMode } from "@prisma/client";
-import { prisma } from "./model";
+/**
+ * ====================================================================================
+ * MAINTAIN EQUIVALENT TYPES in client and server
+ * ---------------------------------------------------------------------------------
+ * This file should be exactly the same in both the client module and the server module!
+ * Use the file `types_module_specific.ts` for any types that are defined differently.
+ *
+ * If you make edits to this file, please copy and paste the full file to the other module.
+ * =====================================================================================
+ */
+
+import { DateTime } from "luxon";
+import { isUuid, Uuid } from "./types_module_specific";
 
 export type DoenetmlVersion = {
   id: number;
@@ -12,6 +23,13 @@ export type DoenetmlVersion = {
 };
 
 export type AssignmentStatus = "Unassigned" | "Closed" | "Open";
+
+/** This type must match the Prisma-defined enum `LibraryStatus` */
+export type LibraryStatus =
+  | "PENDING"
+  | "UNDER_REVIEW"
+  | "PUBLISHED"
+  | "REJECTED";
 
 /**
  * This type represents the library status of a provided content id in both directions.
@@ -27,13 +45,13 @@ export type AssignmentStatus = "Unassigned" | "Closed" | "Open";
 export type LibraryRelations = {
   activity?: {
     status: LibraryStatus;
-    activityContentId: Uint8Array | null;
+    activityContentId: Uuid | null;
     reviewRequestDate?: Date;
   };
   source?: {
     status: LibraryStatus;
-    sourceContentId: Uint8Array | null;
-    reviewRequestDate?: Date;
+    sourceContentId: Uuid | null;
+    reviewRequestDate?: DateTime;
     ownerRequested?: boolean;
     primaryEditor?: UserInfo;
     iAmPrimaryEditor?: boolean;
@@ -42,16 +60,15 @@ export type LibraryRelations = {
 
 export type LibraryComment = {
   user: UserInfo;
-  dateTime: Date;
+  dateTime: DateTime;
   comment: string;
   isMe: boolean;
 };
 
 export type UserInfo = {
-  userId: Uint8Array;
+  userId: Uuid;
   firstNames: string | null;
   lastNames: string;
-  isAnonymous?: boolean;
   isAuthor?: boolean;
   numLibrary?: number;
   numCommunity?: number;
@@ -63,7 +80,7 @@ export function isUserInfo(obj: unknown): obj is UserInfo {
   return (
     typedObj !== null &&
     typeof typedObj === "object" &&
-    typedObj.userId instanceof Uint8Array &&
+    isUuid(typedObj.userId) &&
     (typedObj.firstNames === null || typeof typedObj.firstNames === "string") &&
     typeof typedObj.lastNames === "string" &&
     (typedObj.numLibrary === undefined ||
@@ -147,6 +164,7 @@ export type PartialContentClassification = {
   numCommunity?: number;
 };
 
+export type ContentType = "singleDoc" | "select" | "sequence" | "folder";
 export function isContentType(type: unknown): type is ContentType {
   return (
     typeof type === "string" &&
@@ -154,9 +172,11 @@ export function isContentType(type: unknown): type is ContentType {
   );
 }
 
+export type AssignmentMode = "formative" | "summative";
+
 export type ContentBase = {
-  contentId: Uint8Array;
-  ownerId: Uint8Array;
+  contentId: Uuid;
+  ownerId: Uuid;
   owner?: UserInfo;
   name: string;
   isPublic: boolean;
@@ -174,7 +194,7 @@ export type ContentBase = {
   }[];
   classifications: ContentClassification[];
   parent: {
-    contentId: Uint8Array;
+    contentId: Uuid;
     name: string;
     type: ContentType;
     isPublic: boolean;
@@ -223,76 +243,12 @@ export type Content = Doc | QuestionBank | ProblemSet | Folder;
 export type AssignmentInfo = {
   assignmentStatus: AssignmentStatus;
   classCode: string;
-  codeValidUntil: Date;
+  codeValidUntil: DateTime;
   hasScoreData: boolean;
   mode: AssignmentMode;
   individualizeByStudent: boolean;
   maxAttempts: number;
 };
-
-export async function createContentInfo({
-  contentId,
-  ownerId,
-  contentType,
-}: {
-  contentId: Uint8Array;
-  ownerId: Uint8Array;
-  contentType: ContentType;
-}): Promise<Content> {
-  const contentBase: ContentBase = {
-    contentId: contentId,
-    name: "",
-    ownerId: ownerId,
-    isPublic: false,
-    isShared: false,
-    sharedWith: [],
-    licenseCode: null,
-    parent: null,
-    categories: [],
-    classifications: [],
-  };
-
-  switch (contentType) {
-    case "singleDoc": {
-      const defaultDoenetmlVersion =
-        await prisma.doenetmlVersions.findFirstOrThrow({
-          where: { default: true },
-        });
-      return {
-        type: "singleDoc",
-        numVariants: 1,
-        doenetML: "",
-        doenetmlVersion: defaultDoenetmlVersion,
-        ...contentBase,
-      };
-    }
-    case "select": {
-      return {
-        type: "select",
-        numToSelect: 1,
-        selectByVariant: false,
-        children: [],
-        ...contentBase,
-      };
-    }
-    case "sequence": {
-      return {
-        type: "sequence",
-        shuffle: false,
-        paginate: false,
-        children: [],
-        ...contentBase,
-      };
-    }
-    case "folder": {
-      return {
-        type: "folder",
-        children: [],
-        ...contentBase,
-      };
-    }
-  }
-}
 
 export type LicenseCode = "CCDUAL" | "CCBYSA" | "CCBYNCSA";
 
@@ -322,9 +278,9 @@ export type ActivityRemixItem = {
 };
 
 export type RemixContent = {
-  contentId: Uint8Array;
+  contentId: Uuid;
   revisionNum: number;
-  timestamp: Date;
+  timestamp: DateTime;
   name: string;
   owner: UserInfo;
   cidAtLastUpdate: string;
@@ -350,6 +306,30 @@ export type ClassificationCategoryTree = {
   }[];
 };
 
+export type ContentDescription = {
+  contentId: Uuid;
+  name: string;
+  type: ContentType;
+  parent: { contentId: string; type: ContentType } | null;
+};
+
+export function isContentDescription(obj: unknown): obj is ContentDescription {
+  const typedObj = obj as ContentDescription;
+  return (
+    typedObj !== null &&
+    typeof typedObj === "object" &&
+    isUuid(typedObj.contentId) &&
+    typeof typedObj.name === "string" &&
+    ["singleDoc", "folder", "sequence", "select"].includes(typedObj.type) &&
+    (typedObj.parent === null ||
+      (typeof typedObj.parent === "object" &&
+        typeof typedObj.parent.contentId === "string" &&
+        ["singleDoc", "folder", "sequence", "select"].includes(
+          typedObj.parent.type,
+        )))
+  );
+}
+
 export type ContentRevision = {
   revisionNum: number;
   revisionName: string;
@@ -357,5 +337,5 @@ export type ContentRevision = {
   source: string;
   doenetmlVersion: string | null;
   cid: string;
-  createdAt: Date;
+  createdAt: DateTime;
 };

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -9,8 +9,7 @@
  * =====================================================================================
  */
 
-import { DateTime } from "luxon";
-import { isUuid, Uuid } from "./types_module_specific";
+import { DoenetDateTime, isUuid, Uuid } from "./types_module_specific";
 
 export type DoenetmlVersion = {
   id: number;
@@ -46,12 +45,12 @@ export type LibraryRelations = {
   activity?: {
     status: LibraryStatus;
     activityContentId: Uuid | null;
-    reviewRequestDate?: Date;
+    reviewRequestDate?: DoenetDateTime;
   };
   source?: {
     status: LibraryStatus;
     sourceContentId: Uuid | null;
-    reviewRequestDate?: DateTime;
+    reviewRequestDate?: DoenetDateTime;
     ownerRequested?: boolean;
     primaryEditor?: UserInfo;
     iAmPrimaryEditor?: boolean;
@@ -60,7 +59,7 @@ export type LibraryRelations = {
 
 export type LibraryComment = {
   user: UserInfo;
-  dateTime: DateTime;
+  dateTime: DoenetDateTime;
   comment: string;
   isMe: boolean;
 };
@@ -70,6 +69,7 @@ export type UserInfo = {
   firstNames: string | null;
   lastNames: string;
   isAuthor?: boolean;
+  isAnonymous?: boolean;
   numLibrary?: number;
   numCommunity?: number;
   isMaskForLibrary?: boolean;
@@ -243,7 +243,7 @@ export type Content = Doc | QuestionBank | ProblemSet | Folder;
 export type AssignmentInfo = {
   assignmentStatus: AssignmentStatus;
   classCode: string;
-  codeValidUntil: DateTime;
+  codeValidUntil: DoenetDateTime;
   hasScoreData: boolean;
   mode: AssignmentMode;
   individualizeByStudent: boolean;
@@ -280,7 +280,7 @@ export type ActivityRemixItem = {
 export type RemixContent = {
   contentId: Uuid;
   revisionNum: number;
-  timestamp: DateTime;
+  timestamp: DoenetDateTime;
   name: string;
   owner: UserInfo;
   cidAtLastUpdate: string;
@@ -337,5 +337,5 @@ export type ContentRevision = {
   source: string;
   doenetmlVersion: string | null;
   cid: string;
-  createdAt: DateTime;
+  createdAt: DoenetDateTime;
 };

--- a/server/src/types_module_specific.ts
+++ b/server/src/types_module_specific.ts
@@ -1,0 +1,5 @@
+export type Uuid = Uint8Array;
+
+export function isUuid(obj: unknown): obj is Uuid {
+  return obj instanceof Uint8Array;
+}

--- a/server/src/types_module_specific.ts
+++ b/server/src/types_module_specific.ts
@@ -1,5 +1,11 @@
+/**
+ * Use this file for types are defined differently for the server and the client
+ */
+
 export type Uuid = Uint8Array;
 
 export function isUuid(obj: unknown): obj is Uuid {
   return obj instanceof Uint8Array;
 }
+
+export type DoenetDateTime = Date;


### PR DESCRIPTION
Re-format the `types.ts` files in server and client so that they are exactly the same. You should be able to copy-and-paste the entire file into the other.

There's a couple types we define differently between the two modules. I moved them into `types_module_specific.ts`.