### PR TITLE
Fix logout hanging when Discourse not set up

### DIFF
--- a/client/src/paths/SiteHeader.tsx
+++ b/client/src/paths/SiteHeader.tsx
@@ -265,9 +265,23 @@ export function SiteHeader() {
                       )}
                     </>
                   )}
-                  <NavLinkTab to={discussHref} dataTest="Discourse Link">
-                    Discuss
-                  </NavLinkTab>
+                  <ChakraLink
+                    href={discussHref}
+                    isExternal
+                    data-test="Discourse Link"
+                    _hover={{ textDecoration: "none" }}
+                  >
+                    <Center
+                      h="40px"
+                      borderBottomStyle="none"
+                      borderBottomWidth="0px"
+                      p="4px"
+                    >
+                      <Text fontSize="md" color="doenet.canvastext">
+                        Discuss
+                      </Text>
+                    </Center>
+                  </ChakraLink>
                 </HStack>
               </GridItem>
             </Show>
@@ -439,12 +453,26 @@ export function SiteHeader() {
                                 Curate
                               </NavLinkDropdownTab>
                             )}
-                            <NavLinkDropdownTab
-                              to={discussHref}
-                              dataTest="Discourse Link"
-                            >
-                              Discuss
-                            </NavLinkDropdownTab>
+                            <MenuItem>
+                              <ChakraLink
+                                href={discussHref}
+                                isExternal
+                                data-test="Discourse Link"
+                                _hover={{ textDecoration: "none" }}
+                                w="100%"
+                              >
+                                <Center
+                                  h="40px"
+                                  borderBottomStyle="none"
+                                  borderBottomWidth="0px"
+                                  p="4px"
+                                >
+                                  <Text fontSize="md" color="doenet.canvastext">
+                                    Discuss
+                                  </Text>
+                                </Center>
+                              </ChakraLink>
+                            </MenuItem>
                           </>
                         )}
                       </MenuList>

--- a/server/src/routes/loginRoutes.ts
+++ b/server/src/routes/loginRoutes.ts
@@ -68,7 +68,7 @@ loginRouter.get(
         );
         const discourseUserId = discourseUser.user.id;
 
-        await axios.post(
+        axios.post(
           // https://{defaultHost}/admin/users/{id}/log_out.json
           `${process.env.DISCOURSE_URL}/admin/users/${discourseUserId}/log_out.json`,
           {},

--- a/server/src/routes/loginRoutes.ts
+++ b/server/src/routes/loginRoutes.ts
@@ -58,11 +58,7 @@ loginRouter.get(
   async function (req, _res, next) {
     if (req.user) {
       // Try to log the user out of Discourse, but don't block logout if it fails
-      try {
-        logoutFromDiscourse(req.user);
-      } catch (error) {
-        console.error(`Failed to logout of Discourse: ${error}`);
-      }
+      logoutFromDiscourse(req.user);
     }
     return next();
   },
@@ -77,25 +73,29 @@ loginRouter.get(
 );
 
 async function logoutFromDiscourse(user: UserInfoWithEmail) {
-  const { data: discourseUser } = await axios.get(
-    `${process.env.DISCOURSE_URL}/u/by-external/${user.userId}.json`,
-    {
-      headers: {
-        "Api-Key": process.env.DISCOURSE_API_KEY || "",
-        "Api-Username": process.env.DISCOURSE_API_USERNAME || "",
+  try {
+    const { data: discourseUser } = await axios.get(
+      `${process.env.DISCOURSE_URL}/u/by-external/${user.userId}.json`,
+      {
+        headers: {
+          "Api-Key": process.env.DISCOURSE_API_KEY || "",
+          "Api-Username": process.env.DISCOURSE_API_USERNAME || "",
+        },
       },
-    },
-  );
-  const discourseUserId = discourseUser.user.id;
+    );
+    const discourseUserId = discourseUser.user.id;
 
-  await axios.post(
-    `${process.env.DISCOURSE_URL}/admin/users/${discourseUserId}/log_out.json`,
-    {},
-    {
-      headers: {
-        "Api-Key": process.env.DISCOURSE_API_KEY || "",
-        "Api-Username": process.env.DISCOURSE_API_USERNAME || "",
+    await axios.post(
+      `${process.env.DISCOURSE_URL}/admin/users/${discourseUserId}/log_out.json`,
+      {},
+      {
+        headers: {
+          "Api-Key": process.env.DISCOURSE_API_KEY || "",
+          "Api-Username": process.env.DISCOURSE_API_USERNAME || "",
+        },
       },
-    },
-  );
+    );
+  } catch (error) {
+    console.error(`Failed to logout of Discourse: ${error}`);
+  }
 }


### PR DESCRIPTION
The `logout` endpoint was waiting for a response from Discourse. Now it simply runs a function `logoutFromDiscourse()` without awaiting, so that logout will still suceed if Discourse does not respond.