### PR TITLE
Fix typo in client `tsconfig`

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true
   },
   "include": [
-    "src/**/.*ts",
+    "src/**/*.ts",
     "src/**/*.tsx",
     "cypress/**/*.ts",
     "cypress/**/*.tsx",


### PR DESCRIPTION
This small change should fix the strange lint errors I was getting.