### PR TITLE
Edit navbar organization for clarity

### DIFF
--- a/client/src/features/navbar/Navbar.tsx
+++ b/client/src/features/navbar/Navbar.tsx
@@ -13,10 +13,9 @@ import { NavSection } from "./navbar.types";
 import { NavbarMobile } from "./NavbarMobile";
 
 export function Navbar({ user }: { user?: UserInfoWithEmail }) {
-  const forumLink = getDiscourseUrl(user);
-  const supportLink = getDiscourseUrl(user, "support");
+  const discussionsLink = getDiscourseUrl(user);
 
-  const main = mainSections({ discussionsLink: forumLink, supportLink });
+  const main = mainSections({ discussionsLink });
 
   let account: NavSection;
   if (!user) {

--- a/client/src/features/navbar/navbar.data.ts
+++ b/client/src/features/navbar/navbar.data.ts
@@ -2,10 +2,8 @@ import { NavSection } from "./navbar.types";
 
 export function mainSections({
   discussionsLink,
-  supportLink,
 }: {
   discussionsLink: string;
-  supportLink: string;
 }): NavSection[] {
   return [
     {
@@ -17,7 +15,7 @@ export function mainSections({
           subItems: [
             { label: "Documentation", to: "https://docs.doenet.org" },
             { label: "Events & Workshops", to: "/events" },
-            { label: "Ask a Question (Forums)", to: supportLink },
+            { label: "Ask a Question (Forums)", to: discussionsLink },
           ],
         },
         {

--- a/client/src/utils/discourse.ts
+++ b/client/src/utils/discourse.ts
@@ -1,10 +1,7 @@
 import { SiteContext } from "../paths/SiteHeader";
 
-export function getDiscourseUrl(
-  user: SiteContext["user"],
-  landingPage?: "support" | "discussion",
-) {
+export function getDiscourseUrl(user: SiteContext["user"]) {
   return `${import.meta.env.VITE_DISCOURSE_URL}${
     user && user?.isAnonymous === false ? "/session/sso" : ""
-  }${landingPage ? `/c/${landingPage}` : ""}`;
+  }`;
 }


### PR DESCRIPTION
Change the organization of navbar links.

Top top-level categories are now: `Explore`, `Try Writing`, `Help & Training`, `Community`, and `Students`.

The first 3 are the actions new users (who are presumably instructors) are most likely to care about.

- Removed `Authors` category because new users weren't going to look at it. Now there is `Try Writing` for getting right into trying DoenetML and `Help & Training` for when you get stuck.

- "Try Writing" is a temporary name. In the future, we'll probably want to combine the scratchpad and the normal document editor. When this happens, we'll change the title to "Create".