### PR TITLE
Github action - assume AWS role

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ name: Connect to an AWS role from a GitHub repository
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 env:
   AWS_REGION: "us-east-2"


### PR DESCRIPTION
A github action that connects with our AWS server via OIDC. It triggers on pushes to main. The action doesn't do much yet.