### PR TITLE
Fix move document modal heading

### DIFF
--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -389,7 +389,7 @@ export function MoveCopyContent({
               ${
                 allowedParentTypes.length === 1
                   ? `to ${contentTypeToName[allowedParentTypes[0]].toLowerCase()}`
-                  : null
+                  : ""
               }`;
   }
 


### PR DESCRIPTION
The heading used to display `null` for documents.