### PR TITLE
refactor: move server assets to `assets` folder

### DIFF
--- a/server/assets/signin_email.html
+++ b/server/assets/signin_email.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Confirm Doenet Login</title>
+    <style>
+      .button {
+        background-color: rgb(49, 130, 206);
+        border-radius: 6px;
+        color: #fefefe;
+        border: 1px solid transparent;
+        padding: 10px 60px;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <p>
+      Welcome to Doenet. We have received your request to sign up or log in.
+      Click the below button to verify your email and finish logging in.
+    </p>
+
+    <div>
+      <a href="CONFIRM_LINK" class="button" style="color: #fefefe"
+        >Complete Login
+      </a>
+    </div>
+
+    <div style="margin-top: 30px">
+      <p>Alternatively, you can copy and paste this link into your browser:</p>
+
+      <p><a href="CONFIRM_LINK">CONFIRM_LINK</a></p>
+    </div>
+    <img
+      class="adapt-img"
+      src="https://www.doenet.org/media/Doenet_Logo_Frontpage.png"
+      alt
+      style="display: block"
+      width="175"
+    />
+  </body>
+</html>

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   },
   "wireit": {
     "build": {
-      "command": "tsc && cp src/signin_email.html dist/src/",
+      "command": "tsc",
       "files": [
         "src/**/*.ts",
         "src/**/*.js",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -122,7 +122,11 @@ passport.use(
       let email_html: string = "";
 
       try {
-        const filePath = path.resolve(__dirname, "signin_email.html");
+        const filePath = path.join(
+          process.cwd(),
+          "assets",
+          "signin_email.html",
+        );
 
         email_html = await fs.readFile(filePath, { encoding: "utf8" });
       } catch (err) {


### PR DESCRIPTION
It's more standard for server assets to be located outside the `src` folder.

- No more need to copy the email template into `dist`
- We'll include `assets` in the Docker build

We should test that the email still sends in a deployed environment.