### PR TITLE
change the default of individualizeByStudent to true

### DIFF
--- a/server/prisma/migrations/20260206035937_individualize_default_true/migration.sql
+++ b/server/prisma/migrations/20260206035937_individualize_default_true/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `content` MODIFY `individualizeByStudent` BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -68,7 +68,7 @@ model content {
   assignmentClosedOn     DateTime?
   mode                   AssignmentMode           @default(formative)
   maxAttempts            Int                      @default(1) @db.UnsignedSmallInt
-  individualizeByStudent Boolean                  @default(false)
+  individualizeByStudent Boolean                  @default(true)
   submittedResponses     submittedResponses[]
   contentStates          contentState[]
   assignmentScores       assignmentScores[]

--- a/server/src/test/activity.test.ts
+++ b/server/src/test/activity.test.ts
@@ -103,7 +103,7 @@ test("New activity starts out private, then delete it", async () => {
     categories: [],
     classifications: [],
     doenetmlVersionId: currentDoenetmlVersion.id,
-    individualizeByStudent: false,
+    individualizeByStudent: true,
     maxAttempts: 1,
     mode: "formative",
   });
@@ -870,7 +870,7 @@ test.skip("activity editor data and my folder contents before and after assigned
     licenseCode: "CCDUAL",
     classifications: [],
     doenetmlVersionId: currentDoenetmlVersion.id,
-    individualizeByStudent: false,
+    individualizeByStudent: true,
     maxAttempts: 1,
     mode: "formative",
   });
@@ -926,7 +926,7 @@ test.skip("activity editor data and my folder contents before and after assigned
     licenseCode: "CCDUAL",
     classifications: [],
     maxAttempts: 1,
-    individualizeByStudent: false,
+    individualizeByStudent: true,
     mode: "formative",
   });
   expect(header2.assignmentStatus).eqls("Open");
@@ -963,7 +963,7 @@ test.skip("activity editor data and my folder contents before and after assigned
       hasScoreData: false,
       maxAttempts: 1,
       mode: "formative",
-      individualizeByStudent: false,
+      individualizeByStudent: true,
     },
   });
 
@@ -1010,7 +1010,7 @@ test.skip("activity editor data and my folder contents before and after assigned
       hasScoreData: false,
       maxAttempts: 1,
       mode: "formative",
-      individualizeByStudent: false,
+      individualizeByStudent: true,
     },
   });
 
@@ -1060,7 +1060,7 @@ test.skip("activity editor data and my folder contents before and after assigned
       hasScoreData: false,
       maxAttempts: 1,
       mode: "formative",
-      individualizeByStudent: false,
+      individualizeByStudent: true,
     },
   });
 
@@ -1120,7 +1120,7 @@ test.skip("activity editor data and my folder contents before and after assigned
       hasScoreData: true,
       maxAttempts: 1,
       mode: "formative",
-      individualizeByStudent: false,
+      individualizeByStudent: true,
     },
   });
 
@@ -1167,7 +1167,7 @@ test.skip("activity editor data and my folder contents before and after assigned
       hasScoreData: true,
       maxAttempts: 1,
       mode: "formative",
-      individualizeByStudent: false,
+      individualizeByStudent: true,
     },
   });
 });

--- a/server/src/test/assign.test.ts
+++ b/server/src/test/assign.test.ts
@@ -647,7 +647,7 @@ test("cannot change closedOn, maxAttempts, mode, individualizeByStudent of a non
   const closedOn = DateTime.now().plus({ days: 1 });
   const maxAttempts = 2;
   const mode: AssignmentMode = "summative";
-  const individualizeByStudent = true;
+  const individualizeByStudent = false;
 
   for (const nonRootId of nonRootIds) {
     await expect(
@@ -705,7 +705,7 @@ test("cannot change closedOn, maxAttempts, mode, individualizeByStudent of a non
   expect(content.assignmentInfo?.assignmentClosedOn).eqls(closedOn.toJSDate());
   expect(content.assignmentInfo?.maxAttempts).eq(2);
   expect(content.assignmentInfo?.mode).eq("formative");
-  expect(content.assignmentInfo?.individualizeByStudent).eq(false);
+  expect(content.assignmentInfo?.individualizeByStudent).eq(true);
 });
 
 function scoreFromStudentAttempts(


### PR DESCRIPTION
This PR changes the default of the `individualizeByStudent` field of the `content` table to be `true`.

Resolves #2765.