### PR TITLE
Allow public sharing without categories

### DIFF
--- a/client/src/popups/ShareMyContentModal.tsx
+++ b/client/src/popups/ShareMyContentModal.tsx
@@ -1,6 +1,5 @@
 import {
   Heading,
-  Link as ChakraLink,
   Modal,
   ModalOverlay,
   ModalHeader,
@@ -16,10 +15,6 @@ import {
   HStack,
   Input,
   VStack,
-  Alert,
-  AlertIcon,
-  AlertTitle,
-  AlertDescription,
 } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { contentTypeToName } from "../utils/activity";
@@ -29,11 +24,10 @@ import {
   ContentType,
   UserInfoWithEmail,
 } from "../types";
-import { Link as ReactRouterLink, useFetcher } from "react-router";
+import { useFetcher } from "react-router";
 import { SpinnerWhileFetching } from "../utils/optimistic_ui";
 import { ShareTable } from "../widgets/editor/ShareTable";
 import axios from "axios";
-import { IoCheckmark } from "react-icons/io5";
 import { IoMdLink, IoMdCheckmark } from "react-icons/io";
 
 import { loader as settingsLoader } from "../paths/editor/EditorSettingsMode";
@@ -285,6 +279,11 @@ function SharePublicly({
     // out to share publicly
     // For each group that is required, make sure this activity has at least 1 category in that group.
     // If it doesn't, disable sharing publicly.
+    //
+    // TODO: This restriction is ~really~ annoying. Implement a better system,
+    // one where it can be shared but does not show up on Explore
+    // For now, we'll just allow sharing publicly without restrictions.
+
     let disableSubmit = false;
     const allCategories = settings.allCategories as CategoryGroup[];
     const categories = settings.categories as Category[];
@@ -306,7 +305,9 @@ function SharePublicly({
     return (
       <Box>
         <Text mt="1rem">Allow others to find and use your content.</Text>
-        {disableSubmit ? (
+
+        {/* See above comment. Removing the restriction for now */}
+        {/* {disableSubmit ? (
           <Alert status="warning">
             <AlertIcon />
             <AlertTitle>Incomplete settings</AlertTitle>
@@ -328,13 +329,14 @@ function SharePublicly({
             <IoCheckmark color="green" />
             <Text>Settings are filled out</Text>
           </HStack>
-        )}
+        )} */}
 
         <Button
           mt="1rem"
           size="sm"
           colorScheme="blue"
-          isDisabled={disableSubmit}
+          // See above comment about removing restriction
+          // isDisabled={disableSubmit}
           onClick={() => {
             fetcher.submit(
               {


### PR DESCRIPTION
Before, we prevented sharing an activity publicly unless the owner filled out most of the categories.

This is annoying. There are cases where it makes to share content without categorizing it -- a quick demo, a conference, a draft.

Eventually, we'll implement a better system where the content is public but not in "Explore".