### PR TITLE
Re-enable sharing folders with specific people

### DIFF
--- a/client/src/dropdowns/CreateContentMenu.tsx
+++ b/client/src/dropdowns/CreateContentMenu.tsx
@@ -12,7 +12,6 @@ import {
 } from "@chakra-ui/react";
 import { getAllowedParentTypes, menuIcons } from "../utils/activity";
 import { CreateContentAndPromptName } from "../popups/CreateContentAndPromptName";
-import { FetcherWithComponents } from "react-router";
 
 export function CreateContentMenu({
   sourceContent,
@@ -20,7 +19,6 @@ export function CreateContentMenu({
   label,
   colorScheme,
   followAllowedParents = false,
-  fetcher,
 }: {
   sourceContent: ContentDescription[];
   size?: ResponsiveValue<(string & {}) | "xs" | "sm" | "md" | "lg">;
@@ -40,7 +38,6 @@ export function CreateContentMenu({
     | "whiteAlpha"
     | "blackAlpha";
   followAllowedParents?: boolean;
-  fetcher: FetcherWithComponents<any>;
 }) {
   const [createNewType, setCreateNewType] = useState<ContentType>("folder");
   const [allowedParents, setAllowedParents] = useState<ContentType[]>([]);

--- a/client/src/dropdowns/CreateContentMenu.tsx
+++ b/client/src/dropdowns/CreateContentMenu.tsx
@@ -11,22 +11,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { getAllowedParentTypes, menuIcons } from "../utils/activity";
-import {
-  CreateContentAndPromptName,
-  createContentAndPromptNameActions,
-} from "../popups/CreateContentAndPromptName";
+import { CreateContentAndPromptName } from "../popups/CreateContentAndPromptName";
 import { FetcherWithComponents } from "react-router";
-
-export async function createContentMenuActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  const resultCC = createContentAndPromptNameActions({ formObj });
-  if (resultCC) {
-    return resultCC;
-  }
-}
 
 export function CreateContentMenu({
   sourceContent,

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -452,6 +452,10 @@ const router = createBrowserRouter([
 const root = createRoot(document.getElementById("root")!);
 root.render(<RouterProvider router={router} />);
 
+// TODO before merge::
+// Should `genericAction` return the entire http request or just the data portion?
+// For example, do we want fetchers to be able to check the status number?
+
 // TODO: BUG: Mechanism to redirect for some endpoints, such as the one for creating content
 async function genericAction({ request, params }: ActionFunctionArgs) {
   const { path, ...body } = await request.json();

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -119,7 +119,6 @@ import {
 import {
   CompoundEditorEditMode,
   loader as compoundEditorEditModeLoader,
-  action as compoundEditorEditModeAction,
 } from "./paths/editor/CompoundEditorEditMode";
 import {
   EditorSettingsMode,
@@ -325,7 +324,7 @@ const router = createBrowserRouter([
           {
             path: "edit",
             loader: compoundEditorEditModeLoader,
-            action: compoundEditorEditModeAction,
+            action: genericAction,
             element: <CompoundEditorEditMode />,
             errorElement: <ErrorPage />,
           },

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -25,11 +25,7 @@ import {
 } from "./paths/SiteHeader";
 import { loader as carouselLoader, Home } from "./paths/Home";
 
-import {
-  loader as activitiesLoader,
-  action as activitiesAction,
-  Activities,
-} from "./paths/Activities";
+import { loader as activitiesLoader, Activities } from "./paths/Activities";
 import {
   loader as sharedActivitiesLoader,
   action as sharedActivitiesAction,
@@ -245,7 +241,7 @@ const router = createBrowserRouter([
       {
         path: "activities/:userId/:parentId?",
         loader: activitiesLoader,
-        action: activitiesAction,
+        action: genericAction,
         element: <Activities />,
         errorElement: <ErrorPage />,
       },
@@ -273,7 +269,7 @@ const router = createBrowserRouter([
       {
         path: "documentEditor/:contentId",
         loader: editorHeaderLoader,
-        action: genericContentIdAction,
+        action: genericAction,
         element: <EditorHeader />,
         errorElement: <ErrorPage />,
         children: [
@@ -292,28 +288,28 @@ const router = createBrowserRouter([
           {
             path: "settings",
             loader: docEditorSettingsModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <EditorSettingsMode />,
             errorElement: <ErrorPage />,
           },
           {
             path: "history",
             loader: docEditorHistoryModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <DocEditorHistoryMode />,
             errorElement: <ErrorPage />,
           },
           {
             path: "remixes",
             loader: docEditorRemixModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <DocEditorRemixMode />,
             errorElement: <ErrorPage />,
           },
           {
             path: "library",
             loader: editorLibraryModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <EditorLibraryMode />,
             errorElement: <ErrorPage />,
           },
@@ -322,7 +318,7 @@ const router = createBrowserRouter([
       {
         path: "compoundEditor/:contentId",
         loader: editorHeaderLoader,
-        action: genericContentIdAction,
+        action: genericAction,
         element: <EditorHeader />,
         errorElement: <ErrorPage />,
         children: [
@@ -342,14 +338,14 @@ const router = createBrowserRouter([
           {
             path: "settings",
             loader: docEditorSettingsModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <EditorSettingsMode />,
             errorElement: <ErrorPage />,
           },
           {
             path: "remixes",
             loader: docEditorRemixModeLoader,
-            action: genericContentIdAction,
+            action: genericAction,
             element: <DocEditorRemixMode />,
             errorElement: <ErrorPage />,
           },
@@ -390,7 +386,7 @@ const router = createBrowserRouter([
       {
         path: "assignmentData/:contentId",
         loader: assignmentResponseOverviewLoader,
-        action: genericContentIdAction,
+        action: genericAction,
         element: <AssignmentResponseOverview />,
         errorElement: <ErrorPage />,
       },
@@ -456,12 +452,20 @@ const router = createBrowserRouter([
 const root = createRoot(document.getElementById("root")!);
 root.render(<RouterProvider router={router} />);
 
-async function genericContentIdAction({ request, params }: ActionFunctionArgs) {
+// TODO: BUG: Mechanism to redirect for some endpoints, such as the one for creating content
+async function genericAction({ request, params }: ActionFunctionArgs) {
   const { path, ...body } = await request.json();
+
+  // If the content id is part of this page's path,
+  // we'll add it to the request body.
+  // In the future, we might want to disable this for some requests, TBD.
+  const contentIdParam = params.contentId
+    ? { contentId: params.contentId }
+    : {};
 
   try {
     await axios.post(`/api/${path}`, {
-      contentId: params.contentId,
+      ...contentIdParam,
       ...body,
     });
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -464,12 +464,11 @@ async function genericAction({ request, params }: ActionFunctionArgs) {
     : {};
 
   try {
-    await axios.post(`/api/${path}`, {
+    const results = await axios.post(`/api/${path}`, {
       ...contentIdParam,
       ...body,
     });
-
-    return null;
+    return results;
   } catch (e) {
     /**
      * Special case: sharing content with specific people by email address

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,11 +10,7 @@ import { createRoot } from "react-dom/client";
 import "@doenet/doenetml-iframe/style.css";
 
 import { MathJaxContext } from "better-react-mathjax";
-import {
-  loader as exploreLoader,
-  action as exploreAction,
-  Explore,
-} from "./paths/Explore";
+import { loader as exploreLoader, Explore } from "./paths/Explore";
 
 import { loader as curateLoader, Curate } from "./paths/Curate";
 
@@ -24,19 +20,13 @@ import { loader as carouselLoader, Home } from "./paths/Home";
 import { loader as activitiesLoader, Activities } from "./paths/Activities";
 import {
   loader as sharedActivitiesLoader,
-  action as sharedActivitiesAction,
   SharedActivities,
 } from "./paths/SharedActivities";
 import {
   loader as activityViewerLoader,
-  action as activityViewerAction,
   ActivityViewer,
 } from "./paths/ActivityViewer";
-import {
-  loader as assignedLoader,
-  action as assignedAction,
-  Assigned,
-} from "./paths/Assigned";
+import { loader as assignedLoader, Assigned } from "./paths/Assigned";
 import {
   loader as assignmentResponseOverviewLoader,
   AssignmentData as AssignmentResponseOverview,
@@ -63,11 +53,7 @@ import {
   StudentAssignmentScores,
   assignedDataloader,
 } from "./paths/StudentAssignmentScores";
-import {
-  loader as trashLoader,
-  action as trashAction,
-  Trash,
-} from "./paths/Trash";
+import { loader as trashLoader, Trash } from "./paths/Trash";
 import { ChakraProvider, extendTheme } from "@chakra-ui/react";
 
 import ErrorPage from "./paths/ErrorPage";
@@ -98,7 +84,6 @@ import {
 import {
   LibraryActivities,
   loader as libraryActivitiesLoader,
-  action as libraryActivitiesAction,
 } from "./paths/LibraryActivities";
 import {
   DocEditorViewMode,
@@ -216,7 +201,7 @@ const router = createBrowserRouter([
       {
         path: "explore/:systemId?/:categoryId?/:subCategoryId?/:classificationId?",
         loader: exploreLoader,
-        action: exploreAction,
+        action: genericAction,
         element: <Explore />,
         errorElement: <ErrorPage />,
       },
@@ -229,7 +214,7 @@ const router = createBrowserRouter([
       {
         path: "libraryActivities/:parentId?",
         loader: libraryActivitiesLoader,
-        action: libraryActivitiesAction,
+        action: genericAction,
         element: <LibraryActivities />,
         errorElement: <ErrorPage />,
       },
@@ -243,21 +228,21 @@ const router = createBrowserRouter([
       {
         path: "trash",
         loader: trashLoader,
-        action: trashAction,
+        action: genericAction,
         element: <Trash />,
         errorElement: <ErrorPage />,
       },
       {
         path: "sharedActivities/:ownerId/:parentId?",
         loader: sharedActivitiesLoader,
-        action: sharedActivitiesAction,
+        action: genericAction,
         element: <SharedActivities />,
         errorElement: <ErrorPage />,
       },
       {
         path: "activityViewer/:contentId",
         loader: activityViewerLoader,
-        action: activityViewerAction,
+        action: genericAction,
         errorElement: <ErrorPage />,
         element: <ActivityViewer />,
       },
@@ -361,7 +346,7 @@ const router = createBrowserRouter([
       },
       {
         path: "assigned",
-        action: assignedAction,
+        // no actions on this page
         loader: assignedLoader,
         element: <Assigned />,
         errorElement: <ErrorPage />,

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -120,6 +120,7 @@ import {
   EditorLibraryMode,
   loader as editorLibraryModeLoader,
 } from "./paths/editor/EditorLibraryMode";
+import { editorUrl } from "./utils/url";
 
 const theme = extendTheme({
   fonts: {
@@ -439,8 +440,13 @@ root.render(<RouterProvider router={router} />);
 
 // TODO: BUG: Mechanism to redirect for some endpoints, such as the one for creating content
 async function genericAction({ request, params }: ActionFunctionArgs) {
-  const { path, redirectOnSuccess, replaceOnSuccess, ...body } =
-    await request.json();
+  const {
+    path,
+    redirectOnSuccess,
+    replaceOnSuccess,
+    redirectNewContentId,
+    ...body
+  } = await request.json();
 
   // If the content id is part of this page's path,
   // we'll add it to the request body.
@@ -456,7 +462,10 @@ async function genericAction({ request, params }: ActionFunctionArgs) {
     });
 
     // TODO: Is this a good pattern?
-    if (replaceOnSuccess) {
+    if (redirectNewContentId) {
+      const newContentId: string = results.data.contentId;
+      return redirect(editorUrl(newContentId, body.contentType));
+    } else if (replaceOnSuccess) {
       return replace(redirectOnSuccess);
     } else if (redirectOnSuccess) {
       return redirect(redirectOnSuccess);

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -18,11 +18,7 @@ import {
 
 import { loader as curateLoader, Curate } from "./paths/Curate";
 
-import {
-  loader as siteLoader,
-  action as siteAction,
-  SiteHeader,
-} from "./paths/SiteHeader";
+import { loader as siteLoader, SiteHeader } from "./paths/SiteHeader";
 import { loader as carouselLoader, Home } from "./paths/Home";
 
 import { loader as activitiesLoader, Activities } from "./paths/Activities";
@@ -213,7 +209,7 @@ const router = createBrowserRouter([
       {
         path: "/",
         loader: carouselLoader,
-        action: siteAction,
+        action: genericAction,
         errorElement: <ErrorPage />,
         element: <Home />,
       },

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -538,17 +538,22 @@ export function Activities() {
         </Box>
       </Flex>
 
-      <Heading
-        as="h2"
-        size="lg"
-        marginBottom=".5em"
-        noOfLines={1}
-        maxHeight="1.5em"
-        lineHeight="normal"
-        data-test="Folder Heading"
-      >
-        <Tooltip label={headingText}>{headingText}</Tooltip>
-      </Heading>
+      <HStack justify="center" align="center">
+        <Heading
+          as="h2"
+          size="lg"
+          marginBottom=".5em"
+          noOfLines={1}
+          maxHeight="1.5em"
+          lineHeight="normal"
+          data-test="Folder Heading"
+        >
+          <Tooltip label={headingText}>{headingText}</Tooltip>
+        </Heading>
+        <Button size="sm" colorScheme="blue" mb="0.6rem">
+          Share
+        </Button>
+      </HStack>
       <VStack width="100%">
         <Flex
           width="100%"

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -355,6 +355,7 @@ export function Activities() {
     fetcher.submit(
       {
         path: "updateContent/createContent",
+        redirectNewContentId: true,
         parentId,
         contentType: "singleDoc",
       },
@@ -656,6 +657,7 @@ export function Activities() {
                     fetcher.submit(
                       {
                         path: "updateContent/createContent",
+                        redirectNewContentId: true,
                         parentId,
                         contentType: "sequence",
                       },

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -30,16 +30,12 @@ import {
   Link,
   Form,
   useOutletContext,
-  ActionFunctionArgs,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
 import CardList from "../widgets/CardList";
 import axios from "axios";
-import {
-  MoveCopyContent,
-  moveCopyContentActions,
-} from "../popups/MoveCopyContent";
+import { MoveCopyContent } from "../popups/MoveCopyContent";
 import {
   ContentDescription,
   Content,
@@ -50,49 +46,15 @@ import {
 import { MdClose, MdOutlineSearch } from "react-icons/md";
 import { getAllowedParentTypes, menuIcons } from "../utils/activity";
 import { CreateLocalContent } from "../popups/CreateLocalContent";
-import { DeleteContent, deleteContentActions } from "../popups/DeleteContent";
-import {
-  AddContentToMenu,
-  addContentToMenuActions,
-} from "../popups/AddContentToMenu";
+import { DeleteContent } from "../popups/DeleteContent";
+import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
 import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 import { SiteContext } from "../paths/SiteHeader";
-import {
-  ActivateAuthorMode,
-  activateAuthorModeActions,
-} from "../popups/ActivateAuthorMode";
+import { ActivateAuthorMode } from "../popups/ActivateAuthorMode";
 import { formatAssignmentBlurb } from "../utils/assignment";
 import { editorUrl } from "../utils/url";
 import { ShareMyContentModal } from "../popups/ShareMyContentModal";
-
-// FIX: unconverted actions!
-async function action({ request, params }: ActionFunctionArgs) {
-  const formData: FormData = await request.formData();
-  const formObj = Object.fromEntries(formData.entries());
-
-  const resultMC = await moveCopyContentActions({ formObj });
-  if (resultMC) {
-    return resultMC;
-  }
-
-  const resultDM = await deleteContentActions({ formObj });
-  if (resultDM) {
-    return resultDM;
-  }
-
-  const resultACM = await addContentToMenuActions({ formObj });
-  if (resultACM) {
-    return resultACM;
-  }
-
-  const resultDMM = await activateAuthorModeActions({ formObj });
-  if (resultDMM) {
-    return resultDMM;
-  }
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader({ params, request }: any) {
   const url = new URL(request.url);
@@ -430,7 +392,6 @@ export function Activities() {
         isOpen={deleteContentIsOpen}
         onClose={deleteContentOnClose}
         content={contentData}
-        fetcher={fetcher}
         finalFocusRef={finalFocusRef}
       />
     ) : null;

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -548,7 +548,6 @@ export function Activities() {
                   label="Copy selected to"
                 />
                 <CreateContentMenu
-                  fetcher={fetcher}
                   sourceContent={selectedCardsFiltered}
                   size="xs"
                   colorScheme="blue"

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -55,10 +55,7 @@ import {
   AddContentToMenu,
   addContentToMenuActions,
 } from "../popups/AddContentToMenu";
-import {
-  CreateContentMenu,
-  createContentMenuActions,
-} from "../dropdowns/CreateContentMenu";
+import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
 import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 import { SiteContext } from "../paths/SiteHeader";
 import {
@@ -87,11 +84,6 @@ async function action({ request, params }: ActionFunctionArgs) {
   const resultACM = await addContentToMenuActions({ formObj });
   if (resultACM) {
     return resultACM;
-  }
-
-  const resultCCM = await createContentMenuActions({ formObj });
-  if (resultCCM) {
-    return resultCCM;
   }
 
   const resultDMM = await activateAuthorModeActions({ formObj });
@@ -452,7 +444,6 @@ export function Activities() {
   const copyContentModal =
     addTo !== null ? (
       <CopyContentAndReportFinish
-        fetcher={fetcher}
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         contentIds={selectedCardsFiltered.map((sc) => sc.contentId)}

--- a/client/src/paths/Activities.tsx
+++ b/client/src/paths/Activities.tsx
@@ -49,10 +49,7 @@ import {
 } from "../types";
 import { MdClose, MdOutlineSearch } from "react-icons/md";
 import { getAllowedParentTypes, menuIcons } from "../utils/activity";
-import {
-  CreateLocalContent,
-  createLocalContentActions,
-} from "../popups/CreateLocalContent";
+import { CreateLocalContent } from "../popups/CreateLocalContent";
 import { DeleteContent, deleteContentActions } from "../popups/DeleteContent";
 import {
   AddContentToMenu,
@@ -73,18 +70,13 @@ import { editorUrl } from "../utils/url";
 import { ShareMyContentModal } from "../popups/ShareMyContentModal";
 
 // FIX: unconverted actions!
-export async function action({ request, params }: ActionFunctionArgs) {
+async function action({ request, params }: ActionFunctionArgs) {
   const formData: FormData = await request.formData();
   const formObj = Object.fromEntries(formData.entries());
 
   const resultMC = await moveCopyContentActions({ formObj });
   if (resultMC) {
     return resultMC;
-  }
-
-  const resultCF = await createLocalContentActions({ formObj });
-  if (resultCF) {
-    return resultCF;
   }
 
   const resultDM = await deleteContentActions({ formObj });
@@ -409,7 +401,8 @@ export function Activities() {
     fetcher.submit(
       {
         path: "updateContent/createContent",
-        type: "singleDoc",
+        parentId,
+        contentType: "singleDoc",
       },
       { method: "post", encType: "application/json" },
     );
@@ -711,7 +704,8 @@ export function Activities() {
                     fetcher.submit(
                       {
                         path: "updateContent/createContent",
-                        type: "sequence",
+                        parentId,
+                        contentType: "sequence",
                       },
                       { method: "post", encType: "application/json" },
                     );

--- a/client/src/paths/ActivityViewer.tsx
+++ b/client/src/paths/ActivityViewer.tsx
@@ -4,7 +4,6 @@ import {
   useNavigate,
   useOutletContext,
   Link as ReactRouterLink,
-  ActionFunctionArgs,
 } from "react-router";
 
 import {
@@ -66,14 +65,8 @@ import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
 import { createNameCheckCurateTag } from "../utils/names";
 import { DisplayLicenseItem } from "../widgets/Licenses";
 import { SiteContext } from "./SiteHeader";
-import {
-  AddContentToMenu,
-  addContentToMenuActions,
-} from "../popups/AddContentToMenu";
-import {
-  CopyContentAndReportFinish,
-  copyContentAndReportFinishActions,
-} from "../popups/CopyContentAndReportFinish";
+import { AddContentToMenu } from "../popups/AddContentToMenu";
+import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 import { CloseIcon } from "@chakra-ui/icons";
 import { BsBookmarkCheck } from "react-icons/bs";
 import { ImCheckmark } from "react-icons/im";
@@ -81,23 +74,6 @@ import { DoenetEditor, DoenetViewer } from "@doenet/doenetml-iframe";
 import { BlueBanner } from "../widgets/BlueBanner";
 // @ts-expect-error assignment-viewer doesn't publish types, see https://github.com/Doenet/assignment-viewer/issues/20
 import { ActivityViewer as DoenetActivityViewer } from "@doenet/assignment-viewer";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  const resultACM = await addContentToMenuActions({ formObj });
-  if (resultACM) {
-    return resultACM;
-  }
-
-  const resultCC = await copyContentAndReportFinishActions({ formObj });
-  if (resultCC) {
-    return resultCC;
-  }
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader({ params }: { params: any }) {
   const {
@@ -247,7 +223,6 @@ export function ActivityViewer() {
   const copyContentModal =
     addTo !== null ? (
       <CopyContentAndReportFinish
-        fetcher={fetcher}
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         contentIds={[activityData.contentId]}

--- a/client/src/paths/Assigned.tsx
+++ b/client/src/paths/Assigned.tsx
@@ -1,7 +1,6 @@
-// import axios from 'axios';
 import { Button, Box, Flex, Heading, VStack, HStack } from "@chakra-ui/react";
 import React, { useEffect } from "react";
-import { ActionFunctionArgs, useLoaderData, useNavigate } from "react-router";
+import { useLoaderData, useNavigate } from "react-router";
 
 import { CardContent } from "../widgets/Card";
 import axios from "axios";
@@ -9,13 +8,6 @@ import { createNameNoTag } from "../utils/names";
 import CardList from "../widgets/CardList";
 import { formatAssignmentBlurb } from "../utils/assignment";
 import { Content, UserInfo } from "../types";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader() {
   const { data: assignmentData } = await axios.get(`/api/assign/getAssigned`);

--- a/client/src/paths/CodeViewer.tsx
+++ b/client/src/paths/CodeViewer.tsx
@@ -112,7 +112,6 @@ export function CodeViewer() {
           <CopyContentAndReportFinish
             isOpen={copyDialogIsOpen}
             onClose={copyDialogOnClose}
-            fetcher={fetcher}
             contentIds={[activityData.contentId]}
             desiredParent={null}
             action="Copy"

--- a/client/src/paths/ConfirmSignIn.tsx
+++ b/client/src/paths/ConfirmSignIn.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { ActionFunctionArgs, useLoaderData } from "react-router";
+import { useLoaderData } from "react-router";
 import axios from "axios";
 import {
   Box,
@@ -12,12 +12,6 @@ import {
   Spinner,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router";
-import { action as changeNameAction } from "./ChangeName";
-
-export async function action({ params, request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  return changeNameAction({ params, request, formData });
-}
 
 export async function loader({ request }: { request: any }) {
   const url = new URL(request.url);

--- a/client/src/paths/Explore.tsx
+++ b/client/src/paths/Explore.tsx
@@ -809,7 +809,6 @@ export function Explore() {
                   label="Add selected to"
                 />
                 <CreateContentMenu
-                  fetcher={fetcher}
                   sourceContent={selectedCardsFiltered}
                   size="xs"
                   colorScheme="blue"

--- a/client/src/paths/Explore.tsx
+++ b/client/src/paths/Explore.tsx
@@ -27,7 +27,6 @@ import {
   HStack,
 } from "@chakra-ui/react";
 import {
-  ActionFunctionArgs,
   Link as ReactRouterLink,
   useLoaderData,
   useLocation,
@@ -54,32 +53,9 @@ import { FilterPanel } from "../widgets/FilterPanel";
 import { ExploreFilterDrawer } from "../drawers/ExploreFilterDrawer";
 import { contentTypeToName, menuIcons } from "../utils/activity";
 import { SiteContext } from "./SiteHeader";
-import {
-  AddContentToMenu,
-  addContentToMenuActions,
-} from "../popups/AddContentToMenu";
-import {
-  CopyContentAndReportFinish,
-  copyContentAndReportFinishActions,
-} from "../popups/CopyContentAndReportFinish";
+import { AddContentToMenu } from "../popups/AddContentToMenu";
+import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  const resultACM = await addContentToMenuActions({ formObj });
-  if (resultACM) {
-    return resultACM;
-  }
-
-  const resultCC = await copyContentAndReportFinishActions({ formObj });
-  if (resultCC) {
-    return resultCC;
-  }
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader({
   params,

--- a/client/src/paths/Explore.tsx
+++ b/client/src/paths/Explore.tsx
@@ -62,10 +62,7 @@ import {
   CopyContentAndReportFinish,
   copyContentAndReportFinishActions,
 } from "../popups/CopyContentAndReportFinish";
-import {
-  CreateContentMenu,
-  createContentMenuActions,
-} from "../dropdowns/CreateContentMenu";
+import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
@@ -79,11 +76,6 @@ export async function action({ request }: ActionFunctionArgs) {
   const resultCC = await copyContentAndReportFinishActions({ formObj });
   if (resultCC) {
     return resultCC;
-  }
-
-  const resultCCM = await createContentMenuActions({ formObj });
-  if (resultCCM) {
-    return resultCCM;
   }
 
   throw Error(`Action "${formObj?._action}" not defined or not handled.`);
@@ -309,7 +301,6 @@ export function Explore() {
   const copyContentModal =
     addTo !== null ? (
       <CopyContentAndReportFinish
-        fetcher={fetcher}
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         contentIds={selectedCardsFiltered.map((sc) => sc.contentId)}

--- a/client/src/paths/LibraryActivities.tsx
+++ b/client/src/paths/LibraryActivities.tsx
@@ -24,65 +24,17 @@ import {
   useFetcher,
   Link,
   Form,
-  ActionFunctionArgs,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
 import CardList from "../widgets/CardList";
 import axios from "axios";
-import {
-  MoveCopyContent,
-  moveCopyContentActions,
-} from "../popups/MoveCopyContent";
+import { MoveCopyContent } from "../popups/MoveCopyContent";
 import { Content, LicenseCode, UserInfo, ContentType } from "../types";
 import { MdClose, MdOutlineSearch } from "react-icons/md";
 import { getAllowedParentTypes } from "../utils/activity";
-import {
-  CreateLocalContent,
-  // createLocalContentActions,
-} from "../popups/CreateLocalContent";
+import { CreateLocalContent } from "../popups/CreateLocalContent";
 import { editorUrl } from "../utils/url";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  const resultMC = await moveCopyContentActions({ formObj });
-  if (resultMC) {
-    return resultMC;
-  }
-
-  // const resultCF = await createLocalContentActions({ formObj });
-  // if (resultCF) {
-  //   return resultCF;
-  // }
-
-  if (formObj?._action == "Delete Draft") {
-    await axios.post(`/api/curate/deleteDraftFromLibrary`, {
-      contentId: formObj.contentId,
-      contentType: formObj.contentType,
-    });
-    return true;
-
-    // TODO: Figure out how to delete folders in library (some activities may be published)
-    // One idea is that you can only delete folders that are empty (or have only drafts?)
-
-    // } else if (formObj?._action == "Delete Folder") {
-    //   await axios.post(`/api/deleteCurationFolder`, {
-    //     folderId: formObj.contentId === "null" ? null : formObj.contentId,
-    //   });
-    //   return true;
-  } else if (formObj?._action == "Move") {
-    await axios.post(`/api/copyMove/moveContent`, {
-      contentId: formObj.contentId,
-      parentId: formObj.folderId === "null" ? null : formObj.folderId,
-      desiredPosition: Number(formObj.desiredPosition),
-    });
-    return true;
-  }
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader({
   params,
@@ -222,12 +174,12 @@ export function LibraryActivities() {
             onClick={() => {
               fetcher.submit(
                 {
-                  _action: "Move",
+                  path: "copyMove/moveContent",
                   contentId,
                   desiredPosition: position - 1,
-                  folderId,
+                  parentId: folderId,
                 },
-                { method: "post" },
+                { method: "post", encType: "application/json" },
               );
             }}
           >
@@ -240,12 +192,12 @@ export function LibraryActivities() {
             onClick={() => {
               fetcher.submit(
                 {
-                  _action: "Move",
+                  path: "copyMove/moveContent",
                   contentId,
                   desiredPosition: position + 1,
-                  folderId,
+                  parentId: folderId,
                 },
-                { method: "post" },
+                { method: "post", encType: "application/json" },
               );
             }}
           >
@@ -290,11 +242,11 @@ export function LibraryActivities() {
               onClick={() => {
                 fetcher.submit(
                   {
-                    _action: "Delete Draft",
+                    path: "curate/deleteDraftFromLibrary",
                     contentId,
                     contentType,
                   },
-                  { method: "post" },
+                  { method: "post", encType: "application/json" },
                 );
               }}
             >

--- a/client/src/paths/LibraryActivities.tsx
+++ b/client/src/paths/LibraryActivities.tsx
@@ -39,7 +39,7 @@ import { MdClose, MdOutlineSearch } from "react-icons/md";
 import { getAllowedParentTypes } from "../utils/activity";
 import {
   CreateLocalContent,
-  createLocalContentActions,
+  // createLocalContentActions,
 } from "../popups/CreateLocalContent";
 import { editorUrl } from "../utils/url";
 
@@ -52,10 +52,10 @@ export async function action({ request }: ActionFunctionArgs) {
     return resultMC;
   }
 
-  const resultCF = await createLocalContentActions({ formObj });
-  if (resultCF) {
-    return resultCF;
-  }
+  // const resultCF = await createLocalContentActions({ formObj });
+  // if (resultCF) {
+  //   return resultCF;
+  // }
 
   if (formObj?._action == "Delete Draft") {
     await axios.post(`/api/curate/deleteDraftFromLibrary`, {

--- a/client/src/paths/SharedActivities.tsx
+++ b/client/src/paths/SharedActivities.tsx
@@ -231,7 +231,6 @@ export function SharedActivities() {
                 label="Add selected to"
               />
               <CreateContentMenu
-                fetcher={fetcher}
                 sourceContent={selectedCardsFiltered}
                 size="xs"
                 colorScheme="blue"

--- a/client/src/paths/SharedActivities.tsx
+++ b/client/src/paths/SharedActivities.tsx
@@ -17,7 +17,6 @@ import {
   useFetcher,
   Link,
   useOutletContext,
-  ActionFunctionArgs,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
@@ -29,32 +28,9 @@ import { ContentInfoDrawer } from "../drawers/ContentInfoDrawer";
 import CardList from "../widgets/CardList";
 import { menuIcons } from "../utils/activity";
 import { SiteContext } from "./SiteHeader";
-import {
-  AddContentToMenu,
-  addContentToMenuActions,
-} from "../popups/AddContentToMenu";
+import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
-import {
-  CopyContentAndReportFinish,
-  copyContentAndReportFinishActions,
-} from "../popups/CopyContentAndReportFinish";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  const resultACM = await addContentToMenuActions({ formObj });
-  if (resultACM) {
-    return resultACM;
-  }
-
-  const resultCC = await copyContentAndReportFinishActions({ formObj });
-  if (resultCC) {
-    return resultCC;
-  }
-
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
+import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 
 export async function loader({ params }: { params: any }) {
   const { data } = await axios.get(

--- a/client/src/paths/SharedActivities.tsx
+++ b/client/src/paths/SharedActivities.tsx
@@ -33,10 +33,7 @@ import {
   AddContentToMenu,
   addContentToMenuActions,
 } from "../popups/AddContentToMenu";
-import {
-  CreateContentMenu,
-  createContentMenuActions,
-} from "../dropdowns/CreateContentMenu";
+import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
 import {
   CopyContentAndReportFinish,
   copyContentAndReportFinishActions,
@@ -54,11 +51,6 @@ export async function action({ request }: ActionFunctionArgs) {
   const resultCC = await copyContentAndReportFinishActions({ formObj });
   if (resultCC) {
     return resultCC;
-  }
-
-  const resultCCM = await createContentMenuActions({ formObj });
-  if (resultCCM) {
-    return resultCCM;
   }
 
   throw Error(`Action "${formObj?._action}" not defined or not handled.`);
@@ -165,7 +157,6 @@ export function SharedActivities() {
   const copyContentModal =
     addTo !== null ? (
       <CopyContentAndReportFinish
-        fetcher={fetcher}
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         contentIds={selectedCardsFiltered.map((sc) => sc.contentId)}

--- a/client/src/paths/SiteHeader.tsx
+++ b/client/src/paths/SiteHeader.tsx
@@ -357,7 +357,6 @@ export function SiteHeader() {
                                     onChange={() => {
                                       fetcher.submit(
                                         {
-                                          _action: "set is author",
                                           path: "user/setIsAuthor",
                                           isAuthor: !user.isAuthor,
                                         },

--- a/client/src/paths/SiteHeader.tsx
+++ b/client/src/paths/SiteHeader.tsx
@@ -56,19 +56,6 @@ export type SiteContext = {
   allDoenetmlVersions: DoenetmlVersion[];
 };
 
-export async function action({ request }: { request: any }) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  if (formObj?._action == "set is author") {
-    await axios.post("/api/user/setIsAuthor", {
-      isAuthor: formObj.isAuthor === "true",
-    });
-  }
-
-  return null;
-}
-
 export async function loader() {
   const {
     data: { user },
@@ -371,10 +358,13 @@ export function SiteHeader() {
                                       fetcher.submit(
                                         {
                                           _action: "set is author",
-                                          userId: user.userId,
+                                          path: "user/setIsAuthor",
                                           isAuthor: !user.isAuthor,
                                         },
-                                        { method: "post" },
+                                        {
+                                          method: "post",
+                                          encType: "application/json",
+                                        },
                                       );
                                     }}
                                   />

--- a/client/src/paths/Trash.tsx
+++ b/client/src/paths/Trash.tsx
@@ -12,7 +12,6 @@ import {
   useNavigate,
   useFetcher,
   Link as ReactRouterLink,
-  ActionFunctionArgs,
 } from "react-router";
 
 import { CardContent } from "../widgets/Card";
@@ -21,19 +20,6 @@ import axios from "axios";
 import {} from "../popups/MoveCopyContent";
 import { DateTime } from "luxon";
 import { Content } from "../types";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  if (formObj?._action == "restore content") {
-    await axios.post(`/api/updateContent/restoreDeletedContent`, {
-      contentId: formObj.contentId,
-    });
-    return true;
-  }
-  throw Error(`Action "${formObj?._action}" not defined or not handled.`);
-}
 
 export async function loader() {
   const { data: results } = await axios.get(`/api/contentList/getMyTrash`);
@@ -115,10 +101,10 @@ export function Trash() {
         onClick={() => {
           fetcher.submit(
             {
-              _action: "restore content",
+              path: "updateContent/restoreDeletedContent",
               contentId,
             },
-            { method: "post" },
+            { method: "post", encType: "application/json" },
           );
         }}
       >

--- a/client/src/paths/editor/CompoundEditorEditMode.tsx
+++ b/client/src/paths/editor/CompoundEditorEditMode.tsx
@@ -1,23 +1,8 @@
 import React from "react";
-import { ActionFunctionArgs, useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
 import axios from "axios";
 import { Content } from "../../types";
-import {
-  CompoundActivityEditor,
-  compoundActivityEditorActions,
-} from "../../views/CompoundActivityEditor";
-
-export async function action({ request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  const resultNAE = await compoundActivityEditorActions({ formObj });
-  if (resultNAE) {
-    return resultNAE;
-  }
-
-  return null;
-}
+import { CompoundActivityEditor } from "../../views/CompoundActivityEditor";
 
 export async function loader({ params }: { params: any }) {
   const {

--- a/client/src/paths/editor/EditorHeader.tsx
+++ b/client/src/paths/editor/EditorHeader.tsx
@@ -46,10 +46,7 @@ import { AssignmentStatus, ContentType, ContentDescription } from "../../types";
 import { contentTypeToName, getIconInfo } from "../../utils/activity";
 import { CopyContentAndReportFinish } from "../../popups/CopyContentAndReportFinish";
 import { SiteContext } from "../SiteHeader";
-import {
-  ActivateAuthorMode,
-  activateAuthorModeActions,
-} from "../../popups/ActivateAuthorMode";
+import { ActivateAuthorMode } from "../../popups/ActivateAuthorMode";
 import { ConfirmAssignModal } from "../../popups/ConfirmAssignModal";
 import { ShareMyContentModal } from "../../popups/ShareMyContentModal";
 import { NotificationDot } from "../../widgets/NotificationDot";
@@ -75,11 +72,6 @@ export async function action({ params, request }: ActionFunctionArgs) {
     return true;
   } else if (formObj._action === "go to data") {
     return redirect(`/assignmentData/${params.contentId}`);
-  }
-
-  const resultDM = await activateAuthorModeActions({ formObj });
-  if (resultDM) {
-    return resultDM;
   }
 
   return null;

--- a/client/src/paths/editor/EditorHeader.tsx
+++ b/client/src/paths/editor/EditorHeader.tsx
@@ -3,7 +3,6 @@ import {
   useFetcher,
   Link as ReactRouterLink,
   useNavigate,
-  ActionFunctionArgs,
   Outlet,
   redirect,
   useLoaderData,
@@ -53,29 +52,6 @@ import { NotificationDot } from "../../widgets/NotificationDot";
 import { LibraryEditorControls } from "../../widgets/editor/LibraryEditorControls";
 import { editorUrl } from "../../utils/url";
 import { EditableName } from "../../widgets/EditableName";
-
-export async function action({ params, request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-  const formObj = Object.fromEntries(formData);
-
-  if (formObj._action == "update name") {
-    //Don't let name be blank
-    let name = formObj.name.toString().trim();
-    if (name === "") {
-      name = "Untitled";
-    }
-
-    await axios.post(`/api/updateContent/updateContentSettings`, {
-      contentId: params.contentId,
-      name,
-    });
-    return true;
-  } else if (formObj._action === "go to data") {
-    return redirect(`/assignmentData/${params.contentId}`);
-  }
-
-  return null;
-}
 
 export async function loader({
   params,

--- a/client/src/paths/editor/EditorHeader.tsx
+++ b/client/src/paths/editor/EditorHeader.tsx
@@ -50,7 +50,6 @@ import {
   ActivateAuthorMode,
   activateAuthorModeActions,
 } from "../../popups/ActivateAuthorMode";
-import { compoundActivityEditorActions } from "../../views/CompoundActivityEditor";
 import { ConfirmAssignModal } from "../../popups/ConfirmAssignModal";
 import { ShareMyContentModal } from "../../popups/ShareMyContentModal";
 import { NotificationDot } from "../../widgets/NotificationDot";
@@ -76,11 +75,6 @@ export async function action({ params, request }: ActionFunctionArgs) {
     return true;
   } else if (formObj._action === "go to data") {
     return redirect(`/assignmentData/${params.contentId}`);
-  }
-
-  const resultNAE = await compoundActivityEditorActions({ formObj });
-  if (resultNAE) {
-    return resultNAE;
   }
 
   const resultDM = await activateAuthorModeActions({ formObj });
@@ -240,7 +234,6 @@ export function EditorHeader() {
 
   const copyContentModal = (
     <CopyContentAndReportFinish
-      fetcher={fetcher}
       isOpen={copyDialogIsOpen}
       onClose={copyDialogOnClose}
       contentIds={[contentId]}

--- a/client/src/popups/ActivateAuthorMode.tsx
+++ b/client/src/popups/ActivateAuthorMode.tsx
@@ -10,22 +10,7 @@ import {
 } from "@chakra-ui/react";
 import React, { RefObject, useRef } from "react";
 import { FetcherWithComponents } from "react-router";
-import axios from "axios";
 import { AssignmentStatus, UserInfo } from "../types";
-
-export async function activateAuthorModeActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  if (formObj?._action == "set is author") {
-    await axios.post("/api/user/setIsAuthor", {
-      isAuthor: formObj.isAuthor === "true",
-    });
-  }
-
-  return null;
-}
 
 export function ActivateAuthorMode({
   isOpen,
@@ -95,11 +80,10 @@ export function ActivateAuthorMode({
             onClick={() => {
               fetcher.submit(
                 {
-                  _action: "set is author",
-                  userId: user.userId,
+                  path: "user/setIsAuthor",
                   isAuthor: !user.isAuthor,
                 },
-                { method: "post" },
+                { method: "post", encType: "application/json" },
               );
               proceedCallback();
               onClose();

--- a/client/src/popups/AddContentToMenu.tsx
+++ b/client/src/popups/AddContentToMenu.tsx
@@ -154,7 +154,6 @@ export function AddContentToMenu({
 
   const copyContentModal = (
     <CopyContentAndReportFinish
-      fetcher={fetcher}
       isOpen={copyDialogIsOpen}
       onClose={copyDialogOnClose}
       contentIds={sourceContent.map((sc) => sc.contentId)}

--- a/client/src/popups/AddContentToMenu.tsx
+++ b/client/src/popups/AddContentToMenu.tsx
@@ -23,42 +23,11 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import axios from "axios";
-import {
-  MoveCopyContent,
-  moveCopyContentActions,
-} from "../popups/MoveCopyContent";
-import {
-  CopyContentAndReportFinish,
-  copyContentAndReportFinishActions,
-} from "../popups/CopyContentAndReportFinish";
+import { MoveCopyContent } from "../popups/MoveCopyContent";
+import { CopyContentAndReportFinish } from "../popups/CopyContentAndReportFinish";
 import { FetcherWithComponents, useOutletContext } from "react-router";
 import { SiteContext } from "../paths/SiteHeader";
 import { getAllowedParentTypes, menuIcons } from "../utils/activity";
-
-export async function addContentToMenuActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  if (formObj._action === "suggest curation") {
-    await axios.post(`/api/curate/suggestToBeCurated`, {
-      contentId: formObj.contentId,
-    });
-    return true;
-  }
-
-  const resultMC = await moveCopyContentActions({ formObj });
-  if (resultMC) {
-    return resultMC;
-  }
-
-  const resultCC = await copyContentAndReportFinishActions({ formObj });
-  if (resultCC) {
-    return resultCC;
-  }
-
-  return null;
-}
 
 export function AddContentToMenu({
   sourceContent,
@@ -253,10 +222,10 @@ export function AddContentToMenu({
               onClick={() => {
                 fetcher.submit(
                   {
-                    _action: "suggest curation",
+                    path: "curate/suggestToBeCurated",
                     contentId: sourceContent[0].contentId,
                   },
-                  { method: "post" },
+                  { method: "post", encType: "application/json" },
                 );
                 suggestCurationOnOpen();
               }}

--- a/client/src/popups/CopyContentAndReportFinish.tsx
+++ b/client/src/popups/CopyContentAndReportFinish.tsx
@@ -110,12 +110,12 @@ export function CopyContentAndReportFinish({
         document.body.style.cursor = "wait";
         fetcher.submit(
           {
-            _action: "copy content",
-            contentIds: JSON.stringify(contentIds),
+            path: "copyMove/copyContent",
+            contentIds,
             parentId: desiredParent ? desiredParent.contentId : null,
             prependCopy,
           },
-          { method: "post" },
+          { method: "post", encType: "application/json" },
         );
       }
     } else {

--- a/client/src/popups/CopyContentAndReportFinish.tsx
+++ b/client/src/popups/CopyContentAndReportFinish.tsx
@@ -12,44 +12,12 @@ import {
   Text,
   Spinner,
 } from "@chakra-ui/react";
-import axios, { AxiosError } from "axios";
 import { useFetcher, useNavigate, useOutletContext } from "react-router";
 import { ContentDescription } from "../types";
 import { contentTypeToName } from "../utils/activity";
 import { SiteContext } from "../paths/SiteHeader";
 import { editorUrl } from "../utils/url";
 
-export async function copyContentAndReportFinishActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  if (formObj._action === "copy content") {
-    const newContentIds: string[] = [];
-
-    try {
-      const contentIds = JSON.parse(formObj.contentIds);
-      const { data } = await axios.post(`/api/copyMove/copyContent`, {
-        contentIds,
-        parentId: formObj.parentId === "null" ? null : formObj.parentId,
-        prependCopy: formObj.prependCopy === "true",
-      });
-
-      newContentIds.push(...data.newContentIds);
-      return { action: "copiedContent", success: true, newContentIds };
-    } catch (e) {
-      console.error(e);
-      let message: string | null = null;
-      if (e instanceof AxiosError) {
-        message = e.response?.data.details;
-      }
-
-      return { action: "copiedContent", success: false, message };
-    }
-  }
-
-  return null;
-}
 /**
  * A modal that immediately upon opening copies source content into a parent or Activities
  * Alternatively, if the `copyToLibrary` flag is set and the user is an editor, it copies the activity into the library as a draft.

--- a/client/src/popups/CopyContentAndReportFinish.tsx
+++ b/client/src/popups/CopyContentAndReportFinish.tsx
@@ -13,11 +13,7 @@ import {
   Spinner,
 } from "@chakra-ui/react";
 import axios, { AxiosError } from "axios";
-import {
-  FetcherWithComponents,
-  useNavigate,
-  useOutletContext,
-} from "react-router";
+import { useFetcher, useNavigate, useOutletContext } from "react-router";
 import { ContentDescription } from "../types";
 import { contentTypeToName } from "../utils/activity";
 import { SiteContext } from "../paths/SiteHeader";
@@ -61,7 +57,6 @@ export async function copyContentAndReportFinishActions({
  * When the copy is finished, the modal allows the user to close it or navigate to the parent.
  */
 export function CopyContentAndReportFinish({
-  fetcher,
   isOpen,
   onClose,
   finalFocusRef,
@@ -70,7 +65,6 @@ export function CopyContentAndReportFinish({
   action,
   prependCopy = false,
 }: {
-  fetcher: FetcherWithComponents<any>;
   isOpen: boolean;
   onClose: () => void;
   finalFocusRef?: RefObject<HTMLElement | null>;
@@ -87,12 +81,14 @@ export function CopyContentAndReportFinish({
   const actionPastWord = action === "Add" ? "added" : "copied";
   const actionProgressiveWord = action === "Add" ? "Adding" : "Copying";
 
+  const fetcher = useFetcher();
+
   const { user, setAddTo } = useOutletContext<SiteContext>();
 
   useEffect(() => {
-    if (fetcher.data?.action === "copiedContent") {
-      if (fetcher.data.success) {
-        setNewContentIds(fetcher.data.newContentIds);
+    if (fetcher.data) {
+      if (fetcher.data.status === 200) {
+        setNewContentIds(fetcher.data.data.newContentIds);
       } else {
         const message = fetcher.data.message;
         setErrMsg(

--- a/client/src/popups/CreateLocalContent.tsx
+++ b/client/src/popups/CreateLocalContent.tsx
@@ -11,52 +11,9 @@ import {
   Spinner,
   Input,
 } from "@chakra-ui/react";
-import axios from "axios";
 import { FetcherWithComponents } from "react-router";
 import { ContentType } from "../types";
 import { contentTypeToName } from "../utils/activity";
-
-export async function createLocalContentActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  const contentType = formObj.contentType as
-    | "singleDoc"
-    | "select"
-    | "sequence"
-    | "folder";
-  if (formObj?._action == "Add Content") {
-    try {
-      await axios.post(`/api/updateContent/createContent`, {
-        name: formObj.contentName,
-        parentId: formObj.parentId === "null" ? null : formObj.parentId,
-        contentType,
-      });
-      return { contentCreated: true };
-    } catch (e) {
-      console.error(e);
-      return {
-        errorCreatingContent: `Error creating ${contentTypeToName[contentType].toLowerCase()}`,
-      };
-    }
-  } else if (formObj?._action == "Add Curation Folder") {
-    try {
-      await axios.post(`/api/curate/createCurationFolder`, {
-        name: formObj.contentName,
-        parentId: formObj.parentId === "null" ? null : formObj.parentId,
-      });
-      return { contentCreated: true };
-    } catch (e) {
-      console.error(e);
-      return {
-        errorCreatingContent: `Error creating ${contentTypeToName[contentType].toLowerCase()}`,
-      };
-    }
-  }
-
-  return null;
-}
 
 /**
  * A modal designed for creating content locally, i.e., in the current folder.
@@ -95,14 +52,21 @@ export function CreateLocalContent({
     }
   }, [contentType, isOpen]);
 
+  // useEffect(() => {
+  //   if (!submitted) {
+  //     // trigger when changing submitted to false as this happens
+  //     // after set content name to `Untitled ${contentTypeToName[contentType]}`
+  //     inputRef.current?.focus();
+  //     inputRef.current?.select();
+  //   }
+  // }, [submitted]);
+
   useEffect(() => {
-    if (!submitted) {
-      // trigger when changing submitted to false as this happens
-      // after set content name to `Untitled ${contentTypeToName[contentType]}`
+    if (isOpen) {
       inputRef.current?.focus();
       inputRef.current?.select();
     }
-  }, [submitted]);
+  }, [isOpen]);
 
   useEffect(() => {
     if (fetcher.data?.contentCreated) {
@@ -120,26 +84,26 @@ export function CreateLocalContent({
       // We can't create other types in the library, just remix them
       fetcher.submit(
         {
-          _action: "Add Curation Folder",
-          contentName,
+          path: "curate/createCurationFolder",
+          name: contentName,
           contentType,
           parentId,
         },
-        { method: "post" },
+        { method: "post", encType: "application/json" },
       );
     } else {
       fetcher.submit(
         {
-          _action: "Add Content",
-          contentName,
+          path: "updateContent/createContent",
+          name: contentName,
           contentType,
           parentId,
         },
-        { method: "post" },
+        { method: "post", encType: "application/json" },
       );
     }
-    document.body.style.cursor = "wait";
     setSubmitted(true);
+    onClose();
   }
 
   return (

--- a/client/src/popups/DeleteContent.tsx
+++ b/client/src/popups/DeleteContent.tsx
@@ -56,9 +56,10 @@ export function DeleteContent({
   const [errMsg, setErrMsg] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
 
+  //TODO: YET: cleanup
+  // Is this still necessary?
   useEffect(() => {
     if (isOpen) {
-      document.body.style.cursor = "default";
       setIsDeleting(false);
     }
   }, [isOpen]);
@@ -66,11 +67,9 @@ export function DeleteContent({
   useEffect(() => {
     if (isDeleting) {
       if (fetcher.data?.contentDeleted) {
-        document.body.style.cursor = "default";
         setIsDeleting(false);
         onClose();
       } else if (fetcher.data?.errorDeletingContent) {
-        document.body.style.cursor = "default";
         setIsDeleting(false);
         setErrMsg(fetcher.data.errorDeletingContent);
       }
@@ -79,13 +78,13 @@ export function DeleteContent({
 
   function deleteContent() {
     setIsDeleting(true);
-    document.body.style.cursor = "wait";
+    // document.body.style.cursor = "wait";
     fetcher.submit(
       {
-        _action: "Delete Content",
+        path: "updateContent/deleteContent",
         contentId: content.contentId,
       },
-      { method: "post" },
+      { method: "post", encType: "application/json" },
     );
   }
 

--- a/client/src/popups/DeleteContent.tsx
+++ b/client/src/popups/DeleteContent.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState } from "react";
+import React, { RefObject } from "react";
 import {
   Modal,
   ModalOverlay,
@@ -9,76 +9,25 @@ import {
   Button,
   Box,
   ModalCloseButton,
-  Spinner,
 } from "@chakra-ui/react";
-import axios from "axios";
-import { FetcherWithComponents } from "react-router";
+import { useFetcher } from "react-router";
 import { ContentDescription } from "../types";
 import { contentTypeToName } from "../utils/activity";
 
-export async function deleteContentActions({ formObj }: { [k: string]: any }) {
-  if (formObj?._action == "Delete Content") {
-    try {
-      const contentId = formObj.contentId;
-
-      await axios.post(`/api/updateContent/deleteContent`, {
-        contentId,
-      });
-
-      return { contentDeleted: true };
-    } catch (e) {
-      console.error(e);
-      return {
-        errorDeletingContent: `Error deleting content`,
-      };
-    }
-  }
-
-  return null;
-}
-
-/**
- *
- */
 export function DeleteContent({
   isOpen,
   onClose,
   finalFocusRef,
   content,
-  fetcher,
 }: {
   isOpen: boolean;
   onClose: () => void;
   finalFocusRef?: RefObject<HTMLElement | null>;
   content: ContentDescription;
-  fetcher: FetcherWithComponents<any>;
 }) {
-  const [errMsg, setErrMsg] = useState("");
-  const [isDeleting, setIsDeleting] = useState(false);
-
-  //TODO: YET: cleanup
-  // Is this still necessary?
-  useEffect(() => {
-    if (isOpen) {
-      setIsDeleting(false);
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (isDeleting) {
-      if (fetcher.data?.contentDeleted) {
-        setIsDeleting(false);
-        onClose();
-      } else if (fetcher.data?.errorDeletingContent) {
-        setIsDeleting(false);
-        setErrMsg(fetcher.data.errorDeletingContent);
-      }
-    }
-  }, [fetcher.data, isDeleting, onClose]);
+  const fetcher = useFetcher();
 
   function deleteContent() {
-    setIsDeleting(true);
-    // document.body.style.cursor = "wait";
     fetcher.submit(
       {
         path: "updateContent/deleteContent",
@@ -86,6 +35,7 @@ export function DeleteContent({
       },
       { method: "post", encType: "application/json" },
     );
+    onClose();
   }
 
   return (
@@ -97,23 +47,13 @@ export function DeleteContent({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader textAlign="center">
-          {errMsg ? (
-            <>Error moving to trash</>
-          ) : (
-            <>Move to trash? {isDeleting ? <Spinner /> : null}</>
-          )}
-        </ModalHeader>
+        <ModalHeader textAlign="center">Move to trash?</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          {errMsg ? (
-            <>{errMsg}</>
-          ) : (
-            <Box data-test="Confirm Delete Message">
-              The {contentTypeToName[content.type].toLowerCase()}{" "}
-              <em>{content.name}</em> will be deleted forever after 30 days.
-            </Box>
-          )}
+          <Box data-test="Confirm Delete Message">
+            The {contentTypeToName[content.type].toLowerCase()}{" "}
+            <em>{content.name}</em> will be deleted forever after 30 days.
+          </Box>
         </ModalBody>
 
         <ModalFooter>
@@ -123,7 +63,6 @@ export function DeleteContent({
             onClick={() => {
               deleteContent();
             }}
-            isDisabled={errMsg !== ""}
           >
             Move to trash
           </Button>

--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -194,7 +194,7 @@ export function MoveCopyContent({
       if (action === "Move") {
         setNumItems(1);
       } else {
-        const numItems: number = fetcher.data.contentIds.length;
+        const numItems: number = fetcher.data.data.newContentIds.length;
         setNumItems(numItems);
       }
     } else if (fetcher.data && fetcher.data.success === false) {
@@ -513,7 +513,7 @@ export function MoveCopyContent({
       } else {
         throw Error("Have not implemented moving more than one content");
       }
-    } else if (action === "Copy") {
+    } else if (action === "Copy" || action === "Add") {
       fetcher.submit(
         {
           path: "copyMove/copyContent",
@@ -523,7 +523,7 @@ export function MoveCopyContent({
         { method: "post", encType: "application/json" },
       );
     } else {
-      throw Error("Add action not implemented in `MoveCopyContent`");
+      throw Error("Action not implemented in `MoveCopyContent`");
     }
   }
 }

--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -17,7 +17,7 @@ import {
   Icon,
   Tooltip,
 } from "@chakra-ui/react";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { useFetcher, useNavigate } from "react-router";
 import MoveToSharedAlert from "./MoveToSharedAlert";
@@ -47,53 +47,6 @@ type ActiveView = {
     contentId: string;
   }[];
 };
-
-export async function moveCopyContentActions({
-  formObj,
-}: {
-  [k: string]: any;
-}) {
-  if (formObj?._action == "Move or copy") {
-    try {
-      const contentIds = JSON.parse(formObj.contentIds);
-      let numItems = contentIds.length;
-      if (formObj.action === "Move") {
-        if (contentIds.length === 1) {
-          await axios.post(`/api/copyMove/moveContent`, {
-            contentId: contentIds[0],
-            parentId: formObj.parentId === "null" ? null : formObj.parentId,
-            desiredPosition: Number(formObj.desiredPosition),
-          });
-        } else {
-          throw Error("Have not implemented moving more than one content");
-        }
-      } else {
-        const { data } = await axios.post(`/api/copyMove/copyContent`, {
-          contentIds,
-          parentId: formObj.parentId === "null" ? null : formObj.parentId,
-        });
-        numItems = data.newContentIds?.length;
-      }
-      return { success: true, numItems };
-    } catch (e) {
-      let message = "An error occurred";
-      if (e instanceof AxiosError) {
-        if (e.response?.data?.error) {
-          message += `: ${e.response.data.error}`;
-          if (e.response.data.details) {
-            message += `: ${e.response.data.details}`;
-          }
-        }
-      }
-      return {
-        success: false,
-        message,
-      };
-    }
-  }
-
-  return null;
-}
 
 export function MoveCopyContent({
   isOpen,

--- a/client/src/popups/MoveCopyContent.tsx
+++ b/client/src/popups/MoveCopyContent.tsx
@@ -189,13 +189,16 @@ export function MoveCopyContent({
   const fetcher = useFetcher();
 
   useEffect(() => {
-    if (fetcher.data) {
-      if (fetcher.data.success === true) {
-        setActionFinished(true);
-        setNumItems(fetcher.data.numItems);
-      } else if (fetcher.data.success === false) {
-        setErrMsg(fetcher.data.message);
+    if (fetcher.data && fetcher.data.status === 200) {
+      setActionFinished(true);
+      if (action === "Move") {
+        setNumItems(1);
+      } else {
+        const numItems: number = fetcher.data.contentIds.length;
+        setNumItems(numItems);
       }
+    } else if (fetcher.data && fetcher.data.success === false) {
+      setErrMsg(fetcher.data.message);
     }
   }, [fetcher.data]);
 
@@ -493,15 +496,34 @@ export function MoveCopyContent({
   );
 
   function performAction() {
-    fetcher.submit(
-      {
-        _action: "Move or copy",
-        contentIds: JSON.stringify(sourceContent.map((sc) => sc.contentId)),
-        parentId: activeView.parent?.id ?? null,
-        desiredPosition: activeView.contents.length, // place it as the last item
-        action,
-      },
-      { method: "post" },
-    );
+    const contentIds = sourceContent.map((sc) => sc.contentId);
+    const parentId = activeView.parent?.id ?? null;
+
+    if (action === "Move") {
+      if (contentIds.length === 1) {
+        fetcher.submit(
+          {
+            path: `copyMove/moveContent`,
+            contentId: contentIds[0],
+            parentId,
+            desiredPosition: activeView.contents.length, // place it as the last item
+          },
+          { method: "post", encType: "application/json" },
+        );
+      } else {
+        throw Error("Have not implemented moving more than one content");
+      }
+    } else if (action === "Copy") {
+      fetcher.submit(
+        {
+          path: "copyMove/copyContent",
+          contentIds,
+          parentId,
+        },
+        { method: "post", encType: "application/json" },
+      );
+    } else {
+      throw Error("Add action not implemented in `MoveCopyContent`");
+    }
   }
 }

--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -87,23 +87,23 @@ export function ShareMyContentModal({
         <ModalCloseButton />
         <ModalBody m="1rem">
           <VStack spacing="3rem" align="flex-start">
-            {contentType !== "folder" && (
-              <Box>
-                <Heading size="sm">With the public</Heading>
-                {fetcher.data && settingsFetcher.data ? (
-                  <SharePublicly
-                    isPublic={fetcher.data.isPublic}
-                    parentIsPublic={fetcher.data.parentIsPublic}
-                    contentId={contentId}
-                    contentType={contentType}
-                    settings={settingsFetcher.data}
-                    closeModal={onClose}
-                  />
-                ) : (
-                  <p>Loading...</p>
-                )}
-              </Box>
-            )}
+            <Box>
+              <Heading size="sm">With the public</Heading>
+              {contentType === "folder" ? (
+                <p>Not implemented yet.</p>
+              ) : fetcher.data && settingsFetcher.data ? (
+                <SharePublicly
+                  isPublic={fetcher.data.isPublic}
+                  parentIsPublic={fetcher.data.parentIsPublic}
+                  contentId={contentId}
+                  contentType={contentType}
+                  settings={settingsFetcher.data}
+                  closeModal={onClose}
+                />
+              ) : (
+                <p>Loading...</p>
+              )}
+            </Box>
 
             <Box>
               <Heading size="sm">With specific people</Heading>

--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -90,7 +90,7 @@ export function ShareMyContentModal({
             <Box>
               <Heading size="sm">With the public</Heading>
               {contentType === "folder" ? (
-                <p>Not implemented yet.</p>
+                <p>Not implemented yet for folders.</p>
               ) : fetcher.data && settingsFetcher.data ? (
                 <SharePublicly
                   isPublic={fetcher.data.isPublic}

--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -156,6 +156,7 @@ function ShareWithPeople({
     <>
       {sharedWith.length > 0 && (
         <ShareTable
+          contentId={contentId}
           isPublic={false}
           parentIsPublic={false}
           sharedWith={sharedWith}

--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -137,7 +137,7 @@ function ShareWithPeople({
   const [emailInput, setEmailInput] = useState("");
   const [inputHasChanged, setInputHasChanged] = useState(false);
 
-  const addEmailError = addEmailFetcher.data;
+  const addEmailError = addEmailFetcher.data?.data;
   useEffect(() => {
     if (!addEmailError) {
       setEmailInput("");

--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -68,7 +68,10 @@ export function ShareMyContentModal({
   useEffect(() => {
     if (isOpen && fetcher.state === "idle" && !fetcher.data) {
       fetcher.load(`/loadShareStatus/${contentId}`);
-      settingsFetcher.load(editorUrl(contentId, contentType, "settings"));
+
+      if (contentType !== "folder") {
+        settingsFetcher.load(editorUrl(contentId, contentType, "settings"));
+      }
     }
   }, [isOpen, fetcher, settingsFetcher, contentId, contentType]);
 
@@ -84,26 +87,29 @@ export function ShareMyContentModal({
         <ModalCloseButton />
         <ModalBody m="1rem">
           <VStack spacing="3rem" align="flex-start">
-            <Box>
-              <Heading size="sm">With the public</Heading>
-              {fetcher.data && settingsFetcher.data ? (
-                <SharePublicly
-                  isPublic={fetcher.data.isPublic}
-                  parentIsPublic={fetcher.data.parentIsPublic}
-                  contentId={contentId}
-                  contentType={contentType}
-                  settings={settingsFetcher.data}
-                  closeModal={onClose}
-                />
-              ) : (
-                <p>Loading...</p>
-              )}
-            </Box>
+            {contentType !== "folder" && (
+              <Box>
+                <Heading size="sm">With the public</Heading>
+                {fetcher.data && settingsFetcher.data ? (
+                  <SharePublicly
+                    isPublic={fetcher.data.isPublic}
+                    parentIsPublic={fetcher.data.parentIsPublic}
+                    contentId={contentId}
+                    contentType={contentType}
+                    settings={settingsFetcher.data}
+                    closeModal={onClose}
+                  />
+                ) : (
+                  <p>Loading...</p>
+                )}
+              </Box>
+            )}
 
             <Box>
               <Heading size="sm">With specific people</Heading>
               {fetcher.data ? (
                 <ShareWithPeople
+                  contentId={contentId}
                   sharedWith={fetcher.data.sharedWith}
                   parentSharedWith={fetcher.data.parentSharedWith}
                 />
@@ -119,9 +125,11 @@ export function ShareMyContentModal({
 }
 
 function ShareWithPeople({
+  contentId,
   sharedWith,
   parentSharedWith,
 }: {
+  contentId: string;
   sharedWith: UserInfoWithEmail[];
   parentSharedWith: UserInfoWithEmail[];
 }) {
@@ -138,7 +146,7 @@ function ShareWithPeople({
 
   function addEmail() {
     addEmailFetcher.submit(
-      { path: "share/shareContent", email: emailInput },
+      { path: "share/shareContent", contentId, email: emailInput },
       { method: "POST", encType: "application/json" },
     );
     setInputHasChanged(false);

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -50,7 +50,6 @@ import {
 } from "../dropdowns/CreateContentMenu";
 import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { DeleteContent, deleteContentActions } from "../popups/DeleteContent";
-import { createLocalContentActions } from "../popups/CreateLocalContent";
 import {
   ActivateAuthorMode,
   activateAuthorModeActions,
@@ -80,11 +79,6 @@ export async function compoundActivityEditorActions({
   const resultCCM = await createContentMenuActions({ formObj });
   if (resultCCM) {
     return resultCCM;
-  }
-
-  const resultCF = await createLocalContentActions({ formObj });
-  if (resultCF) {
-    return resultCF;
   }
 
   const resultDMM = await activateAuthorModeActions({ formObj });

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -663,7 +663,6 @@ export function CompoundActivityEditor({
               label="Add selected to"
             />
             <CreateContentMenu
-              fetcher={fetcher}
               sourceContent={selectedCardsFiltered}
               size="xs"
               colorScheme="blue"

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -581,6 +581,7 @@ export function CompoundActivityEditor({
       fetcher.submit(
         {
           path: "updateContent/createContent",
+          redirectNewContentId: true,
           contentType: "singleDoc",
           parentId: contentId || activity.contentId,
           // createNum,

--- a/client/src/views/CompoundActivityEditor.tsx
+++ b/client/src/views/CompoundActivityEditor.tsx
@@ -44,10 +44,7 @@ import {
   CopyContentAndReportFinish,
   copyContentAndReportFinishActions,
 } from "../popups/CopyContentAndReportFinish";
-import {
-  CreateContentMenu,
-  createContentMenuActions,
-} from "../dropdowns/CreateContentMenu";
+import { CreateContentMenu } from "../dropdowns/CreateContentMenu";
 import { AddContentToMenu } from "../popups/AddContentToMenu";
 import { DeleteContent, deleteContentActions } from "../popups/DeleteContent";
 import {
@@ -75,12 +72,6 @@ export async function compoundActivityEditorActions({
   if (resultCC) {
     return resultCC;
   }
-
-  const resultCCM = await createContentMenuActions({ formObj });
-  if (resultCCM) {
-    return resultCCM;
-  }
-
   const resultDMM = await activateAuthorModeActions({ formObj });
   if (resultDMM) {
     return resultDMM;
@@ -248,7 +239,6 @@ export function CompoundActivityEditor({
   const copyContentModal =
     addTo !== null ? (
       <CopyContentAndReportFinish
-        fetcher={fetcher}
         isOpen={copyDialogIsOpen}
         onClose={copyDialogOnClose}
         contentIds={selectedCardsFiltered.map((sc) => sc.contentId)}

--- a/client/src/widgets/editor/ShareTable.tsx
+++ b/client/src/widgets/editor/ShareTable.tsx
@@ -27,11 +27,13 @@ import { SpinnerWhileFetching } from "../../utils/optimistic_ui";
  * This widget must be used on a React Router page that accepts actions encoded as `application/json`.
  */
 export function ShareTable({
+  contentId,
   isPublic,
   parentIsPublic,
   sharedWith,
   parentSharedWith,
 }: {
+  contentId: string;
   isPublic: boolean;
   parentIsPublic: boolean;
   sharedWith: UserInfoWithEmail[];
@@ -69,7 +71,7 @@ export function ShareTable({
       ? undefined
       : () => {
           fetcher.submit(
-            { path: "share/unshareContent", userId: user.userId },
+            { path: "share/unshareContent", contentId, userId: user.userId },
             { method: "post", encType: "application/json" },
           );
         };

--- a/server/src/query/activity.ts
+++ b/server/src/query/activity.ts
@@ -141,7 +141,11 @@ export async function createContent({
     },
   });
 
-  return { contentId: content.id, name: content.name };
+  return {
+    contentId: content.id,
+    name: content.name,
+    contentType: content.type,
+  };
 }
 
 /**

--- a/server/src/query/editor.ts
+++ b/server/src/query/editor.ts
@@ -141,7 +141,6 @@ export async function getEditor({
 }
 
 /**
- * TODO: FIXME: 
  * Get the settings for this activity.
  * Needed for `/documentEditor/[id]/settings` and `/compoundEditor/[id]/settings` pages
  */

--- a/server/src/query/editor.ts
+++ b/server/src/query/editor.ts
@@ -11,6 +11,7 @@ import {
 } from "../utils/contentStructure";
 import {
   filterEditableActivity,
+  filterEditableContent,
   filterViewableActivity,
   getIsEditor,
 } from "../utils/permissions";
@@ -140,6 +141,7 @@ export async function getEditor({
 }
 
 /**
+ * TODO: FIXME: 
  * Get the settings for this activity.
  * Needed for `/documentEditor/[id]/settings` and `/compoundEditor/[id]/settings` pages
  */
@@ -315,6 +317,8 @@ export async function getCompoundEditorEdit({
 }
 
 /**
+ * TODO: FIXME: This function should not be specific to the editor. We're also using it for folders.
+ *
  * Get the share status of an activity. This included whether it is public, who it has been shared with, and which of these
  * were inherited from the parent.
  * Needed for the `Share content` modal in the editor.
@@ -329,7 +333,7 @@ export async function getEditorShareStatus({
   const results = await prisma.content.findUniqueOrThrow({
     where: {
       id: contentId,
-      ...filterEditableActivity(loggedInUserId, false),
+      ...filterEditableContent(loggedInUserId, false),
     },
     select: {
       isPublic: true,

--- a/server/src/schemas/contentSchema.ts
+++ b/server/src/schemas/contentSchema.ts
@@ -13,7 +13,7 @@ export const contentTypeSchema = z.enum([
 ]);
 
 export const createContentSchema = z.object({
-  contentType: contentTypeSchema.prefault("singleDoc"),
+  contentType: contentTypeSchema,
   name: z.string().optional(),
   parentId: uuidOrNullSchema,
 });


### PR DESCRIPTION
In the process of refactoring the editor, we removed the ability to share folders. This PR adds part of that functionality back: sharing folders with specific emails.

The reason I didn't also re-implement sharing folders publicly is that we have some design discussion to do. Now that we're requiring categories to be filled out before making something public, how should that work for folders?

Changes
* Share button next to folder name
* Most React Router pages now use JSON-type actions with the generic action function - this was necessary to make them compatible with the share popup