### PR TITLE
Add "get shareable link" button for public activities

### DIFF
--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -34,6 +34,7 @@ import { SpinnerWhileFetching } from "../utils/optimistic_ui";
 import { ShareTable } from "../widgets/editor/ShareTable";
 import axios from "axios";
 import { IoCheckmark } from "react-icons/io5";
+import { IoMdLink, IoMdCheckmark } from "react-icons/io";
 
 import { loader as settingsLoader } from "../paths/editor/EditorSettingsMode";
 import { editorUrl } from "../utils/url";
@@ -232,12 +233,33 @@ function SharePublicly({
 }) {
   const fetcher = useFetcher();
 
+  const shareableLink = `${window.location.host}/activityViewer/${contentId}`;
+
+  const [copiedLink, setCopiedLink] = useState(false);
+
   if (parentIsPublic) {
     return <p>Parent is public.</p>;
   } else if (isPublic) {
     return (
-      <>
+      <VStack justify="flex-start" align="flex-start">
         <Text mt="1rem">Content is public.</Text>
+
+        <Button
+          mt="1rem"
+          size="sm"
+          colorScheme="blue"
+          onClick={() => {
+            navigator.clipboard.writeText(shareableLink);
+            setCopiedLink(true);
+          }}
+        >
+          {copiedLink ? (
+            <IoMdCheckmark fontSize="1.2rem" />
+          ) : (
+            <IoMdLink fontSize="1.2rem" />
+          )}
+          <Text ml="0.5rem">Copy shareable link</Text>
+        </Button>
 
         <Button
           mt="1rem"
@@ -256,7 +278,7 @@ function SharePublicly({
         >
           Unshare with the public
         </Button>
-      </>
+      </VStack>
     );
   } else {
     // Detect whether or not this activity has the required categories filled


### PR DESCRIPTION
As requested in #2635, this PR adds a button to the share screen.
If the activity is public, users can copy the view link to the clipboard - that is, the one with `/activityViewer`.

If we eventually merge the editor and viewer pages, we'll see if this button is still useful (Google docs still has it).