### PR TITLE
Correctly handle the data when reverting to save point

### DIFF
--- a/client/src/popups/SetDocumentToSavePoint.tsx
+++ b/client/src/popups/SetDocumentToSavePoint.tsx
@@ -46,7 +46,7 @@ export function SetDocumentToSavePoint({
       setStatusStyleIdx((x) => x + 1);
       setUpdated(true);
       const revertedRevision: ContentRevision & { newRevisionNum: number } =
-        fetcher.data.revision;
+        fetcher.data.data;
       setNewRevNum(revertedRevision.newRevisionNum);
     }
   }, [fetcher.data]);


### PR DESCRIPTION
This PR fixes a bug where the site crashed after reverting to a save point.

Apparently, the data format coming from the fetcher changed at some point, and `SetDocumentToSavePoint.tsx` was not adjusted.
