### PR TITLE
Cleaner UI for editor header

### DIFF
--- a/client/src/paths/editor/EditorHeader.tsx
+++ b/client/src/paths/editor/EditorHeader.tsx
@@ -57,7 +57,6 @@ import { LibraryEditorControls } from "../../widgets/editor/LibraryEditorControl
 import { editorUrl } from "../../utils/url";
 import { NameBar } from "../../widgets/NameBar";
 import { loader as settingsLoader } from "./EditorSettingsMode";
-import "../../utils/editor-header.css";
 import { isActivityFullyCategorized } from "../../utils/classification";
 
 export async function loader({
@@ -331,7 +330,7 @@ export function EditorHeader() {
           to={folderLink}
           _hover={{ fontWeight: "bold", textDecoration: "none" }}
         >
-          <HStack spacing="5px">
+          <HStack spacing="0.3rem">
             {folderIcon}
             <Text>{folderName}</Text>
           </HStack>
@@ -371,13 +370,15 @@ export function EditorHeader() {
         />
       </Show>
       <Show above="lg">
-        {outerActivityIcon}
         <ChakraLink
           as={ReactRouterLink}
-          _hover={{ fontWeight: "bold", textDecoration: "none" }}
           to={`/compoundEditor/${parent!.contentId}/${tab}`}
+          _hover={{ fontWeight: "bold", textDecoration: "none" }}
         >
-          {parent!.name!}
+          <HStack spacing="0.3rem">
+            {outerActivityIcon}
+            <Text>{parent!.name!}</Text>
+          </HStack>
         </ChakraLink>
       </Show>
       <Box
@@ -567,7 +568,7 @@ export function EditorHeader() {
         borderBottom="1px solid"
         borderColor="doenet.mediumGray"
       >
-        <HStack width="100%" ml="10px">
+        <HStack width="100%" ml="0.6rem">
           {folder}
           {outerActivity}
           {editableName}

--- a/client/src/utils/editor-header.css
+++ b/client/src/utils/editor-header.css
@@ -1,3 +1,0 @@
-.editable-name {
-  outline: 1px solid gray;
-}

--- a/client/src/widgets/NameBar.tsx
+++ b/client/src/widgets/NameBar.tsx
@@ -8,7 +8,6 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useFetcher } from "react-router";
-import "../utils/editor-header.css";
 
 /**
  * Component to display the title of content, optionally editable


### PR DESCRIPTION
Change the breadcrumb-like name bar at the top of the editor to be cleaner and more compact.