### PR TITLE
Remove create question bank button

### DIFF
--- a/client/src/dropdowns/CreateContentMenu.tsx
+++ b/client/src/dropdowns/CreateContentMenu.tsx
@@ -126,27 +126,6 @@ export function CreateContentMenu({
           >
             {menuIcons.folder} Folder
           </MenuItem>
-          <Tooltip
-            openDelay={500}
-            label={
-              followAllowedParents && !allowedParents.includes("select")
-                ? "Some selected items cannot be added to a question bank"
-                : null
-            }
-          >
-            <MenuItem
-              data-test="Create Question Bank"
-              isDisabled={
-                followAllowedParents && !allowedParents.includes("select")
-              }
-              onClick={() => {
-                setCreateNewType("select");
-                createDialogOnOpen();
-              }}
-            >
-              {menuIcons.select} Question bank
-            </MenuItem>
-          </Tooltip>
         </MenuList>
       </Menu>
     </>

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -717,18 +717,6 @@ export function Activities() {
                 >
                   Folder
                 </MenuItem>
-                <MenuItem
-                  data-test="Add Question Bank Button"
-                  onClick={() => {
-                    setHaveContentSpinner(true);
-                    fetcher.submit(
-                      { _action: "Add Activity", type: "select" },
-                      { method: "post" },
-                    );
-                  }}
-                >
-                  Question Bank
-                </MenuItem>
               </MenuList>
             </Menu>
 

--- a/client/src/popups/AddContentToMenu.tsx
+++ b/client/src/popups/AddContentToMenu.tsx
@@ -308,30 +308,6 @@ export function AddContentToMenu({
               {menuIcons.folder} Folder
             </MenuItem>
           </Tooltip>
-          <Tooltip
-            openDelay={500}
-            label={
-              !baseContains.includes("select")
-                ? "No existing question banks"
-                : restrictToAllowedParents && !allowedParents.includes("select")
-                  ? "Some selected items cannot be added to a question bank"
-                  : null
-            }
-          >
-            <MenuItem
-              data-test="Add To Question Bank"
-              isDisabled={
-                !baseContains.includes("select") ||
-                (restrictToAllowedParents && !allowedParents.includes("select"))
-              }
-              onClick={() => {
-                setAddToType("select");
-                moveCopyContentOnOpen();
-              }}
-            >
-              {menuIcons.select} Question bank
-            </MenuItem>
-          </Tooltip>
           <MenuItem
             data-test="Add To My Activities"
             onClick={() => {

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -50,10 +50,7 @@ import {
 } from "../dropdowns/CreateContentMenu";
 import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { DeleteContent, deleteContentActions } from "../popups/DeleteContent";
-import {
-  CreateLocalContent,
-  createLocalContentActions,
-} from "../popups/CreateLocalContent";
+import { createLocalContentActions } from "../popups/CreateLocalContent";
 import {
   ActivateAuthorMode,
   activateAuthorModeActions,
@@ -275,23 +272,6 @@ export function CompoundActivityEditor({
       finalFocusRef={finalFocusRef}
     />
   ) : null;
-
-  const {
-    isOpen: createQuestionBankIsOpen,
-    onOpen: createQuestionBankOnOpen,
-    onClose: createQuestionBankOnClose,
-  } = useDisclosure();
-
-  const createQuestionBankModal = (
-    <CreateLocalContent
-      isOpen={createQuestionBankIsOpen}
-      onClose={createQuestionBankOnClose}
-      contentType="select"
-      parentId={activity.contentId}
-      fetcher={fetcher}
-      finalFocusRef={finalFocusRef}
-    />
-  );
 
   const {
     isOpen: authorModePromptIsOpen,
@@ -815,16 +795,6 @@ export function CompoundActivityEditor({
           >
             Items from My Activities
           </MenuItem>
-          {activity.type === "sequence" ? (
-            <MenuItem
-              data-test="Add Question Bank Button"
-              onClick={() => {
-                createQuestionBankOnOpen();
-              }}
-            >
-              Empty Question Bank
-            </MenuItem>
-          ) : null}
           <MenuItem
             data-test="Add Document Button"
             onClick={() => {
@@ -848,7 +818,6 @@ export function CompoundActivityEditor({
       {moveContentModal}
       {copyContentModal}
       {deleteModal}
-      {createQuestionBankModal}
       {authorModeModal}
       {heading}
       <Flex

--- a/server/src/query/activity.ts
+++ b/server/src/query/activity.ts
@@ -35,6 +35,15 @@ export async function createContent({
   inLibrary?: boolean;
   name?: string;
 }) {
+  // TODO: Eventually, when we are sure we do not want question banks,
+  // we will remove them entirely from the codebase. For now, just
+  // log it in the server
+  if (contentType === "select") {
+    console.log(
+      "Creating new question bank. They are deprecated and will be removed shortly.",
+    );
+  }
+
   let ownerId = loggedInUserId;
   if (inLibrary) {
     await mustBeEditor(loggedInUserId);


### PR DESCRIPTION
Remove all the buttons that allow you to add a question bank.

The server still allows creating them. After a while, when we're sure we don't want question banks,
we can remove all and code and tests relating to them.