### PR TITLE
Fix adjusting close datetime

### DIFF
--- a/server/src/schemas/assignSchema.ts
+++ b/server/src/schemas/assignSchema.ts
@@ -10,7 +10,9 @@ import {
 
 export const assignmentCloseAtSchema = z.object({
   contentId: uuidSchema,
-  closeAt: z.iso.datetime().transform((val) => DateTime.fromISO(val)),
+  closeAt: z.iso
+    .datetime({ offset: true })
+    .transform((val) => DateTime.fromISO(val)),
 });
 
 export const createAssignmentSchema = assignmentCloseAtSchema.extend({


### PR DESCRIPTION
Fix the schema involved with setting the close datetime of an assigmnent. Update `assignmentCloseAtSchema` to allow ISO offsets.