### PR TITLE
Clearer and more robust `.env` configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,6 +80,7 @@ jobs:
       SESSION_SECRET: ci-test-session-secret
       MAGIC_LINK_SECRET: ci-test-magic-link-secret
       APP_URL: http://localhost:8000
+      EMAIL_SES_REGION: us-east-1
       EMAIL_SES_FROM_ADDRESS: noreply@example.com
       CONSOLE_LOG_EMAIL: "true"
       # Enable test features for CI
@@ -171,6 +172,7 @@ jobs:
       SESSION_SECRET: ci-test-session-secret
       MAGIC_LINK_SECRET: ci-test-magic-link-secret
       APP_URL: http://localhost:8000
+      EMAIL_SES_REGION: us-east-1
       EMAIL_SES_FROM_ADDRESS: noreply@example.com
       CONSOLE_LOG_EMAIL: "true"
       ALLOW_TEST_LOGIN: "true"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,8 +79,8 @@ jobs:
       GITHUB_CLIENT_SECRET: ci-test-client-secret
       SESSION_SECRET: ci-test-session-secret
       MAGIC_LINK_SECRET: ci-test-magic-link-secret
-      LOGIN_CALLBACK_ROOT: http://localhost:8000/
-      CONFIRM_SIGNIN_URL: http://localhost:8000/signIn
+      APP_URL: http://localhost:8000
+      EMAIL_SES_FROM_ADDRESS: noreply@example.com
       CONSOLE_LOG_EMAIL: "true"
       # Enable test features for CI
       ALLOW_TEST_LOGIN: "true"
@@ -170,8 +170,8 @@ jobs:
       GITHUB_CLIENT_SECRET: ci-test-client-secret
       SESSION_SECRET: ci-test-session-secret
       MAGIC_LINK_SECRET: ci-test-magic-link-secret
-      LOGIN_CALLBACK_ROOT: http://localhost:8000/
-      CONFIRM_SIGNIN_URL: http://localhost:8000/signIn
+      APP_URL: http://localhost:8000
+      EMAIL_SES_FROM_ADDRESS: noreply@example.com
       CONSOLE_LOG_EMAIL: "true"
       ALLOW_TEST_LOGIN: "true"
       ADD_TEST_APIS: "true"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,10 +82,10 @@ jobs:
       APP_URL: http://localhost:8000
       EMAIL_SES_REGION: us-east-1
       EMAIL_SES_FROM_ADDRESS: noreply@example.com
-      CONSOLE_LOG_EMAIL: "true"
+      MOCK_SIGNIN_EMAIL: "true"
       # Enable test features for CI
-      ALLOW_TEST_LOGIN: "true"
-      ADD_TEST_APIS: "true"
+      ENABLE_TEST_AUTH_BYPASS: "true"
+      ENABLE_TEST_ROUTES: "true"
 
     steps:
       # Checkout repo
@@ -174,9 +174,9 @@ jobs:
       APP_URL: http://localhost:8000
       EMAIL_SES_REGION: us-east-1
       EMAIL_SES_FROM_ADDRESS: noreply@example.com
-      CONSOLE_LOG_EMAIL: "true"
-      ALLOW_TEST_LOGIN: "true"
-      ADD_TEST_APIS: "true"
+      MOCK_SIGNIN_EMAIL: "true"
+      ENABLE_TEST_AUTH_BYPASS: "true"
+      ENABLE_TEST_ROUTES: "true"
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__
 .env.production.local
 .env.development
 .env.production
+# Exception: apps/app/.env.production is intentionally committed (Vite public vars)
+!apps/app/.env.production
 .cache
 
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,9 @@ Cypress tests (both component and e2e) are tagged with `@group1`–`@group4` for
 
 The API exposes test-only features when these env vars are set:
 
