### PR TITLE
if not logged in, show load into scratchpad button in activity viewer

### DIFF
--- a/client/src/paths/ActivityViewer.tsx
+++ b/client/src/paths/ActivityViewer.tsx
@@ -31,6 +31,7 @@ import {
   PopoverBody,
   PopoverArrow,
   PopoverCloseButton,
+  Hide,
   Show,
   Text,
   Tooltip,
@@ -240,19 +241,23 @@ export function ActivityViewer() {
     ) : null;
 
   let editLabel: string;
+  let editLabelLong: string;
   let editTooltip: string;
 
   const editIcon = <MdOutlineEditOff size={20} />;
   if (authorMode) {
     if (data.type === "singleDoc") {
-      editLabel = "See source code";
+      editLabel = "See source";
+      editLabelLong = "See source code";
       editTooltip = "See read-only view of source code";
     } else {
       editLabel = "See list";
+      editLabelLong = "See list";
       editTooltip = `See read-only view of documents ${data.type === "sequence" ? "and question banks in the problem set" : "in the question bank"}`;
     }
   } else {
-    editLabel = "See source code";
+    editLabel = "See source";
+    editLabelLong = "See source code";
     editTooltip = "Turn on author mode to see read-only view of source code";
   }
 
@@ -517,7 +522,7 @@ export function ActivityViewer() {
                           setMode("View");
                         }}
                       >
-                        <Show above="md">View</Show>
+                        <Show breakpoint="(min-width: 835px)">View</Show>
                       </Button>
                     </Tooltip>
                     <Tooltip hasArrow label={editTooltip}>
@@ -532,7 +537,10 @@ export function ActivityViewer() {
                           setMode("Edit");
                         }}
                       >
-                        <Show above="md">{editLabel}</Show>
+                        <Hide breakpoint="(max-width: 835px)">
+                          <Show below="xl">{editLabel}</Show>
+                          <Hide below="xl">{editLabelLong}</Hide>
+                        </Hide>
                       </Button>
                     </Tooltip>
                   </ButtonGroup>
@@ -638,7 +646,9 @@ export function ActivityViewer() {
                                 }}
                                 leftIcon={<MdEditNote size={20} />}
                               >
-                                <Show above="lg">Load into </Show>
+                                <Show breakpoint="(min-width: 1030px)">
+                                  Load into{" "}
+                                </Show>
                                 <Show above="md">Scratch Pad</Show>
                               </Button>
                             </Tooltip>


### PR DESCRIPTION
In `ActivityViewer`, if the user isn't logged in, display a button to load the contents of the viewer into the scratchpad.

Resolve #2729.