### PR TITLE
add .env.production for discourse

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,1 @@
+VITE_DISCOURSE_URL=https://community.doenet.org/

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
         "src/**/*.ts",
         "src/**/*.js",
         "vite.config.ts",
-        "tsconfig.json"
+        "tsconfig.json",
+        ".env.production"
       ],
       "output": [
         "dist/**/*.js",


### PR DESCRIPTION
This PR add a `.env.production` to client that is needed for discourse. It also adds that file as a wireit dependency.