### PR TITLE
fix: Cloudfront no longer overrides API error responses

### DIFF
--- a/infra/cloudformation/s3-hosted.yml
+++ b/infra/cloudformation/s3-hosted.yml
@@ -117,6 +117,40 @@ Resources:
             return request;
         }
 
+  # Temporary SPA fallback for the app distribution while API traffic still shares
+  # this CloudFront distribution. Long term, split frontend and API onto separate
+  # domains/distributions so API status codes cannot be rewritten here:
+  # https://github.com/Doenet/DoenetTools/issues/2894
+  AppSpaRewriteFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "${EnvironmentName}-app-spa-rewrite"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: Rewrite SPA routes to index.html while preserving API and asset paths
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+            var request = event.request;
+            var uri = request.uri;
+
+            if (uri.startsWith('/api/')) {
+                return request;
+            }
+
+            if (uri === '/blog' || uri.startsWith('/blog/')) {
+                return request;
+            }
+
+            var lastSegment = uri.split('/').pop();
+            if (lastSegment && lastSegment.includes('.')) {
+                return request;
+            }
+
+            request.uri = '/index.html';
+            return request;
+        }
+
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -217,15 +251,11 @@ Resources:
             QueryString: false
             Cookies:
               Forward: none
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt AppSpaRewriteFunction.FunctionARN
         Enabled: true
         DefaultRootObject: index.html
-        CustomErrorResponses:
-          - ErrorCode: 403
-            ResponseCode: 200
-            ResponsePagePath: /index.html
-          - ErrorCode: 404
-            ResponseCode: 200
-            ResponsePagePath: /index.html
         Aliases:
           - !Ref PublicHostedZoneName
         ViewerCertificate:


### PR DESCRIPTION
> [!NOTE]
> The infra changes on this PR have already been deployed to `dev3` and `beta`.

## Problem

Due to the way we've set Cloudfront's error fallbacks, any API responses that give 403 or 404 status codes get overwritten by React Router's `index.html`.

We want the fallback behavior for frontend URLS: direct visits to `doenet.org/some-link` would fail without it. But we don't want this fallback behavior to touch the API

## Short tem solution (this PR)

Remove the fallback behavior. To make sure `doenet.org/some-link` still works, add a Cloudfront function that maps most (but not all!) url paths to the base.


## Longer term solution
See #2894 

