### PR TITLE
fix: startup permissions for local docker DB

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must keep LF endings (they run inside Linux containers).
+*.sh text eol=lf

--- a/configs/mysql/local-docker-db-init.sh
+++ b/configs/mysql/local-docker-db-init.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# Grant the app user the privileges Prisma needs for migrations and shadow databases
-# across all databases matching the MYSQL_DATABASE prefix (e.g. doenet, doenet_shadow).
+# LOCAL DEVELOPMENT ONLY — do not use these broad grants in production.
+#
+# Prisma Migrate creates and drops a temporary shadow database with a
+# random name, so it requires global privileges.
+# This is safe here because the MySQL instance is a disposable Docker container.
 mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" <<EOF
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, REFERENCES, CREATE TEMPORARY TABLES, LOCK TABLES
-ON \`${MYSQL_DATABASE}%\`.*
-TO '${MYSQL_USER}'@'%';
+ON *.* TO '${MYSQL_USER}'@'%';
 FLUSH PRIVILEGES;
 EOF


### PR DESCRIPTION
The permissions in `config/mysql/local-docker-db-init.sh` were insufficient for Prisma to successfully create a shadow database and run migrations.
