### PR TITLE
export module specific types directly

### DIFF
--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -11,6 +11,9 @@
 
 import { DoenetDateTime, isUuid, Uuid } from "./types_module_specific";
 
+export type { DoenetDateTime, Uuid };
+export { isUuid };
+
 export type DoenetmlVersion = {
   id: number;
   displayedVersion: string;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -11,6 +11,9 @@
 
 import { DoenetDateTime, isUuid, Uuid } from "./types_module_specific";
 
+export type { DoenetDateTime, Uuid };
+export { isUuid };
+
 export type DoenetmlVersion = {
   id: number;
   displayedVersion: string;


### PR DESCRIPTION
This PR re-exports module specific types in the `types.ts` of each module so that they can be imported in the same way as other types.