### PR TITLE
Wording change on activity viewer "sign in" button

### DIFF
--- a/client/src/paths/ActivityViewer.tsx
+++ b/client/src/paths/ActivityViewer.tsx
@@ -587,7 +587,7 @@ export function ActivityViewer() {
                           navigate("/signIn");
                         }}
                       >
-                        Sign In To Add Content
+                        Sign In To Use Content
                       </Button>
                     )}
 


### PR DESCRIPTION
The existing wording is confusing:

<img width="1512" height="772" alt="image" src="https://github.com/user-attachments/assets/8f72c56c-7d6f-43ee-ab47-15f2e2acb1b4" />

What are you adding to?

I changed it to "Sign In To Use Content".