### PR TITLE
Configure react router links for /blog to skip SPA navigation

### DIFF
--- a/client/src/features/navbar/NavbarDesktop.tsx
+++ b/client/src/features/navbar/NavbarDesktop.tsx
@@ -110,11 +110,13 @@ function DesktopNavMenuLinks({ navItem }: { navItem: NavItem }) {
       <MenuList borderRadius="0">
         {subItems?.map((option, index) => {
           const link = option.to!;
+          const reloadDocument = option.reloadDocument;
           return (
             <MenuItem
               key={index}
               as={RouterLink}
               to={link}
+              reloadDocument={reloadDocument}
               backgroundColor="transparent"
               _hover={{ backgroundColor: navItemHoverBg }}
             >
@@ -133,12 +135,13 @@ function DesktopNavMenuLinks({ navItem }: { navItem: NavItem }) {
  * Only visible on lg breakpoint and above.
  */
 function DesktopNavSingleLink({ navItem }: { navItem: NavItem }) {
-  const { to, label } = navItem;
+  const { to, label, reloadDocument } = navItem;
   const link = to!;
   return (
     <ChakraLink
       as={RouterLink}
       to={link}
+      reloadDocument={reloadDocument}
       data-test={label}
       h="100%"
       alignContent="center"

--- a/client/src/features/navbar/NavbarMobile.tsx
+++ b/client/src/features/navbar/NavbarMobile.tsx
@@ -172,6 +172,7 @@ function NavbarMobileLeaf({
         as={RouterLink}
         data-test={navItem.label}
         to={navItem.to}
+        reloadDocument={navItem.reloadDocument}
         onClick={onClick}
         {...boxStyles}
       >

--- a/client/src/features/navbar/navbar.data.ts
+++ b/client/src/features/navbar/navbar.data.ts
@@ -10,7 +10,7 @@ export function mainSections(discussionsLink: string): NavSection[] {
           subItems: [
             { label: "About Doenet", to: "/about" },
             { label: "Events", to: "/events" },
-            { label: "Blog", to: "/blog" },
+            { label: "Blog", to: "/blog", reloadDocument: true },
           ],
         },
         {

--- a/client/src/features/navbar/navbar.types.ts
+++ b/client/src/features/navbar/navbar.types.ts
@@ -7,5 +7,6 @@ export type NavSection = {
 export type NavItem = {
   label: string;
   to?: string; // for links
+  reloadDocument?: boolean; // for same-origin links that should bypass client-side routing
   subItems?: NavItem[]; // if present, renders as menu/dropdown
 };


### PR DESCRIPTION
This PR adds the `reloadDocument` prop to react router links to "/blog". The prevents react router from attempting to look up a path in `index.tsx` and instead have the browser request the URL normally.

Before this fix, selecting the blog in the nav bar resulted in a "not found" page, as "/blog" is not a valid react router path. If one then presses the reload button on the page, the blog loads. With this change, the blog should load directly when the link is selected.