### PR TITLE
fix: frontend env vars in different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,21 +2,23 @@
 dist
 node_modules
 .tsbuildinfo
+.cache
 __pycache__
 
 # Environment variables
 **/.env
+**/.env.*
+!**/.env.example
+# Exceptions: these frontend defaults are intentionally committed because they
+# only contain public build-time vars that are bundled into the browser assets.
+!apps/app/.env
+!apps/app/.env.dev3
+!apps/app/.env.prod
+!apps/web/.env
+!apps/web/.env.dev3
+!apps/web/.env.prod
 
 # misc
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-.env.development
-.env.production
-# Exception: apps/app/.env.production is intentionally committed (Vite public vars)
-!apps/app/.env.production
-.cache
 
 npm-debug.log*
 yarn-debug.log*

--- a/apps/app/.env
+++ b/apps/app/.env
@@ -1,0 +1,4 @@
+# Default local build environment variables for the Doenet app.
+# This file is intentionally committed — all VITE_ vars are public.
+# Use .env.local for machine-specific overrides.
+VITE_DISCOURSE_URL=http://localhost:3031

--- a/apps/app/.env.dev3
+++ b/apps/app/.env.dev3
@@ -1,0 +1,3 @@
+# Development environment variables for the Doenet app.
+# This file is intentionally committed — all VITE_ vars are public.
+VITE_DISCOURSE_URL=https://dev3-community.doenet.org/

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,8 +1,0 @@
-# All values must be prefixed with VITE_ — they are visible in the browser bundle!
-#
-# For local development, copy this file to .env.local and set your values there.
-# .env.local is gitignored, so it won't be committed.
-#
-# Production values live in .env.production (committed — no secrets here).
-
-VITE_DISCOURSE_URL=https://link-to-root-of-discourse-forums.com

--- a/apps/app/.env.prod
+++ b/apps/app/.env.prod
@@ -1,0 +1,3 @@
+# Production environment variables for the Doenet app.
+# This file is intentionally committed — all VITE_ vars are public.
+VITE_DISCOURSE_URL=https://community.doenet.org/

--- a/apps/app/.env.production
+++ b/apps/app/.env.production
@@ -1,4 +1,0 @@
-# Production environment variables for the Doenet app.
-# This file is intentionally committed — all VITE_ vars are public (baked into the browser bundle).
-# For local overrides, create a .env.local file (gitignored).
-VITE_DISCOURSE_URL=https://community.doenet.org/

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build:assets": "vite build",
-    "build": "tsc --build && npm run build:assets",
+    "build": "node ./scripts/build.mjs",
     "dev": "cross-env NODE_ENV=production vite",
     "lint": "eslint --fix",
     "lint:check": "eslint",

--- a/apps/app/scripts/build.mjs
+++ b/apps/app/scripts/build.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const extraArgs = process.argv.slice(2);
+
+run("tsc", ["--build"]);
+run("vite", ["build", ...extraArgs]);

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,4 @@
+# Default local build environment variables for the Doenet blog.
+# This file is intentionally committed — all PUBLIC_ vars are public.
+PUBLIC_DOENET_MAIN_URL=http://localhost:8000
+PUBLIC_SITE_URL=http://localhost:4321

--- a/apps/web/.env.dev3
+++ b/apps/web/.env.dev3
@@ -1,0 +1,4 @@
+# Development environment variables for the Doenet blog.
+# This file is intentionally committed — all PUBLIC_ vars are public.
+PUBLIC_DOENET_MAIN_URL=https://dev3.doenet.org
+PUBLIC_SITE_URL=https://dev3.doenet.org

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,9 +1,19 @@
 # General Environment Variables Sample
 # This file shows all available environment variables for the Doenet blog
-# For local development, use .env.local
-# For production builds, use .env.production
+# Default local build values live in .env.
+# Environment-specific build values live in .env.dev3 and .env.prod.
+# Use .env.local for machine-specific overrides.
+# Use `npm run build -- --mode dev3` or `npm run build -- --mode prod` to
+# select a non-default env file.
 
 # Main Doenet application URL
-# Local development: http://localhost:3000
-# Production: https://doenet.org
-PUBLIC_DOENET_MAIN_URL=https://doenet.org
+# Local development: http://localhost:8000
+# Dev3: https://dev3.doenet.org
+# Production: https://beta.doenet.org
+PUBLIC_DOENET_MAIN_URL=https://beta.doenet.org
+
+# Canonical site URL used at build time for metadata and sitemap generation
+# Local development: http://localhost:4321
+# Dev3: https://dev3.doenet.org
+# Production: https://beta.doenet.org
+PUBLIC_SITE_URL=https://beta.doenet.org

--- a/apps/web/.env.prod
+++ b/apps/web/.env.prod
@@ -1,0 +1,4 @@
+# Production environment variables for the Doenet blog.
+# This file is intentionally committed — all PUBLIC_ vars are public.
+PUBLIC_DOENET_MAIN_URL=https://beta.doenet.org
+PUBLIC_SITE_URL=https://beta.doenet.org

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -13,10 +13,9 @@ yarn-error.log*
 pnpm-debug.log*
 
 
-# environment variables
-.env
+# environment variable overrides
 .env.local
-.env.production
+.env.*.local
 
 # macOS-specific files
 .DS_Store

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -55,9 +55,23 @@ All commands are run from the root of the project, from a terminal:
 
 ## Configuration
 
-The header logo link can be configured with a public env var:
+Builds use committed mode-based env files:
 
-- `PUBLIC_DOENET_MAIN_URL`: URL for the main Doenet site (If not specified, shows plain image).
+- `.env`: default local values
+- `.env.dev3`: dev3 deployment values
+- `.env.prod`: production deployment values
+- `.env.local`: optional machine-specific overrides (gitignored)
+
+Build commands:
+
+- `npm run build`: use the default `.env` values
+- `npm run build -- --mode dev3`: use `.env.dev3`
+- `npm run build -- --mode prod`: use `.env.prod`
+
+Public env vars:
+
+- `PUBLIC_DOENET_MAIN_URL`: URL for the main Doenet site. If not specified, the header shows a plain image.
+- `PUBLIC_SITE_URL`: canonical site URL used for build-time metadata and sitemap generation.
 
 ## 👀 Want to learn more?
 

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -3,18 +3,20 @@
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
+import process from "node:process";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import { loadEnv } from "vite";
 
 import react from "@astrojs/react";
 
+const modeIndex = process.argv.indexOf("--mode");
+const mode = modeIndex >= 0 ? process.argv[modeIndex + 1] : "production";
+const env = loadEnv(mode, process.cwd(), "");
+
 // https://astro.build/config
 export default defineConfig({
-  // TODO: Can we make `site` more general?
-  // TODO: When moving to `doenet.org`, we will have to migrate our pages
-  // and possibly add redirects
-  // aka `beta.doenet.org/blog/...` to `doenet.org/blog/...`
-  site: "https://beta.doenet.org",
+  site: env.PUBLIC_SITE_URL,
   integrations: [mdx(), sitemap(), react()],
   markdown: {
     remarkPlugins: [remarkMath],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "build:ts": "astro sync",
     "build:assets": "astro build",
-    "build": "npm run build:ts && npm run build:assets",
+    "build": "node ./scripts/build.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint --fix",

--- a/apps/web/scripts/build.mjs
+++ b/apps/web/scripts/build.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const extraArgs = process.argv.slice(2);
+
+run("astro", ["sync"]);
+run("astro", ["build", ...extraArgs]);


### PR DESCRIPTION
Add `--mode` flag to frontend build commands that configure environment variables.