### PR TITLE
search classification schema coerces to number

### DIFF
--- a/server/src/schemas/classificationSchema.ts
+++ b/server/src/schemas/classificationSchema.ts
@@ -3,9 +3,9 @@ import { uuidSchema } from "./uuid";
 
 export const searchPossibleClassificationsSchema = z.object({
   query: z.string().optional(),
-  systemId: z.int().optional(),
-  categoryId: z.int().optional(),
-  subCategoryId: z.int().optional(),
+  systemId: z.coerce.number().int().optional(),
+  categoryId: z.coerce.number().int().optional(),
+  subCategoryId: z.coerce.number().int().optional(),
 });
 
 export const classificationSchema = z.object({


### PR DESCRIPTION
Since `searchPossibleClassifications` is a GET request with query parameters, all parameters are strings and need to be coerced to numbers.