### PR TITLE
Turn off fail-fast in ci matrix groups

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         test-group: [group1, group2, group3, group4]
 
@@ -189,6 +190,7 @@ jobs:
       ADD_TEST_APIS: "true"
 
     strategy:
+      fail-fast: false
       matrix:
         test-group: [brittle1, brittle2, brittle3]
 
@@ -276,6 +278,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         test-group: [group1, group2, group3, group4]
 


### PR DESCRIPTION
Set `fail-fast` to `false` in the CI jobs so that if one test file in a group fails, the other still run to completion. That way, we still obtain a full report on which tests are failing.