### PR TITLE
Fix student response page

### DIFF
--- a/server/src/schemas/rangedNumber.ts
+++ b/server/src/schemas/rangedNumber.ts
@@ -5,12 +5,19 @@ import { z } from "zod";
  * The upper bound is the max number that can be stored in an `unsigned small int` field.
  */
 export const rangedNumber = z.int().gte(1).lte(65535);
+
 /**
  * A string coerced to an integer in the range [1, 65535] inclusive.
  * The upper bound is the max number that can be stored in an `unsigned small int` field
  *
  * Use this alternative to `rangedNumber` for `GET` requests where all parameters are inherently strings.
  */
-export const stringAsRangedNumber = z.int().gte(1).lte(65535);
+export const stringAsRangedNumber = z.coerce.number().int();
+// We're using legacy number().int() because you can't coerce directly to int
 
-export const stringAsRangedNumberIncludingZero = z.int().gte(0).lte(65535);
+export const stringAsRangedNumberIncludingZero = z.coerce
+  .number()
+  .int()
+  .gte(0)
+  .lte(65535);
+// We're using legacy number().int() because you can't coerce directly to int


### PR DESCRIPTION
Fix Zod's schema so that it allows the student response page to load.

Zod confined `stringAsRangedNumber` to an integer, but that doesn't work for GET parameters which are inherently strings.
Now it's _coerced_ to an integer.