### PR TITLE
fix display of responses in AnswerResponseDrawer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,7 @@
     "@doenet-tools/shared": "*",
     "@fontsource/jost": "^5.2.6",
     "axios": "^1.11.0",
-    "better-react-mathjax": "^2.1.0",
+    "better-react-mathjax": "^2.4.0-beta-1",
     "browser-image-resizer": "^2.4.1",
     "cssesc": "^3.0.0",
     "export-to-csv": "^1.4.0",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -177,11 +177,7 @@ const router = createBrowserRouter([
     element: (
       <>
         <ChakraProvider theme={theme}>
-          <MathJaxContext
-            version={3}
-            config={mathjaxConfig}
-            // onStartup={(mathJax) => (mathJax.Hub.processSectionDelay = 0)}
-          >
+          <MathJaxContext version={4} config={mathjaxConfig}>
             <SiteHeader />
           </MathJaxContext>
         </ChakraProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@doenet/v06-to-v07": "^0.7.0",
         "@fontsource/jost": "^5.2.6",
         "axios": "^1.11.0",
-        "better-react-mathjax": "^2.1.0",
+        "better-react-mathjax": "^2.4.0-beta-1",
         "browser-image-resizer": "^2.4.1",
         "cssesc": "^3.0.0",
         "export-to-csv": "^1.4.0",
@@ -2312,7 +2312,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
       "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -2322,7 +2321,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -2481,6 +2479,56 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mathjax/mathjax-newcm-font": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.0.tgz",
+      "integrity": "sha512-n10AwYubUa2hyOzxSRzkwRrgCVns083zkentryXICMPKaWT/watfvK2sUk5D9Bow9mpDfoqb5EWApuUvqnlzaw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mathjax/src": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@mathjax/src/-/src-4.1.0.tgz",
+      "integrity": "sha512-xnBL2E5uNHR82iLiUVJXYicKh/Jbq2I1+8yCpcBfJqLEM6CrAR9zBpYYkAFtC/Myvykd5U5uMmRrtr49AKk0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mathjax/mathjax-newcm-font": "4.1.0",
+        "mhchemparser": "^4.2.1",
+        "mj-context-menu": "^1.0.0",
+        "speech-rule-engine": "5.0.0-beta.3"
+      }
+    },
+    "node_modules/@mathjax/src/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@mathjax/src/node_modules/mj-context-menu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-1.0.0.tgz",
+      "integrity": "sha512-OSgBFQRCVhrZwRa9lhqnKcJU92dd/YXgBjup0uyeuj9bOaVsf4myOyrjU4PfhYkdDk6AqVUTov7v5uFMvIbduA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rimraf": "^6.0.1"
+      }
+    },
+    "node_modules/@mathjax/src/node_modules/speech-rule-engine": {
+      "version": "5.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-5.0.0-beta.3.tgz",
+      "integrity": "sha512-wSrjCo8h4SJmGtjicD0OrTuCNH/wEaMsV+ktA1D9C2IPnensiP4pfPv+DnEZDMbauC5SCSE1prP5KA0z/W8bLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "14.0.2",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -7188,11 +7236,12 @@
       }
     },
     "node_modules/better-react-mathjax": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.3.0.tgz",
-      "integrity": "sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==",
+      "version": "2.4.0-beta-1",
+      "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.4.0-beta-1.tgz",
+      "integrity": "sha512-idLyXS//8ESuZl2gVSHWx57EbkzX23rjG40RejXUp7V0Yfm5EQMRng6FEx6opk0vP5BuHNIulCoB7Qf6NELiXQ==",
       "license": "MIT",
       "dependencies": {
+        "@mathjax/src": "^4.0.0",
         "mathjax-full": "^3.2.2"
       },
       "peerDependencies": {
@@ -14252,7 +14301,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15239,7 +15287,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/papaparse": {
@@ -15435,7 +15482,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -15452,7 +15498,6 @@
       "version": "11.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
       "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -16797,6 +16842,57 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/rollup": {
       "version": "4.53.3",


### PR DESCRIPTION
This PR upgrades better-react-mathjax and upgrades MathJax to version 4. This fixes a bug where the math responses in AnswerResponseDrawer frequently did not display correctly, possibly caused by using the configuration from DoenetML which had been modified for MathJax version 4.