### PR TITLE
accessible darker red text for form error message

### DIFF
--- a/client/src/popups/CreateDocumentSavePoint.tsx
+++ b/client/src/popups/CreateDocumentSavePoint.tsx
@@ -129,9 +129,7 @@ export function CreateDocumentSavePoint({
               }}
             />
             {revisionName === "" ? (
-              <FormErrorMessage color="red.700">
-                Save point name is required.
-              </FormErrorMessage>
+              <FormErrorMessage>Save point name is required.</FormErrorMessage>
             ) : null}
           </FormControl>
           <FormControl marginTop="10px">

--- a/client/src/popups/SavePointInfo.tsx
+++ b/client/src/popups/SavePointInfo.tsx
@@ -53,9 +53,7 @@ export function SavePointInfo({
           }}
         />
         {revisionName === "" ? (
-          <FormErrorMessage color="red.700">
-            Save point name is required.
-          </FormErrorMessage>
+          <FormErrorMessage>Save point name is required.</FormErrorMessage>
         ) : null}
       </FormControl>
       <FormControl marginTop="10px">

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -40,6 +40,13 @@ const theme = extendTheme({
   components: {
     Button,
     IconButton: Button,
+    FormError: {
+      baseStyle: {
+        text: {
+          color: "red.700",
+        },
+      },
+    },
   },
   fonts: {
     body: "Jost",


### PR DESCRIPTION
This PR changes the default text color of Chakra's `<FormErrorMessage>` to be a darker red that meets WCAG AA accessibility requirements for color contrast on a white background.