### PR TITLE
chore: track some vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 
 **/cypress/accessibility
 **/cypress/videos

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "Prisma.prisma"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/dist/**": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true
+  },
+  "prisma.pinToPrisma6": true,
+  "eslint.workingDirectories": [
+    "apps/api",
+    "apps/app",
+    "apps/web",
+    "packages/shared",
+    "packages/e2e-tests"
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,0 @@
-// @ts-check
-// We don't really need this file once we configure VSCode's eslint to run per workspace
-
-import { createBaseConfig } from "@doenet-tools/eslint-config";
-
-export default createBaseConfig(import.meta.dirname);

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -37,6 +37,11 @@ export function createBaseConfig(dirname) {
     {
       files: ["**/*.ts", "**/*.tsx"],
       extends: [...tseslint.configs.recommended],
+      languageOptions: {
+        parserOptions: {
+          tsconfigRootDir: dirname,
+        },
+      },
       plugins: {
         "unused-imports": unusedImports,
         import: importPlugin,


### PR DESCRIPTION
Track settings for eslint config workspace directories, excludable folders, and recommended extensions. Now the default linter config is the same as the linter in CI.
