### PR TITLE
Add doenetViewerUrl to Doenet viewers and editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -54,6 +54,7 @@
         "@types/react-router": "^5.1.20",
         "@vitejs/plugin-react": "^4.7.0",
         "@web/test-runner": "^0.20.2",
+        "cross-env": "^10.0.0",
         "esbuild": "^0.25.8",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
@@ -839,6 +840,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.2.3",
@@ -5344,6 +5352,24 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",
         "@doenet/assignment-viewer": "^0.1.0-alpha8",
-        "@doenet/doenetml-iframe": "^0.7.0-alpha55",
+        "@doenet/doenetml-iframe": "^0.7.0-beta2",
         "@fontsource/jost": "^5.2.6",
         "axios": "^1.11.0",
         "better-react-mathjax": "^2.1.0",
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@doenet/doenetml-iframe": {
-      "version": "0.7.0-alpha55",
-      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-alpha55.tgz",
-      "integrity": "sha512-XHF5+P6B9/KdhVuK0DNS5YjMjY0ecMfcprsUa/VbfoJOYrl4VokABEOHE35Ca8BkoYIoL5hUiY7fM3DBRN6N5g==",
+      "version": "0.7.0-beta2",
+      "resolved": "https://registry.npmjs.org/@doenet/doenetml-iframe/-/doenetml-iframe-0.7.0-beta2.tgz",
+      "integrity": "sha512-WZ7VnElYrUIHEsPWYKhFwf4YGxhOI0XwojygWypLKcsYGlICV2YB9PopsFQr3GkUYXR/2Fn0+ACUBChCmDZ7Uw==",
       "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "react": "^19.1.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",