-- `ALLOW_TEST_LOGIN=true` — enables login bypassing real auth (used in Cypress tests)
-- `ADD_TEST_APIS=true` — mounts `/api/test` routes from `apps/api/src/test/testRoutes.ts`
-- `CONSOLE_LOG_EMAIL=true` — logs magic-link emails to console instead of sending via SES
+- `ENABLE_TEST_AUTH_BYPASS=true` — enables login bypassing real auth (used in Cypress and load tests)
+- `ENABLE_TEST_ROUTES=true` — mounts `/api/test` routes from `apps/api/src/test/testRoutes.ts`
+- `MOCK_SIGNIN_EMAIL=true` — logs magic-link emails to console instead of sending via SES
 
 ### API Test Utilities
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 npm run setup
 ```
 
-This copies `apps/api/.env.example` to `apps/api/.env`. The defaults work for local development, but edit as needed (e.g. change `DATABASE_PORT` if port `3306` conflicts with another service).
+This copies `apps/api/.env.example` to `apps/api/.env`. The defaults work for local development, but edit as needed (e.g. change `DATABASE_HOST`, `DATABASE_PORT`, or `DATABASE_PASSWORD` if your MySQL setup differs — and update `DATABASE_URL` to match).
 
 **4. Start the database**
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,7 +1,7 @@
 #General
 PORT="3000"
-CONFIRM_SIGNIN_URL="http://localhost:8000/confirmSignIn"
-LOGIN_CALLBACK_ROOT="http://localhost:8000/"
+# Base URL of the frontend app (no trailing slash)
+APP_URL="http://localhost:8000"
 
 #Flags
 ALLOW_TEST_LOGIN="true"
@@ -9,6 +9,7 @@ ADD_TEST_APIS="true"
 CONSOLE_LOG_EMAIL="true"
 
 #Database
+# DATABASE_URL must match the individual vars below. Update both if you change any connection details.
 DATABASE_URL="mysql://myuser:mypassword@localhost:3306/doenet"
 DATABASE_USER="myuser"
 DATABASE_PASSWORD="mypassword"
@@ -16,8 +17,18 @@ DATABASE_HOST="localhost"
 DATABASE_PORT="3306"
 DATABASE_NAME="doenet"
 
+#Email (AWS SES)
+EMAIL_SES_ARN="arn:aws:ses:us-east-1:123456789012:identity/example.com"
+EMAIL_SES_FROM_ADDRESS="no-reply@example.com"
+
 #Login credentials
 SESSION_SECRET="mysecret"
 GOOGLE_CLIENT_ID="mysecret"
 GOOGLE_CLIENT_SECRET="mysecret"
 MAGIC_LINK_SECRET="mysecret"
+
+#Discourse
+DISCOURSE_URL="https://community.example.com"
+DISCOURSE_SSO_SECRET="mysecret"
+DISCOURSE_API_KEY="mysecret"
+DISCOURSE_API_USERNAME="system"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,6 @@
 #General
 PORT="3000"
-# Base URL of the frontend app (no trailing slash)
+# Base URL of the frontend app
 APP_URL="http://localhost:8000"
 
 #Flags

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,7 @@ DATABASE_PORT="3306"
 DATABASE_NAME="doenet"
 
 #Email (AWS SES)
+# Required only if MOCK_SIGNIN_EMAIL is false
 EMAIL_SES_REGION="us-east-1"
 EMAIL_SES_ARN="arn:aws:ses:us-east-1:123456789012:identity/example.com"
 EMAIL_SES_FROM_ADDRESS="no-reply@example.com"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,9 +4,9 @@ PORT="3000"
 APP_URL="http://localhost:8000"
 
 #Flags
-ALLOW_TEST_LOGIN="true"
-ADD_TEST_APIS="true"
-CONSOLE_LOG_EMAIL="true"
+ENABLE_TEST_AUTH_BYPASS="true"
+ENABLE_TEST_ROUTES="true"
+MOCK_SIGNIN_EMAIL="true"
 
 #Database
 # DATABASE_URL must match the individual vars below. Update both if you change any connection details.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,7 @@ DATABASE_PORT="3306"
 DATABASE_NAME="doenet"
 
 #Email (AWS SES)
+EMAIL_SES_REGION="us-east-1"
 EMAIL_SES_ARN="arn:aws:ses:us-east-1:123456789012:identity/example.com"
 EMAIL_SES_FROM_ADDRESS="no-reply@example.com"
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -75,7 +75,7 @@ app.use(function (req, res, next) {
 });
 
 function getEnvVar(name: string, required: true): string;
-function getEnvVar(name: string, required?: false): string | undefined;
+function getEnvVar(name: string, required?: boolean): string | undefined;
 function getEnvVar(name: string, required = false): string | undefined {
   const value = process.env[name]?.trim();
   if (value) {
@@ -87,12 +87,20 @@ function getEnvVar(name: string, required = false): string | undefined {
   return undefined;
 }
 
+const mockSigninEmail =
+  process.env.MOCK_SIGNIN_EMAIL?.trim().toLowerCase() === "true";
 const awsSesArn = getEnvVar("EMAIL_SES_ARN");
-const awsSesRegion = getEnvVar("EMAIL_SES_REGION", true);
-const sendingEmailAddress = getEnvVar("EMAIL_SES_FROM_ADDRESS", true);
+const awsSesRegion = getEnvVar("EMAIL_SES_REGION", !mockSigninEmail);
+const sendingEmailAddress = getEnvVar(
+  "EMAIL_SES_FROM_ADDRESS",
+  !mockSigninEmail,
+);
 const appUrl = getEnvVar("APP_URL", true).replace(/\/$/, "");
 
-const client = new SESClient({ region: awsSesRegion });
+const client =
+  mockSigninEmail || !awsSesRegion
+    ? undefined
+    : new SESClient({ region: awsSesRegion });
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET || "";
@@ -129,11 +137,8 @@ passport.use(
     async (user, token) => {
       const confirmURL = `${appUrl}/confirmSignIn?token=${token}`;
 
-      if (
-        process.env.MOCK_SIGNIN_EMAIL &&
-        process.env.MOCK_SIGNIN_EMAIL.toLocaleLowerCase() !== "false"
-      ) {
-        console.log(`Confirm email link: ${confirmURL}`);
+      if (mockSigninEmail) {
+                console.log(`Confirm email link: ${confirmURL}`);
         return;
       }
 
@@ -173,6 +178,10 @@ passport.use(
 
       // Send the email
       const sendEmail = async () => {
+        if (!client) {
+          console.error("SES client not initialized");
+          return;
+        }
         try {
           const command = new SendEmailCommand(params);
           await client.send(command);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -90,17 +90,21 @@ function getEnvVar(name: string, required = false): string | undefined {
 const mockSigninEmail =
   process.env.MOCK_SIGNIN_EMAIL?.trim().toLowerCase() === "true";
 const awsSesArn = getEnvVar("EMAIL_SES_ARN");
-const awsSesRegion = getEnvVar("EMAIL_SES_REGION", !mockSigninEmail);
-const sendingEmailAddress = getEnvVar(
-  "EMAIL_SES_FROM_ADDRESS",
-  !mockSigninEmail,
-);
 const appUrl = getEnvVar("APP_URL", true).replace(/\/$/, "");
 
-const client =
-  mockSigninEmail || !awsSesRegion
-    ? undefined
-    : new SESClient({ region: awsSesRegion });
+let awsSesRegion: string | undefined;
+let sendingEmailAddress: string | undefined;
+let client: SESClient | undefined;
+
+if (mockSigninEmail) {
+  awsSesRegion = undefined;
+  sendingEmailAddress = undefined;
+  client = undefined;
+} else {
+  awsSesRegion = getEnvVar("EMAIL_SES_REGION", true);
+  sendingEmailAddress = getEnvVar("EMAIL_SES_FROM_ADDRESS", true);
+  client = new SESClient({ region: awsSesRegion });
+}
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET || "";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -76,6 +76,9 @@ app.use(function (req, res, next) {
   next();
 });
 
+const awsSesArn = process.env.EMAIL_SES_ARN || "";
+const sendingEmailAddress = process.env.EMAIL_SES_FROM_ADDRESS || "";
+
 const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET || "";
 
@@ -84,7 +87,7 @@ passport.use(
     {
       clientID: googleClientId,
       clientSecret: googleClientSecret,
-      callbackURL: (process.env.LOGIN_CALLBACK_ROOT || "") + "api/login/google",
+      callbackURL: `${process.env.APP_URL}/api/login/google`,
       scope: ["profile", "email"],
       passReqToCallback: true,
     },
@@ -109,7 +112,7 @@ passport.use(
       tokenField: "token",
     },
     async (user, token) => {
-      const confirmURL = `${process.env.CONFIRM_SIGNIN_URL}?token=${token}`;
+      const confirmURL = `${process.env.APP_URL}/confirmSignIn?token=${token}`;
 
       if (
         process.env.CONSOLE_LOG_EMAIL &&
@@ -133,7 +136,8 @@ passport.use(
       email_html = email_html.replace(/CONFIRM_LINK/g, confirmURL);
 
       const params = {
-        Source: "Doenet Accounts <info@doenet.org>",
+        Source: sendingEmailAddress,
+        SourceArn: awsSesArn,
         Destination: {
           ToAddresses: [user.email],
         },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -74,6 +74,8 @@ app.use(function (req, res, next) {
   next();
 });
 
+function getEnvVar(name: string, required: true): string;
+function getEnvVar(name: string, required?: false): string | undefined;
 function getEnvVar(name: string, required = false): string | undefined {
   const value = process.env[name]?.trim();
   if (value) {
@@ -86,9 +88,9 @@ function getEnvVar(name: string, required = false): string | undefined {
 }
 
 const awsSesArn = getEnvVar("EMAIL_SES_ARN");
-const awsSesRegion = getEnvVar("EMAIL_SES_REGION") ?? "us-east-2";
-const sendingEmailAddress = getEnvVar("EMAIL_SES_FROM_ADDRESS", true) as string;
-const appUrl = getEnvVar("APP_URL", true) as string;
+const awsSesRegion = getEnvVar("EMAIL_SES_REGION", true);
+const sendingEmailAddress = getEnvVar("EMAIL_SES_FROM_ADDRESS", true);
+const appUrl = getEnvVar("APP_URL", true).replace(/\/$/, "");
 
 const client = new SESClient({ region: awsSesRegion });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -130,8 +130,8 @@ passport.use(
       const confirmURL = `${appUrl}/confirmSignIn?token=${token}`;
 
       if (
-        process.env.CONSOLE_LOG_EMAIL &&
-        process.env.CONSOLE_LOG_EMAIL.toLocaleLowerCase() !== "false"
+        process.env.MOCK_SIGNIN_EMAIL &&
+        process.env.MOCK_SIGNIN_EMAIL.toLocaleLowerCase() !== "false"
       ) {
         console.log(`Confirm email link: ${confirmURL}`);
         return;
@@ -318,8 +318,8 @@ passport.serializeUser(async (req: any, user: any, done: any) => {
     let isAuthor = false;
 
     if (
-      process.env.ALLOW_TEST_LOGIN &&
-      process.env.ALLOW_TEST_LOGIN.toLocaleLowerCase() !== "false"
+      process.env.ENABLE_TEST_AUTH_BYPASS &&
+      process.env.ENABLE_TEST_AUTH_BYPASS.toLocaleLowerCase() !== "false"
     ) {
       if (req.body.email && !req.body.isAnonymous) {
         email = req.body.email;
@@ -408,8 +408,8 @@ app.use("/api/metrics", metricsRouter);
 app.use("/api/discourse", discourseRouter);
 
 if (
-  process.env.ADD_TEST_APIS &&
-  process.env.ADD_TEST_APIS.toLocaleLowerCase() !== "false"
+  process.env.ENABLE_TEST_ROUTES &&
+  process.env.ENABLE_TEST_ROUTES.toLocaleLowerCase() !== "false"
 ) {
   app.use("/api/test", testRouter);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -138,7 +138,7 @@ passport.use(
       const confirmURL = `${appUrl}/confirmSignIn?token=${token}`;
 
       if (mockSigninEmail) {
-                console.log(`Confirm email link: ${confirmURL}`);
+        console.log(`Confirm email link: ${confirmURL}`);
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,8 +53,6 @@ import { metricsRouter } from "./routes/metricsRoutes";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const passport = passportLib as any;
 
-const client = new SESClient({ region: "us-east-2" });
-
 dotenv.config();
 
 declare module "express-serve-static-core" {
@@ -76,8 +74,23 @@ app.use(function (req, res, next) {
   next();
 });
 
-const awsSesArn = process.env.EMAIL_SES_ARN || "";
-const sendingEmailAddress = process.env.EMAIL_SES_FROM_ADDRESS || "";
+function getEnvVar(name: string, required = false): string | undefined {
+  const value = process.env[name]?.trim();
+  if (value) {
+    return value;
+  }
+  if (required) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return undefined;
+}
+
+const awsSesArn = getEnvVar("EMAIL_SES_ARN");
+const awsSesRegion = getEnvVar("EMAIL_SES_REGION") ?? "us-east-2";
+const sendingEmailAddress = getEnvVar("EMAIL_SES_FROM_ADDRESS", true) as string;
+const appUrl = getEnvVar("APP_URL", true) as string;
+
+const client = new SESClient({ region: awsSesRegion });
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET || "";
@@ -87,7 +100,7 @@ passport.use(
     {
       clientID: googleClientId,
       clientSecret: googleClientSecret,
-      callbackURL: `${process.env.APP_URL}/api/login/google`,
+      callbackURL: `${appUrl}/api/login/google`,
       scope: ["profile", "email"],
       passReqToCallback: true,
     },
@@ -112,7 +125,7 @@ passport.use(
       tokenField: "token",
     },
     async (user, token) => {
-      const confirmURL = `${process.env.APP_URL}/confirmSignIn?token=${token}`;
+      const confirmURL = `${appUrl}/confirmSignIn?token=${token}`;
 
       if (
         process.env.CONSOLE_LOG_EMAIL &&
@@ -137,7 +150,7 @@ passport.use(
 
       const params = {
         Source: sendingEmailAddress,
-        SourceArn: awsSesArn,
+        ...(awsSesArn ? { SourceArn: awsSesArn } : {}),
         Destination: {
           ToAddresses: [user.email],
         },

--- a/apps/api/src/routes/loginRoutes.ts
+++ b/apps/api/src/routes/loginRoutes.ts
@@ -12,8 +12,8 @@ const passport = passportLib as any;
 export const loginRouter = express.Router();
 
 if (
-  process.env.ALLOW_TEST_LOGIN &&
-  process.env.ALLOW_TEST_LOGIN.toLocaleLowerCase() !== "false"
+  process.env.ENABLE_TEST_AUTH_BYPASS &&
+  process.env.ENABLE_TEST_AUTH_BYPASS.toLocaleLowerCase() !== "false"
 ) {
   loginRouter.post(
     "/createOrLoginAsTest",

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,0 +1,8 @@
+# All values must be prefixed with VITE_ — they are visible in the browser bundle!
+#
+# For local development, copy this file to .env.local and set your values there.
+# .env.local is gitignored, so it won't be committed.
+#
+# Production values live in .env.production (committed — no secrets here).
+
+VITE_DISCOURSE_URL=https://link-to-root-of-discourse-forums.com

--- a/apps/app/.env.production
+++ b/apps/app/.env.production
@@ -1,1 +1,4 @@
+# Production environment variables for the Doenet app.
+# This file is intentionally committed — all VITE_ vars are public (baked into the browser bundle).
+# For local overrides, create a .env.local file (gitignored).
 VITE_DISCOURSE_URL=https://community.doenet.org/

--- a/apps/app/sample.env
+++ b/apps/app/sample.env
@@ -1,4 +1,0 @@
-# All values should start with VITE_
-# All values will be visible in browser!
-
-VITE_DISCOURSE_URL=https://link-to-root-of-discourse-forums.com

--- a/packages/load-tests/README.md
+++ b/packages/load-tests/README.md
@@ -21,7 +21,7 @@ Install Locust:
 pip install locust
 ```
 
-The test login endpoint (`POST /api/login/createOrLoginAsTest`) must be enabled on the target server. This requires the `ALLOW_TEST_LOGIN` environment variable to be set.
+The test login endpoint (`POST /api/login/createOrLoginAsTest`) must be enabled on the target server. This requires the `ENABLE_TEST_AUTH_BYPASS` environment variable to be set.
 
 ## Running
 


### PR DESCRIPTION
- Renamed some .env vars for clarity
- Added env options for AWS SES (email) rather than hard-coding it
- Check for missing env vars on startup rather than failing later
- Include all env vars in `.env.example`

Note: Because I renamed env vars, we will have to remember to update the production environment configuration when this is deployed!