### PR TITLE
Fix MathJax rendering in answer response drawer

### DIFF
--- a/client/src/drawers/AnswerResponseDrawer.cy.tsx
+++ b/client/src/drawers/AnswerResponseDrawer.cy.tsx
@@ -3,7 +3,7 @@ import { DateTime } from "luxon";
 
 describe("AnswerResponseDrawer component tests", { tags: ["@group1"] }, () => {
   it("renders something for math", () => {
-    // Note: these test merely check that there is an SVG rendered by MathJax
+    // Note: this test merely checks that there is an SVG rendered by MathJax
     const responses = [
       {
         answerCreditAchieved: 0,

--- a/client/src/drawers/AnswerResponseDrawer.tsx
+++ b/client/src/drawers/AnswerResponseDrawer.tsx
@@ -68,8 +68,6 @@ export function AnswerResponseDrawer({
         `/api/assign/getStudentSubmittedResponses/${assignment.contentId}/${student.userId}?answerId=${answerId}&contentAttemptNumber=${contentAttemptNumber}${itemQuery}&shuffledOrder=${shuffledOrder.toString()}`,
       );
 
-      console.log("got response data", data);
-
       const responseData = data.responses.map((obj: any) => ({
         response: parseAndFormatResponse(obj.response),
         creditAchieved: Number(obj.answerCreditAchieved),

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,7 +8,7 @@ import {
 import { createRoot } from "react-dom/client";
 
 import "@doenet/doenetml-iframe/style.css";
-import "./utils/util.css";
+import "./styles/mathjax-menu.css";
 
 import { MathJaxContext } from "better-react-mathjax";
 import { theme } from "./theme";

--- a/client/src/styles/mathjax-menu.css
+++ b/client/src/styles/mathjax-menu.css
@@ -1,0 +1,12 @@
+/* MathJax context menu sits at z-index 200/201 by default, which is below
+   Chakra UI's drawer overlay (~1200) and drawer content (~1300).
+   Raise it so the menu is visible when math is inside a drawer.
+   !important is required to override both the injected CSS rule (201) and
+   the inline style setAttribute("style", ...) on the frame (200). */
+.CtxtMenu_MenuFrame {
+  z-index: 1500 !important;
+}
+
+.CtxtMenu_ContextMenu {
+  z-index: 1501 !important;
+}

--- a/client/src/utils/util.css
+++ b/client/src/utils/util.css
@@ -1,15 +1,3 @@
-/* MathJax context menu sits at z-index 200/201 by default, which is below
-   Chakra UI's drawer overlay (~1200) and drawer content (~1300).
-   Raise it so the menu is visible when math is inside a drawer.
-   !important is required to override both the injected CSS rule (201) and
-   the inline style setAttribute("style", ...) on the frame (200). */
-.CtxtMenu_MenuFrame {
-  z-index: 1500 !important;
-}
-.CtxtMenu_ContextMenu {
-  z-index: 1501 !important;
-}
-
 .noselect {
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */


### PR DESCRIPTION
Fix MathJax rendering in the Answer Response Drawer.

This switches the client-side MathJax renderer from CHTML to SVG for the app and component-test mount setup, which avoids the stylesheet insertion failures that were causing fractions and other math to render incorrectly in the drawer.

It also fixes a drawer state issue where reopening the drawer for a different answer could leave the first math expression un-typeset, and raises the MathJax context menu above the Chakra drawer so the accessibility menu is visible and usable.

## Changes

- switch MathJax to the tex-svg.js bundle in the client app
- switch MathJax to the tex-svg.js bundle in Cypress component tests
- clear existing drawer responses before loading new ones to avoid stale MathJax state between openings
- add global CSS overrides so the MathJax context menu appears above the drawer overlay/content
- updateAnswerResponseDrawer component tests to assert SVG MathJax output instead of CHTML text output