-        "@doenet/assignment-viewer": "^0.1.0-alpha8",
+        "@doenet/assignment-viewer": "^0.1.0-alpha9",
         "@doenet/doenetml-iframe": "^0.7.0-beta2",
         "@fontsource/jost": "^5.2.6",
         "axios": "^1.11.0",
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@doenet/assignment-viewer": {
-      "version": "0.1.0-alpha8",
-      "resolved": "https://registry.npmjs.org/@doenet/assignment-viewer/-/assignment-viewer-0.1.0-alpha8.tgz",
-      "integrity": "sha512-c/XFOm7i7WSX6ggvEiFpi9pqaVEmDdQ4fUbkP2XZJU2StdoDQZveA+naz1RG3zy7A8oyJZpCb5a/uAadOjDoiw==",
+      "version": "0.1.0-alpha9",
+      "resolved": "https://registry.npmjs.org/@doenet/assignment-viewer/-/assignment-viewer-0.1.0-alpha9.tgz",
+      "integrity": "sha512-kwBx23Q89Zq9fgdCogKQVS8vtdC2HAhDFgC7ow6WrOa7u9puBKTTyzgOTC3Z0O8F6GA2Hup7iLMjuCeingljLA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "nanoid": "^5.1.5",
@@ -680,7 +680,7 @@
         "seedrandom": "^3.0.5"
       },
       "peerDependencies": {
-        "@doenet/doenetml-iframe": "^0.7.0-alpha53",
+        "@doenet/doenetml-iframe": "^0.7.0-beta2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "cross-env NODE_ENV=production vite",
     "build": "tsc && vite build",
     "test": "cypress open",
     "test:all": "cypress run -b 'chrome' --config video=false --headless",
@@ -59,6 +59,7 @@
     "@types/react-router": "^5.1.20",
     "@vitejs/plugin-react": "^4.7.0",
     "@web/test-runner": "^0.20.2",
+    "cross-env": "^10.0.0",
     "esbuild": "^0.25.8",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.9",
-    "@doenet/assignment-viewer": "^0.1.0-alpha8",
+    "@doenet/assignment-viewer": "^0.1.0-alpha9",
     "@doenet/doenetml-iframe": "^0.7.0-beta2",
     "@fontsource/jost": "^5.2.6",
     "axios": "^1.11.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.9",
     "@doenet/assignment-viewer": "^0.1.0-alpha8",
-    "@doenet/doenetml-iframe": "^0.7.0-alpha55",
+    "@doenet/doenetml-iframe": "^0.7.0-beta2",
     "@fontsource/jost": "^5.2.6",
     "axios": "^1.11.0",
     "better-react-mathjax": "^2.1.0",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -7,6 +7,8 @@ import {
 } from "react-router";
 import { createRoot } from "react-dom/client";
 
+import "@doenet/doenetml-iframe/style.css";
+
 import { MathJaxContext } from "better-react-mathjax";
 import {
   loader as exploreLoader,

--- a/client/src/paths/ActivityViewer.tsx
+++ b/client/src/paths/ActivityViewer.tsx
@@ -277,6 +277,9 @@ export function ActivityViewer() {
 
   let mainContent: ReactElement<any> = <></>;
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   if (data.type === "singleDoc") {
     if (mode === "Edit") {
       const initialWarnings = getDoenetMLDeprecationWarnings(
@@ -292,6 +295,7 @@ export function ActivityViewer() {
           initialWarnings={initialWarnings}
           border="none"
           readOnly={true}
+          doenetViewerUrl={doenetViewerUrl}
         />
       );
     } else {
@@ -312,12 +316,7 @@ export function ActivityViewer() {
               allowSaveEvents: false,
             }}
             attemptNumber={1}
-            location={location}
-            navigate={navigate}
-            linkSettings={{
-              viewURL: "",
-              editURL: "",
-            }}
+            doenetViewerUrl={doenetViewerUrl}
             includeVariantSelector={true}
           />
         </BlueBanner>
@@ -352,6 +351,7 @@ export function ActivityViewer() {
             }
             maxAttemptsAllowed={activityData.assignmentInfo?.maxAttempts}
             showTitle={false}
+            doenetViewerUrl={doenetViewerUrl}
           />
         </BlueBanner>
       );

--- a/client/src/paths/AssignmentViewer.tsx
+++ b/client/src/paths/AssignmentViewer.tsx
@@ -559,6 +559,9 @@ export function AssignmentViewer() {
     return <ChangeName hideHomeButton />;
   }
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   let viewer: ReactElement<any>;
   if (loaderData.type === "singleDoc") {
     const maxAttempts = assignment.assignmentInfo?.maxAttempts ?? 0;
@@ -601,12 +604,7 @@ export function AssignmentViewer() {
             allowSaveEvents: true,
           }}
           attemptNumber={attemptNumber}
-          location={location}
-          navigate={navigate}
-          linkSettings={{
-            viewURL: "/activityViewer",
-            editURL: "/codeViewer",
-          }}
+          doenetViewerUrl={doenetViewerUrl}
         />
       </Box>
     );
@@ -619,7 +617,7 @@ export function AssignmentViewer() {
           // DoenetActivityViewer adjusts variant based on attempt number, so we don't need to add it to initial variant
           requestedVariantIndex={initialVariant}
           userId={user.userId}
-          linkSettings={{ viewUrl: "", editURL: "" }}
+          doenetViewerUrl={doenetViewerUrl}
           paginate={
             assignment.type === "sequence" ? assignment.paginate : false
           }

--- a/client/src/paths/CodeViewer.tsx
+++ b/client/src/paths/CodeViewer.tsx
@@ -102,6 +102,9 @@ export function CodeViewer() {
     document.title = `${label} - Doenet`;
   }, [label]);
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   return (
     <>
       {activityData ? (
@@ -259,6 +262,7 @@ export function CodeViewer() {
             border="none"
             showFormatter={false}
             showErrorsWarnings={false}
+            doenetViewerUrl={doenetViewerUrl}
           />
         </GridItem>
       </Grid>

--- a/client/src/paths/DoenetMLComparison.tsx
+++ b/client/src/paths/DoenetMLComparison.tsx
@@ -129,6 +129,9 @@ export function DoenetMLComparison() {
     updateMessage = `Show possible actions for updating your activity from the ${compareRelation === "source" ? "remix source" : "remixed activity"}`;
   }
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   const currentEditor = (
     <Box height="100%">
       <Flex
@@ -157,6 +160,7 @@ export function DoenetMLComparison() {
         viewerLocation="bottom"
         showErrorsWarnings={false}
         showResponses={false}
+        doenetViewerUrl={doenetViewerUrl}
       />
     </Box>
   );
@@ -201,6 +205,7 @@ export function DoenetMLComparison() {
         readOnly={true}
         showErrorsWarnings={false}
         showResponses={false}
+        doenetViewerUrl={doenetViewerUrl}
       />
     </Box>
   );

--- a/client/src/paths/Home.tsx
+++ b/client/src/paths/Home.tsx
@@ -32,7 +32,7 @@ export async function loader() {
 
 const HomeIntroVideo = lazy(() => import("../widgets/HomeIntroVideo"));
 
-const doenetmlVersion = "0.7.0-alpha55";
+const doenetmlVersion = "0.7.0-beta2";
 const doenetML = `
 <example>
 <setup>
@@ -524,10 +524,6 @@ export function Home() {
                 attemptNumber={1}
                 // setIsInErrorState={setIsInErrorState}
                 addBottomPadding={false}
-                linkSettings={{
-                  viewURL: "/activityViewer",
-                  editURL: "/codeViewer",
-                }}
               />
             </Flex>
           </Show>

--- a/client/src/paths/editor/CompoundEditorViewMode.tsx
+++ b/client/src/paths/editor/CompoundEditorViewMode.tsx
@@ -45,13 +45,16 @@ export function CompoundEditorViewMode() {
     maxAttemptsAllowed?: number;
   };
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   return (
     <BlueBanner>
       <DoenetActivityViewer
         source={source}
         requestedVariantIndex={1}
         userId={"hi"}
-        linkSettings={{ viewUrl: "", editURL: "" }}
+        doenetViewerUrl={doenetViewerUrl}
         paginate={paginate}
         activityLevelAttempts={activityLevelAttempts}
         itemLevelAttempts={itemLevelAttempts}

--- a/client/src/paths/editor/DocEditorEditMode.tsx
+++ b/client/src/paths/editor/DocEditorEditMode.tsx
@@ -130,6 +130,9 @@ function DocumentEditor({
     };
   }, [handleSaveDoc]);
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   return (
     <DoenetEditor
       height={`calc(100vh - ${headerHeight})`}
@@ -154,6 +157,7 @@ function DocumentEditor({
       initialWarnings={initialWarnings}
       border="none"
       readOnly={readOnly}
+      doenetViewerUrl={doenetViewerUrl}
     />
   );
 }

--- a/client/src/paths/editor/DocEditorHistoryMode.tsx
+++ b/client/src/paths/editor/DocEditorHistoryMode.tsx
@@ -161,6 +161,9 @@ export function DocEditorHistoryMode() {
     />
   );
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   let updateButton: ReactElement<any> | null = null;
   if (selectedRevision) {
     const message =
@@ -226,6 +229,7 @@ export function DocEditorHistoryMode() {
         viewerLocation="bottom"
         showErrorsWarnings={false}
         showResponses={false}
+        doenetViewerUrl={doenetViewerUrl}
       />
     </Box>
   );
@@ -308,6 +312,7 @@ export function DocEditorHistoryMode() {
             showErrorsWarnings={false}
             showResponses={false}
             readOnly={true}
+            doenetViewerUrl={doenetViewerUrl}
           />
         </>
       ) : (

--- a/client/src/paths/editor/DocEditorViewMode.tsx
+++ b/client/src/paths/editor/DocEditorViewMode.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { useLoaderData, useNavigate } from "react-router";
+import { useLoaderData } from "react-router";
 import { DoenetmlVersion } from "../../types";
-import { useLocation } from "react-router";
 import { DoenetViewer } from "@doenet/doenetml-iframe";
 import { BlueBanner } from "../../widgets/BlueBanner";
 import axios from "axios";
@@ -27,8 +26,8 @@ export function DocEditorViewMode() {
     doenetmlVersion: DoenetmlVersion | null;
   };
 
-  const location = useLocation();
-  const navigate = useNavigate();
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
 
   return (
     <BlueBanner>
@@ -47,12 +46,7 @@ export function DocEditorViewMode() {
           allowSaveEvents: false,
         }}
         attemptNumber={1}
-        location={location}
-        navigate={navigate}
-        linkSettings={{
-          viewURL: "",
-          editURL: "",
-        }}
+        doenetViewerUrl={doenetViewerUrl}
         includeVariantSelector={true}
       />
     </BlueBanner>

--- a/client/src/views/AssignmentItemResponseStudent.tsx
+++ b/client/src/views/AssignmentItemResponseStudent.tsx
@@ -146,6 +146,9 @@ export function AssignmentItemResponseStudent({
       />
     ) : null;
 
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
+
   const viewer = (
     <DoenetViewer
       doenetML={doenetML}
@@ -168,10 +171,7 @@ export function AssignmentItemResponseStudent({
       //   forceShowCorrectness={true}
       forceShowSolution={true}
       forceUnsuppressCheckwork={true}
-      linkSettings={{
-        viewURL: "/activityViewer",
-        editURL: "/codeViewer",
-      }}
+      doenetViewerUrl={doenetViewerUrl}
       showAnswerResponseButton={true}
       answerResponseCounts={responseCounts}
     />

--- a/client/src/views/AssignmentPreview.tsx
+++ b/client/src/views/AssignmentPreview.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { Box } from "@chakra-ui/react";
 import { DoenetViewer } from "@doenet/doenetml-iframe";
-import { useLocation, useNavigate } from "react-router";
 import { DoenetmlVersion } from "../types";
 import { ActivitySource } from "../viewerTypes";
 // @ts-expect-error assignment-viewer doesn't publish types, see https://github.com/Doenet/assignment-viewer/issues/20
@@ -35,10 +34,10 @@ export default function AssignmentPreview({
     allPossibleVariants: ["a"],
   });
 
-  const navigate = useNavigate();
-  const location = useLocation();
-
   let viewer: ReactElement<any> | null = null;
+
+  const baseUrl = window.location.host;
+  const doenetViewerUrl = `${baseUrl}/activityViewer`;
 
   if (active) {
     if (data.type === "singleDoc") {
@@ -60,12 +59,7 @@ export default function AssignmentPreview({
           attemptNumber={1}
           generatedVariantCallback={setVariants}
           requestedVariantIndex={variants.index}
-          location={location}
-          navigate={navigate}
-          linkSettings={{
-            viewURL: "/activityViewer",
-            editURL: "/codeViewer",
-          }}
+          doenetViewerUrl={doenetViewerUrl}
           showAnswerTitles={true}
         />
       );
@@ -79,7 +73,7 @@ export default function AssignmentPreview({
         <DoenetActivityViewer
           source={source}
           requestedVariantIndex={1}
-          linkSettings={{ viewUrl: "", editURL: "" }}
+          doenetViewerUrl={doenetViewerUrl}
           paginate={false}
           showTitle={false}
           flags={{

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -29,7 +29,7 @@ async function seedDoenetMLVersions() {
   });
   await updateOrCreateDoenetMLVersion({
     displayedVersion: "0.7",
-    fullVersion: "0.7.0-alpha55",
+    fullVersion: "0.7.0-beta2",
     default: true,
   });
 }

--- a/server/src/test/activity.test.ts
+++ b/server/src/test/activity.test.ts
@@ -46,7 +46,7 @@ import { isEqualUUID } from "../utils/uuid";
 const currentDoenetmlVersion = {
   id: 2,
   displayedVersion: "0.7",
-  fullVersion: "0.7.0-alpha55",
+  fullVersion: "0.7.0-beta2",
   default: true,
   deprecated: false,
   removed: false,

--- a/server/src/test/assign.test.ts
+++ b/server/src/test/assign.test.ts
@@ -926,7 +926,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
+      doenetmlVersion: { fullVersion: "0.7.0-beta2" },
     },
   });
 
@@ -963,7 +963,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
+      doenetmlVersion: { fullVersion: "0.7.0-beta2" },
     },
   });
 
@@ -1000,7 +1000,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
+      doenetmlVersion: { fullVersion: "0.7.0-beta2" },
     },
   });
 
@@ -1075,7 +1075,7 @@ test("get assignment data from anonymous users", async () => {
     source: {
       name: "Activity 1",
       doenetML: "Some content",
-      doenetmlVersion: { fullVersion: "0.7.0-alpha55" },
+      doenetmlVersion: { fullVersion: "0.7.0-beta2" },
     },
   });
 });


### PR DESCRIPTION
This PR sets the `doenetViewerUrl` attribute on `<DoenetViewer>`, `<DoenetEditor>` and `<DoenetActivityViewer>` so that references to external DoenetML point to the `activityViewer` URL on the server.

It also upgrades DoenetML to beta2 and fixes the virtual keyboard.