### PR TITLE
[share unlisted 1/3] Expand the sharing API for visibility and content audits

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,6 +46,12 @@ jobs:
         run: npm run build
 
       # -----------------------------
+      # Shared package tests
+      # -----------------------------
+      - name: Test shared package
+        run: npm test --workspace @doenet-tools/shared
+
+      # -----------------------------
       # Start MySQL + Test server
       # -----------------------------
       - name: Start MySQL

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "bcryptjs": "^3.0.3",
     "body-parser": "^1.20.4",
     "cookie-parser": "^1.4.7",
+    "deepmerge-ts": "^7.1.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-session": "^1.18.1",

--- a/apps/api/prisma/migrations/20260515182139_add_document_diagnostics/migration.sql
+++ b/apps/api/prisma/migrations/20260515182139_add_document_diagnostics/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE `content`
+ADD COLUMN `accessibilityCheck` ENUM ('unchecked', 'pass', 'fail') NOT NULL DEFAULT 'unchecked',
+ADD COLUMN `errorsCheck` ENUM ('unchecked', 'pass', 'fail') NOT NULL DEFAULT 'unchecked';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -46,6 +46,8 @@ model content {
   doenetmlVersionId      Int?
   doenetmlVersion        doenetmlVersions?        @relation(fields: [doenetmlVersionId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   numVariants            Int                      @default(1)
+  errorsCheck            AuditState               @default(unchecked)
+  accessibilityCheck     AuditState               @default(unchecked)
   // Specific to documents inside problem sets
   repeatInProblemSet     Int                      @default(1)
   // 
@@ -142,6 +144,12 @@ model recentContent {
 enum RecentMode {
   edit
   view
+}
+
+enum AuditState {
+  unchecked
+  pass
+  fail
 }
 
 model contentRevisions {

--- a/apps/api/src/access/index.ts
+++ b/apps/api/src/access/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./visibility";
+export * from "./visibility.schema";

--- a/apps/api/src/access/visibility.test.ts
+++ b/apps/api/src/access/visibility.test.ts
@@ -121,6 +121,31 @@ describe("updateVisibility", () => {
     );
   });
 
+  test("treats trashed content as not found", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { isDeletedOn: new Date() },
+    });
+
+    const error = await expectInvalidRequest(
+      updateVisibility({
+        loggedInUserId: user.userId,
+        contentId,
+        visibility: "unlisted",
+      }),
+    );
+
+    expect(error.errorCode).toBe(StatusCodes.NOT_FOUND);
+    expect(error.message).toBe("Content not found");
+  });
+
   test("checks descendant diagnostics before allowing public sharing", async () => {
     const user = await createTestUser();
     const { contentId: sequenceId } = await createContent({

--- a/apps/api/src/access/visibility.test.ts
+++ b/apps/api/src/access/visibility.test.ts
@@ -51,11 +51,17 @@ async function makeDocumentPubliclyShareable({
   userId: Uint8Array;
 }) {
   await connectRequiredCategories(contentId);
+  const { source } = await prisma.content.findUniqueOrThrow({
+    where: { id: contentId },
+    select: { source: true },
+  });
+
   await updateContentAudit({
     contentId,
     loggedInUserId: userId,
-    noErrorsConfirmed: true,
-    accessibilityConfirmed: true,
+    source: source ?? "",
+    errorsCheckPasses: true,
+    accessibilityCheckPasses: true,
   });
 }
 

--- a/apps/api/src/access/visibility.test.ts
+++ b/apps/api/src/access/visibility.test.ts
@@ -52,15 +52,16 @@ async function makeDocumentPubliclyShareable({
   userId: Uint8Array;
 }) {
   await connectRequiredCategories(contentId);
-  const { source } = await prisma.content.findUniqueOrThrow({
+  const { source, doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
     where: { id: contentId },
-    select: { source: true },
+    select: { source: true, doenetmlVersionId: true },
   });
 
   await updateContentAudit({
     contentId,
     loggedInUserId: userId,
     source: source ?? "",
+    doenetmlVersionId,
     errorsCheckPasses: true,
     accessibilityCheckPasses: true,
   });
@@ -146,6 +147,22 @@ describe("updateVisibility", () => {
     expect(status.publicShareIssues).toContain("accessibilityCheckPending");
     expect(status.publicShareIssues).not.toContain("errorsCheck");
     expect(status.publicShareIssues).not.toContain("accessibilityCheck");
+  });
+
+  test("reports folders as not publicly shareable", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+
+    const status = await getEditorShareStatus({
+      contentId,
+      loggedInUserId: user.userId,
+    });
+
+    expect(status.canSharePublicly).toBe(false);
   });
 
   test("treats trashed content as not found", async () => {

--- a/apps/api/src/access/visibility.test.ts
+++ b/apps/api/src/access/visibility.test.ts
@@ -1,20 +1,87 @@
 import { describe, expect, test } from "vitest";
-import { createTestUser, fold, setupTestContent, doc } from "../test/utils";
-import { updateVisibility } from "./visibility";
+import { updateContentAudit } from "../content-audit";
 import { createContent } from "../query/activity";
-import { createAssignment } from "../query/assign";
-import { InvalidRequestError } from "../utils/error";
+import { createTestUser } from "../test/utils";
 import { prisma } from "../model";
+import { InvalidRequestError } from "../utils/error";
 import { StatusCodes } from "http-status-codes";
-import { DateTime } from "luxon";
+import { updateVisibility } from "./visibility";
+
+async function expectInvalidRequest(promise: Promise<unknown>) {
+  try {
+    await promise;
+    expect.fail("Expected InvalidRequestError");
+  } catch (error) {
+    expect(error).toBeInstanceOf(InvalidRequestError);
+    return error as InvalidRequestError;
+  }
+}
+
+async function connectRequiredCategories(contentId: Uint8Array) {
+  const groups = await prisma.categoryGroups.findMany({
+    where: { isRequired: true },
+    select: {
+      categories: {
+        select: { code: true },
+        orderBy: { sortIndex: "asc" },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+
+  const categories = groups.map((group) => {
+    const [category] = group.categories;
+    if (!category) {
+      throw new Error("Required category group is missing seeded categories");
+    }
+    return { code: category.code };
+  });
+
+  await prisma.content.update({
+    where: { id: contentId },
+    data: { categories: { connect: categories } },
+  });
+}
+
+async function makeDocumentPubliclyShareable({
+  contentId,
+  userId,
+}: {
+  contentId: Uint8Array;
+  userId: Uint8Array;
+}) {
+  await connectRequiredCategories(contentId);
+  await updateContentAudit({
+    contentId,
+    loggedInUserId: userId,
+    noErrorsConfirmed: true,
+    accessibilityConfirmed: true,
+  });
+}
+
+async function getVisibilityState(contentId: Uint8Array) {
+  return prisma.content.findUniqueOrThrow({
+    where: { id: contentId },
+    select: {
+      visibility: true,
+      isPublic: true,
+      publiclySharedAt: true,
+    },
+  });
+}
 
 describe("updateVisibility", () => {
-  test("Owner can change visibility from private to public", async () => {
+  test("allows owners to make eligible documents public", async () => {
     const user = await createTestUser();
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId: null,
+    });
+
+    await makeDocumentPubliclyShareable({
+      contentId,
+      userId: user.userId,
     });
 
     const result = await updateVisibility({
@@ -23,10 +90,15 @@ describe("updateVisibility", () => {
       visibility: "public",
     });
 
-    expect(result.visibility).toBe("public");
+    expect(result).toEqual({ visibility: "public" });
+
+    const content = await getVisibilityState(contentId);
+    expect(content.visibility).toBe("public");
+    expect(content.isPublic).toBe(true);
+    expect(content.publiclySharedAt).toBeInstanceOf(Date);
   });
 
-  test("Owner can change visibility from public to private", async () => {
+  test("blocks public sharing until categories and diagnostics are satisfied", async () => {
     const user = await createTestUser();
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
@@ -34,79 +106,23 @@ describe("updateVisibility", () => {
       parentId: null,
     });
 
-    await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId,
-      visibility: "public",
-    });
-
-    const result = await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId,
-      visibility: "private",
-    });
-
-    expect(result.visibility).toBe("private");
-  });
-
-  test("Non-owner cannot change visibility", async () => {
-    const user1 = await createTestUser();
-    const user2 = await createTestUser();
-
-    const { contentId } = await createContent({
-      loggedInUserId: user1.userId,
-      contentType: "singleDoc",
-      parentId: null,
-    });
-
-    try {
-      await updateVisibility({
-        loggedInUserId: user2.userId,
+    const error = await expectInvalidRequest(
+      updateVisibility({
+        loggedInUserId: user.userId,
         contentId,
         visibility: "public",
-      });
-      expect.fail("Should have thrown permission error");
-    } catch (e) {
-      expect(e).toBeInstanceOf(InvalidRequestError);
-      expect((e as InvalidRequestError).errorCode).toBe(StatusCodes.NOT_FOUND);
-    }
+      }),
+    );
+
+    expect(error.message).toContain("required categories are filled out");
+    expect(error.message).toContain("documents have no errors");
+    expect(error.message).toContain(
+      "documents have no level 1 accessibility violations",
+    );
   });
 
-  test("Cannot change assignment visibility", async () => {
+  test("checks descendant diagnostics before allowing public sharing", async () => {
     const user = await createTestUser();
-
-    // Create an assignment by setting isAssignmentRoot
-    const { contentId: assignmentId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId: null,
-    });
-
-    // Mark as assignment
-    await prisma.content.update({
-      where: { id: assignmentId },
-      data: { isAssignmentRoot: true },
-    });
-
-    try {
-      await updateVisibility({
-        loggedInUserId: user.userId,
-        contentId: assignmentId,
-        visibility: "public",
-      });
-      expect.fail("Should have thrown assignment error");
-    } catch (e) {
-      expect(e).toBeInstanceOf(InvalidRequestError);
-      expect((e as InvalidRequestError).message).toContain(
-        "Assignment visibility",
-      );
-    }
-  });
-
-  test("Cannot change visibility of content within assignment", async () => {
-    const user = await createTestUser();
-
-    // Assignments are shallow, so assigned content sits directly under the root.
     const { contentId: sequenceId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "sequence",
@@ -119,150 +135,75 @@ describe("updateVisibility", () => {
       parentId: sequenceId,
     });
 
-    // Create an assignment (copies the sequence and its direct children)
-    const { assignmentId } = await createAssignment({
-      contentId: sequenceId,
-      loggedInUserId: user.userId,
-      closedOn: DateTime.now().plus({ days: 1 }),
-      destinationParentId: null,
-    });
+    await connectRequiredCategories(sequenceId);
 
-    const assignmentChild = await prisma.content.findFirstOrThrow({
-      where: {
-        isDeletedOn: null,
-        ownerId: user.userId,
-        parentId: assignmentId,
-      },
-      select: { id: true },
-    });
-
-    // Try to change visibility of the copied assignment child - should fail
-    try {
-      await updateVisibility({
+    const error = await expectInvalidRequest(
+      updateVisibility({
         loggedInUserId: user.userId,
-        contentId: assignmentChild.id,
+        contentId: sequenceId,
         visibility: "public",
-      });
-      expect.fail("Should have thrown assignment content error");
-    } catch (e) {
-      expect(e).toBeInstanceOf(InvalidRequestError);
-      expect((e as InvalidRequestError).message).toContain(
-        "Assignment visibility",
-      );
-    }
+      }),
+    );
+
+    expect(error.message).not.toContain("required categories are filled out");
+    expect(error.message).toContain("documents have no errors");
+    expect(error.message).toContain(
+      "documents have no level 1 accessibility violations",
+    );
   });
 
-  test("Cannot make child less public than parent (private child in unlisted parent)", async () => {
+  test("rejects publicly sharing folders", async () => {
     const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "folder",
+      parentId: null,
+    });
 
-    // Create a folder (will be unlisted)
+    const error = await expectInvalidRequest(
+      updateVisibility({
+        loggedInUserId: user.userId,
+        contentId,
+        visibility: "public",
+      }),
+    );
+
+    expect(error.message).toContain("not yet implemented");
+  });
+
+  test("does not allow a child to become less public than its parent", async () => {
+    const user = await createTestUser();
     const { contentId: parentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "folder",
       parentId: null,
     });
 
-    // Make parent unlisted
     await updateVisibility({
       loggedInUserId: user.userId,
       contentId: parentId,
       visibility: "unlisted",
     });
 
-    // Create child document (default is private)
     const { contentId: childId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId,
     });
 
-    // Try to keep child private - should fail
-    try {
-      await updateVisibility({
+    const error = await expectInvalidRequest(
+      updateVisibility({
         loggedInUserId: user.userId,
         contentId: childId,
         visibility: "private",
-      });
-      expect.fail("Should have thrown hierarchy error");
-    } catch (e) {
-      expect(e).toBeInstanceOf(InvalidRequestError);
-      expect((e as InvalidRequestError).message).toContain("less public");
-    }
-  });
-
-  test("Can make child more public than parent", async () => {
-    const user = await createTestUser();
-
-    // Create a private folder
-    const { contentId: parentId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "folder",
-      parentId: null,
-    });
-
-    // Create child document
-    const { contentId: childId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId,
-    });
-
-    // Make child public (parent is private) - should succeed
-    const result = await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId: childId,
-      visibility: "public",
-    });
-
-    expect(result.visibility).toBe("public");
-  });
-
-  test("Cascades visibility to descendants when making parent more public", async () => {
-    const user = await createTestUser();
-
-    // Create a structure: folder > subfolder > doc
-    const [folderId, subfolderId, docId] = await setupTestContent(user.userId, {
-      folder1: fold({
-        subfolder1: fold({
-          doc1: doc("<p>test</p>"),
-        }),
       }),
-    });
+    );
 
-    // All start private
-    const content = await prisma.content.findUniqueOrThrow({
-      where: { id: folderId },
-    });
-    expect(content.visibility).toBe("private");
-
-    // Make parent public - should cascade
-    await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId: folderId,
-      visibility: "public",
-    });
-
-    // Check all descendants are now public
-    const folder = await prisma.content.findUniqueOrThrow({
-      where: { id: folderId },
-    });
-    expect(folder.visibility).toBe("public");
-
-    const subfolder = await prisma.content.findUniqueOrThrow({
-      where: { id: subfolderId },
-    });
-    expect(subfolder.visibility).toBe("public");
-
-    const docContent = await prisma.content.findUniqueOrThrow({
-      where: { id: docId },
-    });
-    expect(docContent.visibility).toBe("public");
+    expect(error.message).toContain("less public");
   });
 
-  test("Cascade excludes assignments", async () => {
+  test("cascades unlisted visibility while excluding assignment content", async () => {
     const user = await createTestUser();
-
-    // Create folder with a document
     const { contentId: folderId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "folder",
@@ -275,7 +216,6 @@ describe("updateVisibility", () => {
       parentId: folderId,
     });
 
-    // Create assignment subtree as sibling
     const { contentId: assignmentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "sequence",
@@ -288,221 +228,107 @@ describe("updateVisibility", () => {
       parentId: assignmentId,
     });
 
-    // Mark as assignment
     await prisma.content.update({
       where: { id: assignmentId },
       data: { isAssignmentRoot: true },
     });
 
-    // Make folder public
     await updateVisibility({
       loggedInUserId: user.userId,
       contentId: folderId,
-      visibility: "public",
+      visibility: "unlisted",
     });
 
-    // Document should be public
-    const docContent = await prisma.content.findUniqueOrThrow({
-      where: { id: docId },
-    });
-    expect(docContent.visibility).toBe("public");
+    const [folder, doc, assignment, assignmentChild] = await Promise.all([
+      prisma.content.findUniqueOrThrow({ where: { id: folderId } }),
+      prisma.content.findUniqueOrThrow({ where: { id: docId } }),
+      prisma.content.findUniqueOrThrow({ where: { id: assignmentId } }),
+      prisma.content.findUniqueOrThrow({ where: { id: assignmentChildId } }),
+    ]);
 
-    // Assignment should still be private
-    const assignment = await prisma.content.findUniqueOrThrow({
-      where: { id: assignmentId },
-    });
+    expect(folder.visibility).toBe("unlisted");
+    expect(doc.visibility).toBe("unlisted");
     expect(assignment.visibility).toBe("private");
-
-    const assignmentChild = await prisma.content.findUniqueOrThrow({
-      where: { id: assignmentChildId },
-    });
     expect(assignmentChild.visibility).toBe("private");
   });
 
-  test("Cascades when making parent less public (override children)", async () => {
+  test("clears the public timestamp when content becomes unlisted again", async () => {
     const user = await createTestUser();
-
-    // Create folder with public document
-    const { contentId: folderId } = await createContent({
+    const { contentId } = await createContent({
       loggedInUserId: user.userId,
-      contentType: "folder",
+      contentType: "singleDoc",
       parentId: null,
     });
 
-    const { contentId: docId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId: folderId,
+    await makeDocumentPubliclyShareable({
+      contentId,
+      userId: user.userId,
     });
 
-    // Make both public
     await updateVisibility({
       loggedInUserId: user.userId,
-      contentId: folderId,
+      contentId,
       visibility: "public",
     });
 
-    // Make folder private - should cascade and override children
-    await updateVisibility({
+    const publicState = await getVisibilityState(contentId);
+    expect(publicState.publiclySharedAt).toBeInstanceOf(Date);
+
+    const result = await updateVisibility({
       loggedInUserId: user.userId,
-      contentId: folderId,
-      visibility: "private",
+      contentId,
+      visibility: "unlisted",
     });
 
-    // Folder is private
-    const folder = await prisma.content.findUniqueOrThrow({
-      where: { id: folderId },
-    });
-    expect(folder.visibility).toBe("private");
+    expect(result).toEqual({ visibility: "unlisted" });
 
-    // Document should also be private now (cascaded)
-    const docContent = await prisma.content.findUniqueOrThrow({
-      where: { id: docId },
-    });
-    expect(docContent.visibility).toBe("private");
+    const unlistedState = await getVisibilityState(contentId);
+    expect(unlistedState.visibility).toBe("unlisted");
+    expect(unlistedState.isPublic).toBe(false);
+    expect(unlistedState.publiclySharedAt).toBeNull();
   });
 
-  test("Cascade excludes assignments when making parent less public", async () => {
-    const user = await createTestUser();
-
-    // Create folder with document and assignment
-    const { contentId: folderId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "folder",
+  test("rejects non-owner visibility changes with a not found error", async () => {
+    const owner = await createTestUser();
+    const otherUser = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
       parentId: null,
     });
 
-    const { contentId: docId } = await createContent({
+    const error = await expectInvalidRequest(
+      updateVisibility({
+        loggedInUserId: otherUser.userId,
+        contentId,
+        visibility: "unlisted",
+      }),
+    );
+
+    expect(error.errorCode).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  test("rejects changing assignment visibility", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
-      parentId: folderId,
+      parentId: null,
     });
 
-    const { contentId: assignmentId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId: folderId,
-    });
-
-    // Mark as assignment
     await prisma.content.update({
-      where: { id: assignmentId },
+      where: { id: contentId },
       data: { isAssignmentRoot: true },
     });
 
-    // Make all public
-    await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId: folderId,
-      visibility: "public",
-    });
-
-    // Make folder private
-    await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId: folderId,
-      visibility: "private",
-    });
-
-    // Document should be private
-    const doc = await prisma.content.findUniqueOrThrow({
-      where: { id: docId },
-    });
-    expect(doc.visibility).toBe("private");
-
-    // Assignment should still be private (unchanged)
-    const assignment = await prisma.content.findUniqueOrThrow({
-      where: { id: assignmentId },
-    });
-    expect(assignment.visibility).toBe("private");
-  });
-
-  test("Works with all content types", async () => {
-    const user = await createTestUser();
-
-    const types: Array<"singleDoc" | "sequence" | "select" | "folder"> = [
-      "singleDoc",
-      "sequence",
-      "select",
-      "folder",
-    ];
-
-    for (const contentType of types) {
-      const { contentId } = await createContent({
-        loggedInUserId: user.userId,
-        contentType,
-        parentId: null,
-      });
-
-      const result = await updateVisibility({
+    const error = await expectInvalidRequest(
+      updateVisibility({
         loggedInUserId: user.userId,
         contentId,
-        visibility: "public",
-      });
+        visibility: "unlisted",
+      }),
+    );
 
-      expect(result.visibility).toBe("public");
-    }
-  });
-
-  test("Returns the requested visibility when the update is idempotent", async () => {
-    const user = await createTestUser();
-    const { contentId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId: null,
-    });
-
-    // Set to public
-    await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId,
-      visibility: "public",
-    });
-
-    // Set to public again - should just return current
-    const result = await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId,
-      visibility: "public",
-    });
-
-    expect(result.visibility).toBe("public");
-  });
-
-  test("Rejects non-existent content", async () => {
-    const user = await createTestUser();
-    const fakeId = new Uint8Array(16);
-
-    try {
-      await updateVisibility({
-        loggedInUserId: user.userId,
-        contentId: fakeId,
-        visibility: "public",
-      });
-      expect.fail("Should have thrown not found error");
-    } catch (e) {
-      expect(e).toBeInstanceOf(InvalidRequestError);
-      expect((e as InvalidRequestError).errorCode).toBe(StatusCodes.NOT_FOUND);
-    }
-  });
-
-  test("Response is AccessPolicy (only visibility, no Content properties)", async () => {
-    const user = await createTestUser();
-    const { contentId } = await createContent({
-      loggedInUserId: user.userId,
-      contentType: "singleDoc",
-      parentId: null,
-    });
-
-    const result = await updateVisibility({
-      loggedInUserId: user.userId,
-      contentId,
-      visibility: "public",
-    });
-
-    // Verify response is AccessPolicy (only has visibility)
-    expect(result).toEqual({ visibility: "public" });
-    // Ensure no Content properties are present
-    expect(Object.keys(result).sort()).toEqual(["visibility"]);
+    expect(error.message).toContain("Assignment visibility");
   });
 });

--- a/apps/api/src/access/visibility.test.ts
+++ b/apps/api/src/access/visibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { updateContentAudit } from "../content-audit";
 import { createContent } from "../query/activity";
+import { getEditorShareStatus } from "../query/editor";
 import { createTestUser } from "../test/utils";
 import { prisma } from "../model";
 import { InvalidRequestError } from "../utils/error";
@@ -125,6 +126,26 @@ describe("updateVisibility", () => {
     expect(error.message).toContain(
       "documents have no level 1 accessibility violations",
     );
+  });
+
+  test("reports pending diagnostics for new blank documents", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    const status = await getEditorShareStatus({
+      contentId,
+      loggedInUserId: user.userId,
+    });
+
+    expect(status.canSharePublicly).toBe(false);
+    expect(status.publicShareIssues).toContain("errorsCheckPending");
+    expect(status.publicShareIssues).toContain("accessibilityCheckPending");
+    expect(status.publicShareIssues).not.toContain("errorsCheck");
+    expect(status.publicShareIssues).not.toContain("accessibilityCheck");
   });
 
   test("treats trashed content as not found", async () => {

--- a/apps/api/src/access/visibility.ts
+++ b/apps/api/src/access/visibility.ts
@@ -1,4 +1,10 @@
-import { Visibility } from "@prisma/client";
+import { getCategoryIssues, type CategoryIssue } from "@doenet-tools/shared";
+import { ContentType, Visibility } from "@prisma/client";
+import {
+  getContentAuditIssues,
+  selectContentAuditFields,
+  type ContentAuditIssue,
+} from "../content-audit";
 import { prisma } from "../model";
 import { InvalidRequestError } from "../utils/error";
 import { getDescendantIds } from "../query/activity";
@@ -6,12 +12,35 @@ import type { AccessPolicy } from "./types";
 import { filterExcludeAssignments } from "../utils/permissions";
 import { StatusCodes } from "http-status-codes";
 import { isEqualUUID } from "../utils/uuid";
+import {
+  ContentPayload,
+  contentSelect,
+  mergeContentSelects,
+} from "../utils/prismaSelect";
+import { isAssignment, selectAssignmentFields } from "../assignments";
+import { getAllCategories, selectCategoryFields } from "../categories";
 
-// Visibility levels ordered from most restrictive to least restrictive
-const visibilityOrder: Record<Visibility, number> = {
-  private: 0,
-  unlisted: 1,
-  public: 2,
+// __________________________________________________________________________
+//
+//
+//                     Exported types and functions
+//
+// __________________________________________________________________________
+//
+
+/**
+ * Issues that would prevent a content item from being shared publicly
+ */
+export type PublicShareIssue = CategoryIssue | ContentAuditIssue;
+
+/**
+ * A violation that would prevent a content item from being shared publicly
+ */
+export type PublicShareViolation = {
+  contentId: Uint8Array;
+  name: string;
+  type: ContentType;
+  issues: PublicShareIssue[];
 };
 
 /**
@@ -22,6 +51,7 @@ const visibilityOrder: Record<Visibility, number> = {
  * 2. Assignments cannot have their visibility changed (always private)
  * 3. A child cannot be less public than its parent
  * 4. Content within an assignment cannot have visibility changed
+ * 5. There are additional criteria to be shared publicly, see {@link getPublicShareViolations}
  */
 export async function updateVisibility({
   loggedInUserId,
@@ -34,26 +64,14 @@ export async function updateVisibility({
 }): Promise<AccessPolicy> {
   const content = await prisma.content.findFirst({
     where: { id: contentId, isDeletedOn: null },
-    select: {
-      ownerId: true,
-      isAssignmentRoot: true,
-      visibility: true,
-      parent: {
-        select: {
-          isAssignmentRoot: true,
-          visibility: true,
-        },
-      },
-    },
+    select: selectRelevantFields,
   });
 
   if (!content || !isEqualUUID(content.ownerId, loggedInUserId)) {
     throw new InvalidRequestError("Content not found", StatusCodes.NOT_FOUND);
   }
 
-  // Assignment content is shallow by design, so checking the root and immediate
-  // parent is sufficient to exclude all assignment-owned content here.
-  if (content.isAssignmentRoot || content.parent?.isAssignmentRoot) {
+  if (isAssignment(content)) {
     throw new InvalidRequestError("Assignment visibility cannot be changed");
   }
 
@@ -71,13 +89,31 @@ export async function updateVisibility({
   const descendantIds = await getDescendantIds(contentId, {
     excludeAssignments: true,
   });
+  const contentIds = [contentId, ...descendantIds];
+
+  if (visibility === "public") {
+    if (content.type === "folder") {
+      throw new InvalidRequestError(
+        `Publicly sharing folders is not yet implemented.`,
+      );
+    }
+
+    const violations = await getPublicShareViolationsForContent({
+      content,
+      descendantIds,
+    });
+
+    if (violations.length > 0) {
+      throw new InvalidRequestError(formatPublicShareViolation(violations));
+    }
+  }
 
   const publiclySharedAt = visibility === "public" ? new Date() : null;
 
   // Update share timestamp for those whose share status is changing
   const updateTimestamp = prisma.content.updateMany({
     where: {
-      id: { in: [contentId, ...descendantIds] },
+      id: { in: contentIds },
       NOT: { visibility },
       ...filterExcludeAssignments,
     },
@@ -86,7 +122,7 @@ export async function updateVisibility({
 
   const updateContent = prisma.content.updateMany({
     where: {
-      id: { in: [contentId, ...descendantIds] },
+      id: { in: contentIds },
       ...filterExcludeAssignments,
     },
     data: {
@@ -99,4 +135,136 @@ export async function updateVisibility({
   await prisma.$transaction([updateTimestamp, updateContent]);
 
   return { visibility };
+}
+
+// __________________________________________________________________________
+//
+//
+//                 Internal types and helper functions
+//
+//___________________________________________________________________________
+//
+
+// Visibility levels ordered from most restrictive to least restrictive
+const visibilityOrder: Record<Visibility, number> = {
+  private: 0,
+  unlisted: 1,
+  public: 2,
+};
+
+const generalFields = contentSelect({
+  id: true,
+  name: true,
+  type: true,
+  ownerId: true,
+  visibility: true,
+  parent: {
+    select: {
+      visibility: true,
+    },
+  },
+});
+
+const selectRelevantFields = mergeContentSelects(
+  generalFields,
+  selectContentAuditFields,
+  selectAssignmentFields,
+);
+
+type RelevantFields = ContentPayload<typeof selectRelevantFields>;
+
+/**
+ * Checks a content item and its descendants for issues that would prevent it from being made `public`.
+ *
+ * Criteria for public sharing:
+ * 1. All required categories must be filled out
+ * 2. Documents must have no errors
+ * 3. Documents must have no level 1 accessibility violations
+ */
+export async function getPublicShareViolations({
+  contentIds,
+}: {
+  contentIds: Uint8Array[];
+}): Promise<PublicShareViolation[]> {
+  const [contentId, ...descendantIds] = contentIds;
+
+  if (!contentId) {
+    return [];
+  }
+
+  const content = await prisma.content.findUniqueOrThrow({
+    where: { id: contentId, isDeletedOn: null },
+    select: selectRelevantFields,
+  });
+
+  return getPublicShareViolationsForContent({ content, descendantIds });
+}
+
+async function getPublicShareViolationsForContent({
+  content,
+  descendantIds,
+}: {
+  content: RelevantFields;
+  descendantIds: Uint8Array[];
+}): Promise<PublicShareViolation[]> {
+  const fetchDescendantAudits = prisma.content.findMany({
+    where: { id: { in: descendantIds } },
+    select: mergeContentSelects(
+      selectContentAuditFields,
+      { id: true },
+      { name: true },
+      { type: true },
+    ),
+  });
+
+  const fetchAllCategories = getAllCategories();
+
+  const fetchCategoryFields = prisma.content.findUniqueOrThrow({
+    where: { id: content.id },
+    select: selectCategoryFields,
+  });
+
+  const [descendantAudits, { allCategories }, { categories }] =
+    await Promise.all([
+      fetchDescendantAudits,
+      fetchAllCategories,
+      fetchCategoryFields,
+    ]);
+
+  const violations: PublicShareViolation[] = descendantAudits.map((audit) => ({
+    contentId: audit.id,
+    name: audit.name,
+    type: audit.type,
+    issues: getContentAuditIssues(audit),
+  }));
+  violations.push({
+    contentId: content.id,
+    name: content.name,
+    type: content.type,
+    issues: [
+      ...getContentAuditIssues(content),
+      ...getCategoryIssues({ allCategories, categories }),
+    ],
+  });
+
+  return violations.filter((violation) => violation.issues.length > 0);
+}
+
+/**
+ * Formats a list of public share violations into a user-friendly error message.
+ */
+function formatPublicShareViolation(violations: PublicShareViolation[]) {
+  const issues = new Set(violations.flatMap((violation) => violation.issues));
+  const blockingCriteria: string[] = [];
+
+  if (issues.has("missingRequiredCategories")) {
+    blockingCriteria.push("required categories are filled out");
+  }
+  if (issues.has("documentErrors")) {
+    blockingCriteria.push("documents have no errors");
+  }
+  if (issues.has("level1AccessibilityViolations")) {
+    blockingCriteria.push("documents have no level 1 accessibility violations");
+  }
+  return `Content cannot be made public until ${blockingCriteria.join(", ")}.`;
 }

--- a/apps/api/src/access/visibility.ts
+++ b/apps/api/src/access/visibility.ts
@@ -260,10 +260,13 @@ function formatPublicShareViolation(violations: PublicShareViolation[]) {
   if (issues.has("missingRequiredCategories")) {
     blockingCriteria.push("required categories are filled out");
   }
-  if (issues.has("errorsCheck")) {
+  if (issues.has("errorsCheck") || issues.has("errorsCheckPending")) {
     blockingCriteria.push("documents have no errors");
   }
-  if (issues.has("accessibilityCheck")) {
+  if (
+    issues.has("accessibilityCheck") ||
+    issues.has("accessibilityCheckPending")
+  ) {
     blockingCriteria.push("documents have no level 1 accessibility violations");
   }
   return `Content cannot be made public until ${blockingCriteria.join(", ")}.`;

--- a/apps/api/src/access/visibility.ts
+++ b/apps/api/src/access/visibility.ts
@@ -260,10 +260,10 @@ function formatPublicShareViolation(violations: PublicShareViolation[]) {
   if (issues.has("missingRequiredCategories")) {
     blockingCriteria.push("required categories are filled out");
   }
-  if (issues.has("documentErrors")) {
+  if (issues.has("errorsCheck")) {
     blockingCriteria.push("documents have no errors");
   }
-  if (issues.has("level1AccessibilityViolations")) {
+  if (issues.has("accessibilityCheck")) {
     blockingCriteria.push("documents have no level 1 accessibility violations");
   }
   return `Content cannot be made public until ${blockingCriteria.join(", ")}.`;

--- a/apps/api/src/assignments/assignments.test.ts
+++ b/apps/api/src/assignments/assignments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { isAssignment, type AssignmentFields } from "./assignments";
+
+function buildAssignmentFields(
+  overrides: Partial<AssignmentFields> = {},
+): AssignmentFields {
+  return {
+    isAssignmentRoot: false,
+    parent: null,
+    ...overrides,
+  };
+}
+
+describe("isAssignment", () => {
+  test("returns true for assignment roots", () => {
+    expect(
+      isAssignment(buildAssignmentFields({ isAssignmentRoot: true })),
+    ).toBe(true);
+  });
+
+  test("returns true for direct children of assignment roots", () => {
+    expect(
+      isAssignment(
+        buildAssignmentFields({
+          parent: { isAssignmentRoot: true },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false when neither the content nor its parent is an assignment root", () => {
+    expect(
+      isAssignment(
+        buildAssignmentFields({
+          parent: { isAssignmentRoot: false },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/assignments/assignments.ts
+++ b/apps/api/src/assignments/assignments.ts
@@ -1,0 +1,33 @@
+import { ContentPayload, contentSelect } from "../utils/prismaSelect";
+
+/**
+ * Prisma selection for the minimal set of database fields (from
+ * the `content` table) needed to manage assignments
+ */
+export const selectAssignmentFields = contentSelect({
+  isAssignmentRoot: true,
+  parent: {
+    select: {
+      isAssignmentRoot: true,
+    },
+  },
+});
+
+/**
+ * Payload shape produced by {@link selectAssignmentFields}.
+ */
+export type AssignmentFields = ContentPayload<typeof selectAssignmentFields>;
+
+/**
+ * Check if content is an assignment or part of an assignment.
+ *
+ * Requires data from {@link selectAssignmentFields}.
+ */
+export function isAssignment(assignmentFields: AssignmentFields): boolean {
+  // Assignment content is shallow by design, so checking the root and immediate
+  // parent is sufficient to exclude all assignment-owned content here.
+  return (
+    assignmentFields.isAssignmentRoot ||
+    assignmentFields.parent?.isAssignmentRoot === true
+  );
+}

--- a/apps/api/src/assignments/index.ts
+++ b/apps/api/src/assignments/index.ts
@@ -1,0 +1,1 @@
+export * from "./assignments";

--- a/apps/api/src/categories/categories.test.ts
+++ b/apps/api/src/categories/categories.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest";
+import { createContent } from "../query/activity";
+import { prisma } from "../model";
+import { createTestUser } from "../test/utils";
+import { getAllCategories, selectCategoryFields } from "./categories";
+
+async function getSeededGroup(name: string) {
+  const group = await prisma.categoryGroups.findUnique({
+    where: { name },
+    select: {
+      categories: {
+        select: {
+          code: true,
+          term: true,
+          description: true,
+        },
+        orderBy: { sortIndex: "asc" },
+      },
+    },
+  });
+
+  if (!group) {
+    throw new Error(`Missing seeded category group: ${name}`);
+  }
+
+  return group;
+}
+
+describe("categories", () => {
+  test("selectCategoryFields returns attached category metadata", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    const scopeGroup = await getSeededGroup("Scope");
+    const modeGroup = await getSeededGroup("Mode");
+
+    const [scopeCategory, modeCategory] = [
+      scopeGroup.categories[0],
+      modeGroup.categories[0],
+    ];
+
+    if (!scopeCategory || !modeCategory) {
+      throw new Error("Expected seeded categories in Scope and Mode groups");
+    }
+
+    await prisma.content.update({
+      where: { id: contentId },
+      data: {
+        categories: {
+          connect: [{ code: scopeCategory.code }, { code: modeCategory.code }],
+        },
+      },
+    });
+
+    const { categories } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: selectCategoryFields,
+    });
+
+    expect(categories.toSorted((a, b) => a.code.localeCompare(b.code))).toEqual(
+      [modeCategory, scopeCategory].toSorted((a, b) =>
+        a.code.localeCompare(b.code),
+      ),
+    );
+  });
+
+  test("getAllCategories returns seeded groups with expected flags and sort order", async () => {
+    const { allCategories } = await getAllCategories();
+
+    const scope = allCategories.find((group) => group.name === "Scope");
+    const mode = allCategories.find((group) => group.name === "Mode");
+    const duration = allCategories.find((group) => group.name === "Duration");
+
+    if (!scope || !mode || !duration) {
+      throw new Error(
+        "Expected seeded Scope, Mode, and Duration category groups",
+      );
+    }
+
+    expect(scope).toMatchObject({
+      isRequired: true,
+      isExclusive: true,
+    });
+    expect(scope.categories.map((category) => category.code)).toEqual([
+      "isWidget",
+      "isProblemSet",
+      "isQuestion",
+    ]);
+
+    expect(mode).toMatchObject({
+      isRequired: true,
+      isExclusive: false,
+    });
+    expect(
+      mode.categories.slice(0, 3).map((category) => category.code),
+    ).toEqual(["isPreview", "isPractice", "isAssessment"]);
+
+    expect(duration).toMatchObject({
+      isRequired: true,
+      isExclusive: true,
+    });
+    expect(duration.categories[0]?.code).toBe("takesLessThanFiveMinutes");
+  });
+});

--- a/apps/api/src/categories/categories.ts
+++ b/apps/api/src/categories/categories.ts
@@ -1,0 +1,42 @@
+import { CategoryGroup } from "@doenet-tools/shared";
+import { contentSelect } from "../utils/prismaSelect";
+import { prisma } from "../model";
+
+/**
+ * Prisma selection for the minimal set of database fields (from
+ * the `content` table) needed to manage categories
+ */
+export const selectCategoryFields = contentSelect({
+  categories: {
+    select: {
+      code: true,
+      description: true,
+      term: true,
+    },
+  },
+});
+
+/**
+ * Get full list of categories and category groups defined in the system.
+ */
+export async function getAllCategories(): Promise<{
+  allCategories: CategoryGroup[];
+}> {
+  const allCategories: CategoryGroup[] = await prisma.categoryGroups.findMany({
+    select: {
+      name: true,
+      isRequired: true,
+      isExclusive: true,
+      categories: {
+        select: {
+          code: true,
+          term: true,
+          description: true,
+        },
+        orderBy: { sortIndex: "asc" },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+  return { allCategories };
+}

--- a/apps/api/src/categories/index.ts
+++ b/apps/api/src/categories/index.ts
@@ -1,0 +1,1 @@
+export * from "./categories";

--- a/apps/api/src/content-audit/content-audit.schema.ts
+++ b/apps/api/src/content-audit/content-audit.schema.ts
@@ -4,6 +4,7 @@ import { uuidSchema } from "../schemas/uuid";
 export const updateContentAuditSchema = z.object({
   contentId: uuidSchema,
   source: z.string(),
+  doenetmlVersionId: z.number().int().nullable(),
   errorsCheckPasses: z.boolean(),
   accessibilityCheckPasses: z.boolean(),
 });

--- a/apps/api/src/content-audit/content-audit.schema.ts
+++ b/apps/api/src/content-audit/content-audit.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { uuidSchema } from "../schemas/uuid";
+
+export const updateContentAuditSchema = z.object({
+  contentId: uuidSchema,
+  noErrorsConfirmed: z.boolean(),
+  accessibilityConfirmed: z.boolean(),
+});

--- a/apps/api/src/content-audit/content-audit.schema.ts
+++ b/apps/api/src/content-audit/content-audit.schema.ts
@@ -3,6 +3,7 @@ import { uuidSchema } from "../schemas/uuid";
 
 export const updateContentAuditSchema = z.object({
   contentId: uuidSchema,
-  noErrorsConfirmed: z.boolean(),
-  accessibilityConfirmed: z.boolean(),
+  source: z.string(),
+  errorsCheckPasses: z.boolean(),
+  accessibilityCheckPasses: z.boolean(),
 });

--- a/apps/api/src/content-audit/content-audit.test.ts
+++ b/apps/api/src/content-audit/content-audit.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "vitest";
+import {
+  createContent,
+  createContentRevision,
+  revertToRevision,
+  saveSyntaxUpdate,
+  updateContent,
+} from "../query/activity";
+import {
+  contentAuditPasses,
+  getContentAuditIssues,
+  maintainContentAuditFields,
+  resetContentAuditFields,
+  updateContentAudit,
+} from "./content-audit";
+import { prisma } from "../model";
+import { createTestUser } from "../test/utils";
+
+describe("content audit helpers", () => {
+  test("returns both issues for single documents missing both confirmations", () => {
+    const content = {
+      type: "singleDoc" as const,
+      noErrorsConfirmed: false,
+      accessibilityConfirmed: false,
+    };
+
+    expect(getContentAuditIssues(content)).toEqual([
+      "documentErrors",
+      "level1AccessibilityViolations",
+    ]);
+    expect(contentAuditPasses(content)).toBe(false);
+  });
+
+  test("returns only remaining issues for partially confirmed single documents", () => {
+    const content = {
+      type: "singleDoc" as const,
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: false,
+    };
+
+    expect(getContentAuditIssues(content)).toEqual([
+      "level1AccessibilityViolations",
+    ]);
+    expect(contentAuditPasses(content)).toBe(false);
+  });
+
+  test("ignores audit confirmations for non-document content", () => {
+    const content = {
+      type: "sequence" as const,
+      noErrorsConfirmed: false,
+      accessibilityConfirmed: false,
+    };
+
+    expect(getContentAuditIssues(content)).toEqual([]);
+    expect(contentAuditPasses(content)).toBe(true);
+  });
+
+  test("resets cached confirmations only when the source changes", () => {
+    expect(maintainContentAuditFields(undefined)).toEqual({});
+    expect(maintainContentAuditFields("<document />")).toEqual(
+      resetContentAuditFields,
+    );
+  });
+});
+
+describe("content audit updates", () => {
+  test("updateContentAudit stores confirmations on editable docs", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: "<document><text>Initial</text></document>",
+    });
+
+    const result = await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+
+    expect(result).toMatchObject({
+      type: "singleDoc",
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        noErrorsConfirmed: true,
+        accessibilityConfirmed: true,
+      },
+    });
+
+    expect(content).toEqual({
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+  });
+
+  test("updateContent resets audit confirmations when source changes", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: "<document><text>Initial</text></document>",
+    });
+
+    await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+
+    await updateContent({
+      contentId,
+      loggedInUserId: user.userId,
+      source: "<document><text>Changed</text></document>",
+    });
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        source: true,
+        noErrorsConfirmed: true,
+        accessibilityConfirmed: true,
+      },
+    });
+
+    expect(content).toEqual({
+      source: "<document><text>Changed</text></document>",
+      noErrorsConfirmed: false,
+      accessibilityConfirmed: false,
+    });
+  });
+
+  test("revertToRevision resets audit confirmations when source changes", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: "<document><text>Initial</text></document>",
+    });
+
+    const revision = await createContentRevision({
+      contentId,
+      loggedInUserId: user.userId,
+      revisionName: "Initial save point",
+    });
+
+    await updateContent({
+      contentId,
+      loggedInUserId: user.userId,
+      source: "<document><text>Changed</text></document>",
+    });
+
+    await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+
+    await revertToRevision({
+      contentId,
+      loggedInUserId: user.userId,
+      revisionNum: revision.revisionNum,
+    });
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        source: true,
+        noErrorsConfirmed: true,
+        accessibilityConfirmed: true,
+      },
+    });
+
+    expect(content).toEqual({
+      source: "<document><text>Initial</text></document>",
+      noErrorsConfirmed: false,
+      accessibilityConfirmed: false,
+    });
+  }, 30000);
+
+  test("saveSyntaxUpdate resets audit confirmations when source changes", async () => {
+    const user = await createTestUser();
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: "<document><text>Initial</text></document>",
+    });
+
+    await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      noErrorsConfirmed: true,
+      accessibilityConfirmed: true,
+    });
+
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
+    if (doenetmlVersionId === null) {
+      throw new Error("Document should have a DoenetML version");
+    }
+
+    await saveSyntaxUpdate({
+      contentId,
+      loggedInUserId: user.userId,
+      updatedDoenetmlVersionId: doenetmlVersionId,
+      updatedSource: "<document><text>Updated</text></document>",
+    });
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        source: true,
+        noErrorsConfirmed: true,
+        accessibilityConfirmed: true,
+      },
+    });
+
+    expect(content).toEqual({
+      source: "<document><text>Updated</text></document>",
+      noErrorsConfirmed: false,
+      accessibilityConfirmed: false,
+    });
+  });
+});

--- a/apps/api/src/content-audit/content-audit.test.ts
+++ b/apps/api/src/content-audit/content-audit.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import {
   createContent,
   createContentRevision,
+  getAllDoenetmlVersions,
   revertToRevision,
   saveSyntaxUpdate,
   updateContent,
@@ -56,9 +57,17 @@ describe("content audit helpers", () => {
     expect(contentAuditPasses(content)).toBe(true);
   });
 
-  test("resets cached confirmations only when the source changes", () => {
-    expect(maintainContentAuditFields(undefined)).toEqual({});
-    expect(maintainContentAuditFields("<document />")).toEqual(
+  test("resets cached confirmations when source or version changes", () => {
+    expect(
+      maintainContentAuditFields({
+        source: undefined,
+        doenetmlVersionId: undefined,
+      }),
+    ).toEqual({});
+    expect(maintainContentAuditFields({ source: "<document />" })).toEqual(
+      resetContentAuditFields,
+    );
+    expect(maintainContentAuditFields({ doenetmlVersionId: 2 })).toEqual(
       resetContentAuditFields,
     );
   });
@@ -75,10 +84,16 @@ describe("content audit updates", () => {
       doenetml: source,
     });
 
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
     const result = await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
       source,
+      doenetmlVersionId,
       errorsCheckPasses: true,
       accessibilityCheckPasses: false,
     });
@@ -113,11 +128,17 @@ describe("content audit updates", () => {
       doenetml: source,
     });
 
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
     try {
       await updateContentAudit({
         contentId,
         loggedInUserId: user.userId,
         source: "<document><text>Outdated</text></document>",
+        doenetmlVersionId,
         errorsCheckPasses: true,
         accessibilityCheckPasses: true,
       });
@@ -156,10 +177,16 @@ describe("content audit updates", () => {
       doenetml: source,
     });
 
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
     await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
       source,
+      doenetmlVersionId,
       errorsCheckPasses: true,
       accessibilityCheckPasses: true,
     });
@@ -202,6 +229,11 @@ describe("content audit updates", () => {
       revisionName: "Initial save point",
     });
 
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
     await updateContent({
       contentId,
       loggedInUserId: user.userId,
@@ -212,6 +244,7 @@ describe("content audit updates", () => {
       contentId,
       loggedInUserId: user.userId,
       source: "<document><text>Changed</text></document>",
+      doenetmlVersionId,
       errorsCheckPasses: true,
       accessibilityCheckPasses: true,
     });
@@ -248,14 +281,6 @@ describe("content audit updates", () => {
       doenetml: source,
     });
 
-    await updateContentAudit({
-      contentId,
-      loggedInUserId: user.userId,
-      source,
-      errorsCheckPasses: true,
-      accessibilityCheckPasses: true,
-    });
-
     const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
       where: { id: contentId },
       select: { doenetmlVersionId: true },
@@ -264,6 +289,15 @@ describe("content audit updates", () => {
     if (doenetmlVersionId === null) {
       throw new Error("Document should have a DoenetML version");
     }
+
+    await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      source,
+      doenetmlVersionId,
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: true,
+    });
 
     await saveSyntaxUpdate({
       contentId,
@@ -283,6 +317,133 @@ describe("content audit updates", () => {
 
     expect(content).toEqual({
       source: "<document><text>Updated</text></document>",
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
+    });
+  });
+
+  test("updateContent resets audit confirmations when only doenetmlVersionId changes", async () => {
+    const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: source,
+    });
+
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
+    if (doenetmlVersionId === null) {
+      throw new Error("Document should have a DoenetML version");
+    }
+
+    await updateContentAudit({
+      contentId,
+      loggedInUserId: user.userId,
+      source,
+      doenetmlVersionId,
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: true,
+    });
+
+    const { allDoenetmlVersions } = await getAllDoenetmlVersions();
+    const nextVersion = allDoenetmlVersions.find(
+      (version) => version.id !== doenetmlVersionId,
+    );
+
+    if (!nextVersion) {
+      throw new Error("Expected a second DoenetML version in seeded data");
+    }
+
+    await updateContent({
+      contentId,
+      loggedInUserId: user.userId,
+      doenetmlVersionId: nextVersion.id,
+    });
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        doenetmlVersionId: true,
+        errorsCheck: true,
+        accessibilityCheck: true,
+      },
+    });
+
+    expect(content).toEqual({
+      doenetmlVersionId: nextVersion.id,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
+    });
+  });
+
+  test("updateContentAudit rejects stale doenetmlVersionId without changing audit state", async () => {
+    const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: source,
+    });
+
+    const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: { doenetmlVersionId: true },
+    });
+
+    if (doenetmlVersionId === null) {
+      throw new Error("Document should have a DoenetML version");
+    }
+
+    const { allDoenetmlVersions } = await getAllDoenetmlVersions();
+    const nextVersion = allDoenetmlVersions.find(
+      (version) => version.id !== doenetmlVersionId,
+    );
+
+    if (!nextVersion) {
+      throw new Error("Expected a second DoenetML version in seeded data");
+    }
+
+    await updateContent({
+      contentId,
+      loggedInUserId: user.userId,
+      doenetmlVersionId: nextVersion.id,
+    });
+
+    try {
+      await updateContentAudit({
+        contentId,
+        loggedInUserId: user.userId,
+        source,
+        doenetmlVersionId,
+        errorsCheckPasses: true,
+        accessibilityCheckPasses: true,
+      });
+      expect.fail("Expected InvalidRequestError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidRequestError);
+      expect((error as InvalidRequestError).errorCode).toBe(
+        StatusCodes.CONFLICT,
+      );
+      expect((error as InvalidRequestError).message).toBe(
+        "Content source is out of date",
+      );
+    }
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        errorsCheck: true,
+        accessibilityCheck: true,
+      },
+    });
+
+    expect(content).toEqual({
       errorsCheck: AuditState.unchecked,
       accessibilityCheck: AuditState.unchecked,
     });

--- a/apps/api/src/content-audit/content-audit.test.ts
+++ b/apps/api/src/content-audit/content-audit.test.ts
@@ -149,7 +149,7 @@ describe("content audit updates", () => {
         StatusCodes.CONFLICT,
       );
       expect((error as InvalidRequestError).message).toBe(
-        "Content source is out of date",
+        "Content source or DoenetML version is out of date",
       );
     }
 
@@ -431,7 +431,7 @@ describe("content audit updates", () => {
         StatusCodes.CONFLICT,
       );
       expect((error as InvalidRequestError).message).toBe(
-        "Content source is out of date",
+        "Content source or DoenetML version is out of date",
       );
     }
 

--- a/apps/api/src/content-audit/content-audit.test.ts
+++ b/apps/api/src/content-audit/content-audit.test.ts
@@ -1,3 +1,5 @@
+import { AuditState } from "@prisma/client";
+import { StatusCodes } from "http-status-codes";
 import { describe, expect, test } from "vitest";
 import {
   createContent,
@@ -15,18 +17,19 @@ import {
 } from "./content-audit";
 import { prisma } from "../model";
 import { createTestUser } from "../test/utils";
+import { InvalidRequestError } from "../utils/error";
 
 describe("content audit helpers", () => {
   test("returns both issues for single documents missing both confirmations", () => {
     const content = {
       type: "singleDoc" as const,
-      noErrorsConfirmed: false,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     };
 
     expect(getContentAuditIssues(content)).toEqual([
-      "documentErrors",
-      "level1AccessibilityViolations",
+      "errorsCheck",
+      "accessibilityCheck",
     ]);
     expect(contentAuditPasses(content)).toBe(false);
   });
@@ -34,21 +37,19 @@ describe("content audit helpers", () => {
   test("returns only remaining issues for partially confirmed single documents", () => {
     const content = {
       type: "singleDoc" as const,
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.pass,
+      accessibilityCheck: AuditState.fail,
     };
 
-    expect(getContentAuditIssues(content)).toEqual([
-      "level1AccessibilityViolations",
-    ]);
+    expect(getContentAuditIssues(content)).toEqual(["accessibilityCheck"]);
     expect(contentAuditPasses(content)).toBe(false);
   });
 
   test("ignores audit confirmations for non-document content", () => {
     const content = {
       type: "sequence" as const,
-      noErrorsConfirmed: false,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     };
 
     expect(getContentAuditIssues(content)).toEqual([]);
@@ -64,56 +65,103 @@ describe("content audit helpers", () => {
 });
 
 describe("content audit updates", () => {
-  test("updateContentAudit stores confirmations on editable docs", async () => {
+  test("updateContentAudit stores pass/fail states on editable docs", async () => {
     const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId: null,
-      doenetml: "<document><text>Initial</text></document>",
+      doenetml: source,
     });
 
     const result = await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      source,
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: false,
     });
 
     expect(result).toMatchObject({
       type: "singleDoc",
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      errorsCheck: AuditState.pass,
+      accessibilityCheck: AuditState.fail,
     });
 
     const content = await prisma.content.findUniqueOrThrow({
       where: { id: contentId },
       select: {
-        noErrorsConfirmed: true,
-        accessibilityConfirmed: true,
+        errorsCheck: true,
+        accessibilityCheck: true,
       },
     });
 
     expect(content).toEqual({
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      errorsCheck: AuditState.pass,
+      accessibilityCheck: AuditState.fail,
+    });
+  });
+
+  test("updateContentAudit rejects stale source without changing audit state", async () => {
+    const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
+    const { contentId } = await createContent({
+      loggedInUserId: user.userId,
+      contentType: "singleDoc",
+      parentId: null,
+      doenetml: source,
+    });
+
+    try {
+      await updateContentAudit({
+        contentId,
+        loggedInUserId: user.userId,
+        source: "<document><text>Outdated</text></document>",
+        errorsCheckPasses: true,
+        accessibilityCheckPasses: true,
+      });
+      expect.fail("Expected InvalidRequestError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidRequestError);
+      expect((error as InvalidRequestError).errorCode).toBe(
+        StatusCodes.CONFLICT,
+      );
+      expect((error as InvalidRequestError).message).toBe(
+        "Content source is out of date",
+      );
+    }
+
+    const content = await prisma.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        errorsCheck: true,
+        accessibilityCheck: true,
+      },
+    });
+
+    expect(content).toEqual({
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     });
   });
 
   test("updateContent resets audit confirmations when source changes", async () => {
     const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId: null,
-      doenetml: "<document><text>Initial</text></document>",
+      doenetml: source,
     });
 
     await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      source,
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: true,
     });
 
     await updateContent({
@@ -126,25 +174,26 @@ describe("content audit updates", () => {
       where: { id: contentId },
       select: {
         source: true,
-        noErrorsConfirmed: true,
-        accessibilityConfirmed: true,
+        errorsCheck: true,
+        accessibilityCheck: true,
       },
     });
 
     expect(content).toEqual({
       source: "<document><text>Changed</text></document>",
-      noErrorsConfirmed: false,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     });
   });
 
   test("revertToRevision resets audit confirmations when source changes", async () => {
     const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId: null,
-      doenetml: "<document><text>Initial</text></document>",
+      doenetml: source,
     });
 
     const revision = await createContentRevision({
@@ -162,8 +211,9 @@ describe("content audit updates", () => {
     await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      source: "<document><text>Changed</text></document>",
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: true,
     });
 
     await revertToRevision({
@@ -176,32 +226,34 @@ describe("content audit updates", () => {
       where: { id: contentId },
       select: {
         source: true,
-        noErrorsConfirmed: true,
-        accessibilityConfirmed: true,
+        errorsCheck: true,
+        accessibilityCheck: true,
       },
     });
 
     expect(content).toEqual({
       source: "<document><text>Initial</text></document>",
-      noErrorsConfirmed: false,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     });
   }, 30000);
 
   test("saveSyntaxUpdate resets audit confirmations when source changes", async () => {
     const user = await createTestUser();
+    const source = "<document><text>Initial</text></document>";
     const { contentId } = await createContent({
       loggedInUserId: user.userId,
       contentType: "singleDoc",
       parentId: null,
-      doenetml: "<document><text>Initial</text></document>",
+      doenetml: source,
     });
 
     await updateContentAudit({
       contentId,
       loggedInUserId: user.userId,
-      noErrorsConfirmed: true,
-      accessibilityConfirmed: true,
+      source,
+      errorsCheckPasses: true,
+      accessibilityCheckPasses: true,
     });
 
     const { doenetmlVersionId } = await prisma.content.findUniqueOrThrow({
@@ -224,15 +276,15 @@ describe("content audit updates", () => {
       where: { id: contentId },
       select: {
         source: true,
-        noErrorsConfirmed: true,
-        accessibilityConfirmed: true,
+        errorsCheck: true,
+        accessibilityCheck: true,
       },
     });
 
     expect(content).toEqual({
       source: "<document><text>Updated</text></document>",
-      noErrorsConfirmed: false,
-      accessibilityConfirmed: false,
+      errorsCheck: AuditState.unchecked,
+      accessibilityCheck: AuditState.unchecked,
     });
   });
 });

--- a/apps/api/src/content-audit/content-audit.test.ts
+++ b/apps/api/src/content-audit/content-audit.test.ts
@@ -20,7 +20,7 @@ import { createTestUser } from "../test/utils";
 import { InvalidRequestError } from "../utils/error";
 
 describe("content audit helpers", () => {
-  test("returns both issues for single documents missing both confirmations", () => {
+  test("returns pending issues for single documents missing both confirmations", () => {
     const content = {
       type: "singleDoc" as const,
       errorsCheck: AuditState.unchecked,
@@ -28,8 +28,8 @@ describe("content audit helpers", () => {
     };
 
     expect(getContentAuditIssues(content)).toEqual([
-      "errorsCheck",
-      "accessibilityCheck",
+      "errorsCheckPending",
+      "accessibilityCheckPending",
     ]);
     expect(contentAuditPasses(content)).toBe(false);
   });

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -1,6 +1,9 @@
+import { AuditState } from "@prisma/client";
+import { StatusCodes } from "http-status-codes";
 import { prisma } from "../model";
 import { filterEditableActivity, getIsEditor } from "../utils/permissions";
 import { ContentPayload, contentSelect } from "../utils/prismaSelect";
+import { InvalidRequestError } from "../utils/error";
 
 /**
  * Enumerates the content-audit issues that can affect a content node.
@@ -9,20 +12,17 @@ import { ContentPayload, contentSelect } from "../utils/prismaSelect";
  * the conditions that must be confirmed before content is treated
  * as having passed the audit.
  */
-export type ContentAuditIssue =
-  | "documentErrors"
-  | "level1AccessibilityViolations";
+export type ContentAuditIssue = "errorsCheck" | "accessibilityCheck";
 
 /**
  * The audit status for a piece of content.
  *
- * If a flag is `true`, the content passes the check.
- * If a flag is `false`, the content either fails the
- * check or has not yet been confirmed as passing.
+ * Each check stores whether the content is known to pass, known to fail,
+ * or has not been audited since the latest source change.
  */
 export type ContentAudit = {
-  noErrorsConfirmed: boolean;
-  accessibilityConfirmed: boolean;
+  errorsCheck: AuditState;
+  accessibilityCheck: AuditState;
 };
 
 /**
@@ -31,8 +31,8 @@ export type ContentAudit = {
  */
 export const selectContentAuditFields = contentSelect({
   type: true,
-  noErrorsConfirmed: true,
-  accessibilityConfirmed: true,
+  errorsCheck: true,
+  accessibilityCheck: true,
 });
 
 /**
@@ -52,8 +52,8 @@ export type ContentAuditFields = ContentPayload<
  * are reset to `false` until the updated document is reviewed again.
  */
 export const resetContentAuditFields: ContentAudit = {
-  noErrorsConfirmed: false,
-  accessibilityConfirmed: false,
+  errorsCheck: AuditState.unchecked,
+  accessibilityCheck: AuditState.unchecked,
 } satisfies ContentAudit;
 
 /**
@@ -69,14 +69,13 @@ export function getContentAuditIssues(
   contentAuditFields: ContentAuditFields,
 ): ContentAuditIssue[] {
   const issues: ContentAuditIssue[] = [];
-  const { type, noErrorsConfirmed, accessibilityConfirmed } =
-    contentAuditFields;
+  const { type, errorsCheck, accessibilityCheck } = contentAuditFields;
 
-  if (type === "singleDoc" && !noErrorsConfirmed) {
-    issues.push("documentErrors");
+  if (type === "singleDoc" && errorsCheck !== AuditState.pass) {
+    issues.push("errorsCheck");
   }
-  if (type === "singleDoc" && !accessibilityConfirmed) {
-    issues.push("level1AccessibilityViolations");
+  if (type === "singleDoc" && accessibilityCheck !== AuditState.pass) {
+    issues.push("accessibilityCheck");
   }
 
   return issues;
@@ -104,7 +103,7 @@ export function contentAuditPasses(
  *
  * When no new source is provided, this helper returns an empty update so the
  * existing confirmations are preserved. When source content is provided, both
- * confirmations are reset because the previous audit no longer applies.
+ * states are reset to `unchecked` because the previous audit no longer applies.
  *
  * @param source Updated source content, if one is being saved.
  * @returns An empty update or a reset audit state, depending on whether the
@@ -123,28 +122,44 @@ export function maintainContentAuditFields(source: string | undefined) {
 export async function updateContentAudit({
   contentId,
   loggedInUserId,
-  noErrorsConfirmed,
-  accessibilityConfirmed,
+  source,
+  errorsCheckPasses,
+  accessibilityCheckPasses,
 }: {
   contentId: Uint8Array;
   loggedInUserId: Uint8Array;
-} & ContentAudit): Promise<ContentAudit> {
+  source: string;
+  errorsCheckPasses: boolean;
+  accessibilityCheckPasses: boolean;
+}): Promise<ContentAuditFields> {
   const isEditor = await getIsEditor(loggedInUserId);
 
-  await prisma.content.findFirstOrThrow({
+  const content = await prisma.content.findFirstOrThrow({
     where: {
       id: contentId,
       ...filterEditableActivity(loggedInUserId, isEditor),
       type: "singleDoc",
     },
-    select: { id: true },
+    select: {
+      id: true,
+      source: true,
+    },
   });
+
+  if (content.source !== source) {
+    throw new InvalidRequestError(
+      "Content source is out of date",
+      StatusCodes.CONFLICT,
+    );
+  }
 
   return await prisma.content.update({
     where: { id: contentId },
     data: {
-      noErrorsConfirmed,
-      accessibilityConfirmed,
+      errorsCheck: errorsCheckPasses ? AuditState.pass : AuditState.fail,
+      accessibilityCheck: accessibilityCheckPasses
+        ? AuditState.pass
+        : AuditState.fail,
     },
     select: {
       ...selectContentAuditFields,

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -1,0 +1,86 @@
+import { prisma } from "../model";
+import { filterEditableActivity, getIsEditor } from "../utils/permissions";
+import { ContentPayload, contentSelect } from "../utils/prismaSelect";
+
+export type ContentAuditIssue =
+  | "documentErrors"
+  | "level1AccessibilityViolations";
+
+export type ContentAudit = {
+  noErrorsConfirmed: boolean;
+  accessibilityConfirmed: boolean;
+};
+
+export const selectContentAuditFields = contentSelect({
+  type: true,
+  noErrorsConfirmed: true,
+  accessibilityConfirmed: true,
+});
+
+export type ContentAuditFields = ContentPayload<
+  typeof selectContentAuditFields
+>;
+
+export const resetContentAuditFields: ContentAudit = {
+  noErrorsConfirmed: false,
+  accessibilityConfirmed: false,
+} satisfies ContentAudit;
+
+export function getContentAuditIssues(
+  contentAuditFields: ContentAuditFields,
+): ContentAuditIssue[] {
+  const issues: ContentAuditIssue[] = [];
+  const { type, noErrorsConfirmed, accessibilityConfirmed } =
+    contentAuditFields;
+
+  if (type === "singleDoc" && !noErrorsConfirmed) {
+    issues.push("documentErrors");
+  }
+  if (type === "singleDoc" && !accessibilityConfirmed) {
+    issues.push("level1AccessibilityViolations");
+  }
+
+  return issues;
+}
+
+export function contentAuditPasses(
+  contentAuditFields: ContentAuditFields,
+): boolean {
+  return getContentAuditIssues(contentAuditFields).length === 0;
+}
+
+export function maintainContentAuditFields(source: string | undefined) {
+  return source === undefined ? {} : resetContentAuditFields;
+}
+
+export async function updateContentAudit({
+  contentId,
+  loggedInUserId,
+  noErrorsConfirmed,
+  accessibilityConfirmed,
+}: {
+  contentId: Uint8Array;
+  loggedInUserId: Uint8Array;
+} & ContentAudit): Promise<ContentAudit> {
+  const isEditor = await getIsEditor(loggedInUserId);
+
+  await prisma.content.findFirstOrThrow({
+    where: {
+      id: contentId,
+      ...filterEditableActivity(loggedInUserId, isEditor),
+      type: "singleDoc",
+    },
+    select: { id: true },
+  });
+
+  return await prisma.content.update({
+    where: { id: contentId },
+    data: {
+      noErrorsConfirmed,
+      accessibilityConfirmed,
+    },
+    select: {
+      ...selectContentAuditFields,
+    },
+  });
+}

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -2,30 +2,69 @@ import { prisma } from "../model";
 import { filterEditableActivity, getIsEditor } from "../utils/permissions";
 import { ContentPayload, contentSelect } from "../utils/prismaSelect";
 
+/**
+ * Enumerates the content-audit issues that can affect a content node.
+ *
+ * These issue codes are returned by helpers in this module and represent
+ * the conditions that must be confirmed before content is treated
+ * as having passed the audit.
+ */
 export type ContentAuditIssue =
   | "documentErrors"
   | "level1AccessibilityViolations";
 
+/**
+ * The audit status for a piece of content.
+ *
+ * If a flag is `true`, the content passes the check.
+ * If a flag is `false`, the content either fails the
+ * check or has not yet been confirmed as passing.
+ */
 export type ContentAudit = {
   noErrorsConfirmed: boolean;
   accessibilityConfirmed: boolean;
 };
 
+/**
+ * Prisma selection for the minimal set of database fields (from
+ * the `content` table) needed to manage audits.
+ */
 export const selectContentAuditFields = contentSelect({
   type: true,
   noErrorsConfirmed: true,
   accessibilityConfirmed: true,
 });
 
+/**
+ * Payload shape produced by {@link selectContentAuditFields}.
+ *
+ * This is the input type expected by the audit-evaluation helpers in this
+ * module.
+ */
 export type ContentAuditFields = ContentPayload<
   typeof selectContentAuditFields
 >;
 
+/**
+ * Default audit state used after document content changes.
+ *
+ * Any source change invalidates earlier confirmations, so both audit flags
+ * are reset to `false` until the updated document is reviewed again.
+ */
 export const resetContentAuditFields: ContentAudit = {
   noErrorsConfirmed: false,
   accessibilityConfirmed: false,
 } satisfies ContentAudit;
 
+/**
+ * Returns the unresolved audit issues for the provided content.
+ *
+ * Only `singleDoc` content participates in this audit flow. Other content
+ * types always return an empty list, even if the confirmation flags are false.
+ *
+ * @param contentAuditFields Content fields needed to evaluate audit status.
+ * @returns The set of outstanding audit issues for the content.
+ */
 export function getContentAuditIssues(
   contentAuditFields: ContentAuditFields,
 ): ContentAuditIssue[] {
@@ -43,16 +82,44 @@ export function getContentAuditIssues(
   return issues;
 }
 
+/**
+ * Returns whether the content currently passes the content audit.
+ *
+ * This is a convenience wrapper around {@link getContentAuditIssues} that is
+ * useful when callers only need a boolean pass/fail result.
+ *
+ * @param contentAuditFields Content fields needed to evaluate audit status.
+ * @returns `true` when no audit issues remain, otherwise `false`.
+ */
 export function contentAuditPasses(
   contentAuditFields: ContentAuditFields,
 ): boolean {
   return getContentAuditIssues(contentAuditFields).length === 0;
 }
 
+/**
+ * Use this whenever you're updating/creating content, and the update
+ * might touch the doenetml source. We need to make sure that outdated
+ * audits don't persist.
+ *
+ * When no new source is provided, this helper returns an empty update so the
+ * existing confirmations are preserved. When source content is provided, both
+ * confirmations are reset because the previous audit no longer applies.
+ *
+ * @param source Updated source content, if one is being saved.
+ * @returns An empty update or a reset audit state, depending on whether the
+ * source changed.
+ */
 export function maintainContentAuditFields(source: string | undefined) {
   return source === undefined ? {} : resetContentAuditFields;
 }
 
+/**
+ * Store latest pass/fail audit results.
+ *
+ * The content must exist, belong to a document node, and be editable by the
+ * requesting user.
+ */
 export async function updateContentAudit({
   contentId,
   loggedInUserId,

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -53,7 +53,7 @@ export type ContentAuditFields = ContentPayload<
  * Default audit state used after document content changes.
  *
  * Any source change invalidates earlier confirmations, so both audit flags
- * are reset to `false` until the updated document is reviewed again.
+ * are reset to `unchecked` until the updated document is reviewed again.
  */
 export const resetContentAuditFields: ContentAudit = {
   errorsCheck: AuditState.unchecked,
@@ -118,11 +118,20 @@ export function contentAuditPasses(
  * states are reset to `unchecked` because the previous audit no longer applies.
  *
  * @param source Updated source content, if one is being saved.
+ * @param doenetmlVersionId Updated DoenetML version, if one is being saved.
  * @returns An empty update or a reset audit state, depending on whether the
- * source changed.
+ * content definition changed.
  */
-export function maintainContentAuditFields(source: string | undefined) {
-  return source === undefined ? {} : resetContentAuditFields;
+export function maintainContentAuditFields({
+  source,
+  doenetmlVersionId,
+}: {
+  source?: string;
+  doenetmlVersionId?: number;
+}) {
+  return source === undefined && doenetmlVersionId === undefined
+    ? {}
+    : resetContentAuditFields;
 }
 
 /**
@@ -135,46 +144,68 @@ export async function updateContentAudit({
   contentId,
   loggedInUserId,
   source,
+  doenetmlVersionId,
   errorsCheckPasses,
   accessibilityCheckPasses,
 }: {
   contentId: Uint8Array;
   loggedInUserId: Uint8Array;
   source: string;
+  doenetmlVersionId: number | null;
   errorsCheckPasses: boolean;
   accessibilityCheckPasses: boolean;
 }): Promise<ContentAuditFields> {
   const isEditor = await getIsEditor(loggedInUserId);
 
-  const content = await prisma.content.findFirstOrThrow({
-    where: {
-      id: contentId,
-      ...filterEditableActivity(loggedInUserId, isEditor),
-      type: "singleDoc",
-    },
-    select: {
-      id: true,
-      source: true,
-    },
-  });
+  return await prisma.$transaction(async (tx) => {
+    const updateResult = await tx.content.updateMany({
+      where: {
+        id: contentId,
+        ...filterEditableActivity(loggedInUserId, isEditor),
+        type: "singleDoc",
+        source,
+        doenetmlVersionId,
+      },
+      data: {
+        errorsCheck: errorsCheckPasses ? AuditState.pass : AuditState.fail,
+        accessibilityCheck: accessibilityCheckPasses
+          ? AuditState.pass
+          : AuditState.fail,
+      },
+    });
 
-  if (content.source !== source) {
-    throw new InvalidRequestError(
-      "Content source is out of date",
-      StatusCodes.CONFLICT,
-    );
-  }
+    if (updateResult.count === 0) {
+      const matchingContent = await tx.content.findFirst({
+        where: {
+          id: contentId,
+          ...filterEditableActivity(loggedInUserId, isEditor),
+          type: "singleDoc",
+        },
+        select: {
+          source: true,
+          doenetmlVersionId: true,
+        },
+      });
 
-  return await prisma.content.update({
-    where: { id: contentId },
-    data: {
-      errorsCheck: errorsCheckPasses ? AuditState.pass : AuditState.fail,
-      accessibilityCheck: accessibilityCheckPasses
-        ? AuditState.pass
-        : AuditState.fail,
-    },
-    select: {
-      ...selectContentAuditFields,
-    },
+      if (
+        matchingContent &&
+        (matchingContent.source !== source ||
+          matchingContent.doenetmlVersionId !== doenetmlVersionId)
+      ) {
+        throw new InvalidRequestError(
+          "Content source is out of date",
+          StatusCodes.CONFLICT,
+        );
+      }
+
+      throw new InvalidRequestError("Content not found", StatusCodes.NOT_FOUND);
+    }
+
+    return await tx.content.findUniqueOrThrow({
+      where: { id: contentId },
+      select: {
+        ...selectContentAuditFields,
+      },
+    });
   });
 }

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -12,7 +12,11 @@ import { InvalidRequestError } from "../utils/error";
  * the conditions that must be confirmed before content is treated
  * as having passed the audit.
  */
-export type ContentAuditIssue = "errorsCheck" | "accessibilityCheck";
+export type ContentAuditIssue =
+  | "errorsCheck"
+  | "errorsCheckPending"
+  | "accessibilityCheck"
+  | "accessibilityCheckPending";
 
 /**
  * The audit status for a piece of content.
@@ -71,11 +75,19 @@ export function getContentAuditIssues(
   const issues: ContentAuditIssue[] = [];
   const { type, errorsCheck, accessibilityCheck } = contentAuditFields;
 
-  if (type === "singleDoc" && errorsCheck !== AuditState.pass) {
-    issues.push("errorsCheck");
+  if (type === "singleDoc") {
+    if (errorsCheck === AuditState.fail) {
+      issues.push("errorsCheck");
+    } else if (errorsCheck === AuditState.unchecked) {
+      issues.push("errorsCheckPending");
+    }
   }
-  if (type === "singleDoc" && accessibilityCheck !== AuditState.pass) {
-    issues.push("accessibilityCheck");
+  if (type === "singleDoc") {
+    if (accessibilityCheck === AuditState.fail) {
+      issues.push("accessibilityCheck");
+    } else if (accessibilityCheck === AuditState.unchecked) {
+      issues.push("accessibilityCheckPending");
+    }
   }
 
   return issues;

--- a/apps/api/src/content-audit/content-audit.ts
+++ b/apps/api/src/content-audit/content-audit.ts
@@ -193,7 +193,7 @@ export async function updateContentAudit({
           matchingContent.doenetmlVersionId !== doenetmlVersionId)
       ) {
         throw new InvalidRequestError(
-          "Content source is out of date",
+          "Content source or DoenetML version is out of date",
           StatusCodes.CONFLICT,
         );
       }

--- a/apps/api/src/content-audit/index.ts
+++ b/apps/api/src/content-audit/index.ts
@@ -1,0 +1,13 @@
+/**
+ * This module is responsible for updating and managing content audits
+ * (such as tracking doenetml errors and accessibility violations).
+ *
+ * It provides helpers to get audit data from the database, reason about
+ * content using that data, and update the audits as needed.
+ *
+ * This module deals with content on a per-node basis. It does not
+ * make any assumptions about how the audit system and the folder
+ * tree interact.
+ */
+
+export * from "./content-audit";

--- a/apps/api/src/content-audit/index.ts
+++ b/apps/api/src/content-audit/index.ts
@@ -11,3 +11,4 @@
  */
 
 export * from "./content-audit";
+export * from "./content-audit.schema";

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -1,4 +1,4 @@
-import { ContentType, Prisma } from "@prisma/client";
+import { ContentType, Prisma, Visibility } from "@prisma/client";
 import { prisma } from "../model";
 import { getLibraryAccountId } from "./curate";
 import {
@@ -18,6 +18,10 @@ import { compileActivityFromContent } from "../utils/contentStructure";
 import { InvalidRequestError } from "../utils/error";
 import { ContentDescription } from "../types";
 import { isEqualUUID } from "../utils/uuid";
+import {
+  maintainContentAuditFields,
+  resetContentAuditFields,
+} from "../content-audit";
 
 /**
  * Creates a new content of type `contentType` in `parentId` of `ownerId`,
@@ -60,6 +64,7 @@ export async function createContent({
   const { defaultDoenetmlVersion } = await getDefaultDoenetmlVersion();
 
   let isPublic = false;
+  let visibility: Visibility = "private";
   let licenseCode = undefined;
   let sharedWith: Uint8Array[] = [];
   let courseRootId: Uint8Array | null = null;
@@ -76,6 +81,7 @@ export async function createContent({
       },
       select: {
         isPublic: true,
+        visibility: true,
         licenseCode: true,
         sharedWith: { select: { userId: true } },
         isAssignmentRoot: true,
@@ -92,8 +98,9 @@ export async function createContent({
 
     courseRootId = parent.courseRootId;
 
-    if (parent.isPublic) {
-      isPublic = true;
+    if (parent.visibility !== "private") {
+      visibility = parent.visibility;
+      isPublic = parent.visibility === "public";
       if (parent.licenseCode) {
         licenseCode = parent.licenseCode;
       }
@@ -135,7 +142,7 @@ export async function createContent({
       parentId,
       name,
       isPublic,
-      visibility: isPublic ? "public" : "private",
+      visibility,
       licenseCode,
       sortIndex,
       courseRootId,
@@ -534,6 +541,7 @@ export async function updateContent({
       source,
       doenetmlVersionId,
       numVariants,
+      ...maintainContentAuditFields(source),
       shuffle,
       numToSelect,
       selectByVariant,
@@ -1080,6 +1088,7 @@ export async function revertToRevision({
       source: revision.source,
       doenetmlVersionId: revision.doenetmlVersionId,
       numVariants: revision.numVariants,
+      ...resetContentAuditFields,
     },
   });
 

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -541,7 +541,7 @@ export async function updateContent({
       source,
       doenetmlVersionId,
       numVariants,
-      ...maintainContentAuditFields(source),
+      ...maintainContentAuditFields({ source, doenetmlVersionId }),
       shuffle,
       numToSelect,
       selectByVariant,

--- a/apps/api/src/query/activity_edit_view.ts
+++ b/apps/api/src/query/activity_edit_view.ts
@@ -207,6 +207,15 @@ export async function getPublicContent({
 }: {
   contentId: Uint8Array;
 }) {
+  await prisma.content.findUniqueOrThrow({
+    where: {
+      id: contentId,
+      isDeletedOn: null,
+      visibility: "public",
+    },
+    select: { id: true },
+  });
+
   const activity = await getContent({
     contentId,
     loggedInUserId: new Uint8Array(16),
@@ -222,7 +231,11 @@ export async function getPublicContentByCid({ cid }: { cid: string }) {
   const content = await prisma.contentRevisions.findFirstOrThrow({
     where: {
       cid,
-      content: { isDeletedOn: null, isPublic: true, type: { not: "folder" } },
+      content: {
+        isDeletedOn: null,
+        visibility: "public",
+        type: { not: "folder" },
+      },
     },
     select: {
       contentId: true,

--- a/apps/api/src/query/classification.ts
+++ b/apps/api/src/query/classification.ts
@@ -19,7 +19,6 @@ import {
   getIsEditor,
 } from "../utils/permissions";
 import { InvalidRequestError } from "../utils/error";
-import { CategoryGroup } from "@doenet-tools/shared";
 
 export async function getClassificationCategories() {
   const results = await prisma.classificationSystems.findMany({
@@ -428,26 +427,4 @@ export async function getClassificationInfo({
   } else {
     return null;
   }
-}
-
-export async function getAllCategories(): Promise<{
-  allCategories: CategoryGroup[];
-}> {
-  const allCategories: CategoryGroup[] = await prisma.categoryGroups.findMany({
-    select: {
-      name: true,
-      isRequired: true,
-      isExclusive: true,
-      categories: {
-        select: {
-          code: true,
-          term: true,
-          description: true,
-        },
-        orderBy: { sortIndex: "asc" },
-      },
-    },
-    orderBy: { id: "asc" },
-  });
-  return { allCategories };
 }

--- a/apps/api/src/query/content_list.ts
+++ b/apps/api/src/query/content_list.ts
@@ -337,8 +337,13 @@ export async function getSharedContent({
         isDeletedOn: null,
 
         OR: [
-          { isPublic: true },
-          { sharedWith: { some: { userId: loggedInUserId } } },
+          { visibility: "public" },
+          {
+            AND: [
+              { visibility: "private" },
+              { sharedWith: { some: { userId: loggedInUserId } } },
+            ],
+          },
         ],
       },
       select: returnContentSelect({}),
@@ -349,10 +354,11 @@ export async function getSharedContent({
     if (
       !(
         preliminaryParent.parent &&
-        (preliminaryParent.parent.isPublic ||
-          preliminaryParent.parent.sharedWith.findIndex((cs) =>
-            isEqualUUID(cs.userId, loggedInUserId),
-          ) !== -1)
+        (preliminaryParent.parent.visibility === "public" ||
+          (preliminaryParent.parent.visibility === "private" &&
+            preliminaryParent.parent.sharedWith.findIndex((cs) =>
+              isEqualUUID(cs.userId, loggedInUserId),
+            ) !== -1))
       )
     ) {
       preliminaryParent.parent = null;
@@ -369,8 +375,13 @@ export async function getSharedContent({
       // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
       isDeletedOn: null,
       OR: [
-        { isPublic: true },
-        { sharedWith: { some: { userId: loggedInUserId } } },
+        { visibility: "public" },
+        {
+          AND: [
+            { visibility: "private" },
+            { sharedWith: { some: { userId: loggedInUserId } } },
+          ],
+        },
       ],
     },
     select: returnContentSelect({ includeOwnerDetails: true }),
@@ -388,15 +399,25 @@ export async function getSharedContent({
         ownerId,
         parent: {
           AND: [
-            { isPublic: false },
-            { sharedWith: { none: { userId: loggedInUserId } } },
+            { visibility: { not: "public" } },
+            {
+              OR: [
+                { visibility: { not: "private" } },
+                { sharedWith: { none: { userId: loggedInUserId } } },
+              ],
+            },
           ],
         },
         // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
         isDeletedOn: null,
         OR: [
-          { isPublic: true },
-          { sharedWith: { some: { userId: loggedInUserId } } },
+          { visibility: "public" },
+          {
+            AND: [
+              { visibility: "private" },
+              { sharedWith: { some: { userId: loggedInUserId } } },
+            ],
+          },
         ],
       },
       select: returnContentSelect({ includeOwnerDetails: true }),

--- a/apps/api/src/query/content_list.ts
+++ b/apps/api/src/query/content_list.ts
@@ -8,7 +8,7 @@ import {
 } from "../utils/permissions";
 import { processContent, returnContentSelect } from "../utils/contentStructure";
 import { Content } from "../types";
-import { getAllCategories } from "./classification";
+import { getAllCategories } from "../categories";
 import { sanitizeQuery } from "../utils/search";
 import { Prisma } from "@prisma/client";
 import {

--- a/apps/api/src/query/content_list.ts
+++ b/apps/api/src/query/content_list.ts
@@ -21,6 +21,47 @@ import { getAllLicenses } from "./license";
 import { recordRecentContent } from "./recent";
 import { recordContentView } from "./popularity";
 
+function sharedWithLoggedInUser(loggedInUserId: Uint8Array) {
+  return { sharedWith: { some: { userId: loggedInUserId } } };
+}
+
+function isDiscoverableSharedContent(loggedInUserId: Uint8Array) {
+  return {
+    OR: [
+      { visibility: "public" as const },
+      sharedWithLoggedInUser(loggedInUserId),
+    ],
+  } satisfies Prisma.contentWhereInput;
+}
+
+function isOpenableSharedFolder(loggedInUserId: Uint8Array) {
+  return {
+    OR: [
+      { visibility: { in: ["public", "unlisted"] } },
+      sharedWithLoggedInUser(loggedInUserId),
+    ],
+  } satisfies Prisma.contentWhereInput;
+}
+
+function parentIsVisibleInSharedBreadcrumb(
+  parent: {
+    visibility: string;
+    sharedWith: { userId: Uint8Array }[];
+  } | null,
+  loggedInUserId: Uint8Array,
+) {
+  if (!parent) {
+    return false;
+  }
+
+  return (
+    parent.visibility !== "private" ||
+    parent.sharedWith.findIndex((cs) =>
+      isEqualUUID(cs.userId, loggedInUserId),
+    ) !== -1
+  );
+}
+
 export async function getMyContent({
   ownerId,
   parentId,
@@ -328,37 +369,24 @@ export async function getSharedContent({
 
   if (parentId !== null) {
     // if ask for a parent, make sure it exists and is viewable by logged in user
-    const preliminaryParent = await prisma.content.findUniqueOrThrow({
+    const preliminaryParent = await prisma.content.findFirstOrThrow({
       where: {
         ownerId,
         id: parentId,
         type: "folder",
         // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
         isDeletedOn: null,
-
-        OR: [
-          { visibility: "public" },
-          {
-            AND: [
-              { visibility: "private" },
-              { sharedWith: { some: { userId: loggedInUserId } } },
-            ],
-          },
-        ],
+        ...isOpenableSharedFolder(loggedInUserId),
       },
-      select: returnContentSelect({}),
+      select: returnContentSelect({ includeShareDetails: false }),
     });
 
     // If parent is not public or not shared with me,
     // make it look like it doesn't have a parent.
     if (
-      !(
-        preliminaryParent.parent &&
-        (preliminaryParent.parent.visibility === "public" ||
-          (preliminaryParent.parent.visibility === "private" &&
-            preliminaryParent.parent.sharedWith.findIndex((cs) =>
-              isEqualUUID(cs.userId, loggedInUserId),
-            ) !== -1))
+      !parentIsVisibleInSharedBreadcrumb(
+        preliminaryParent.parent,
+        loggedInUserId,
       )
     ) {
       preliminaryParent.parent = null;
@@ -374,15 +402,9 @@ export async function getSharedContent({
       parentId: parentId,
       // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
       isDeletedOn: null,
-      OR: [
-        { visibility: "public" },
-        {
-          AND: [
-            { visibility: "private" },
-            { sharedWith: { some: { userId: loggedInUserId } } },
-          ],
-        },
-      ],
+      ...(parentId === null
+        ? isDiscoverableSharedContent(loggedInUserId)
+        : isOpenableSharedFolder(loggedInUserId)),
     },
     select: returnContentSelect({ includeOwnerDetails: true }),
     orderBy: { sortIndex: "asc" },
@@ -399,26 +421,15 @@ export async function getSharedContent({
         ownerId,
         parent: {
           AND: [
-            { visibility: { not: "public" } },
+            { visibility: { notIn: ["public", "unlisted"] } },
             {
-              OR: [
-                { visibility: { not: "private" } },
-                { sharedWith: { none: { userId: loggedInUserId } } },
-              ],
+              sharedWith: { none: { userId: loggedInUserId } },
             },
           ],
         },
         // Note: don't use viewable filter, as we require it to be public/shared even if owned by loggedInUserId
         isDeletedOn: null,
-        OR: [
-          { visibility: "public" },
-          {
-            AND: [
-              { visibility: "private" },
-              { sharedWith: { some: { userId: loggedInUserId } } },
-            ],
-          },
-        ],
+        ...isDiscoverableSharedContent(loggedInUserId),
       },
       select: returnContentSelect({ includeOwnerDetails: true }),
       orderBy: { sortIndex: "asc" },

--- a/apps/api/src/query/curate.ts
+++ b/apps/api/src/query/curate.ts
@@ -15,7 +15,7 @@ import {
   searchMyContentOrLibraryContent,
 } from "./content_list";
 import { processContent, returnContentSelect } from "../utils/contentStructure";
-import { getAllCategories } from "./classification";
+import { getAllCategories } from "../categories";
 import { getAllLicenses } from "./license";
 import { InvalidRequestError } from "../utils/error";
 

--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -358,6 +358,7 @@ export async function getEditorShareStatus({
       ...filterEditableContent(loggedInUserId, false),
     },
     select: {
+      type: true,
       isPublic: true,
       visibility: true,
       sharedWith: {
@@ -413,7 +414,8 @@ export async function getEditorShareStatus({
     visibility: results.visibility,
     parentIsPublic: results.parent?.isPublic ?? false,
     parentVisibility: results.parent?.visibility ?? "private",
-    canSharePublicly: publicShareViolations.length === 0,
+    canSharePublicly:
+      results.type !== "folder" && publicShareViolations.length === 0,
     publicShareIssues,
     sharedWith,
     parentSharedWith,

--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -28,7 +28,24 @@ import {
   PermissionDeniedRedirectError,
 } from "../utils/error";
 import { StatusCodes } from "http-status-codes";
-import { getPublicShareViolations } from "../access";
+import { getPublicShareViolations, type PublicShareIssue } from "../access";
+
+// Fixed display priority so `publicShareIssues` ordering is stable regardless
+// of the (unordered) row order returned by the descendant audit query.
+const publicShareIssueOrder: PublicShareIssue[] = [
+  "errorsCheck",
+  "errorsCheckPending",
+  "accessibilityCheck",
+  "accessibilityCheckPending",
+  "missingRequiredCategories",
+];
+
+function sortPublicShareIssues(issues: PublicShareIssue[]): PublicShareIssue[] {
+  return [...issues].sort(
+    (a, b) =>
+      publicShareIssueOrder.indexOf(a) - publicShareIssueOrder.indexOf(b),
+  );
+}
 
 /**
  * Gets the general metadata relevant to editing for an activity.
@@ -405,9 +422,9 @@ export async function getEditorShareStatus({
   });
   const contentIds = [contentId, ...descendantIds];
   const publicShareViolations = await getPublicShareViolations({ contentIds });
-  const publicShareIssues = [
+  const publicShareIssues = sortPublicShareIssues([
     ...new Set(publicShareViolations.flatMap((violation) => violation.issues)),
-  ];
+  ]);
 
   return {
     isPublic: results.isPublic,

--- a/apps/api/src/query/editor.ts
+++ b/apps/api/src/query/editor.ts
@@ -18,12 +18,17 @@ import {
 import { ActivitySource } from "@doenet-tools/shared";
 import { getContent } from "./activity_edit_view";
 import { recordRecentContent } from "./recent";
-import { getAllDoenetmlVersions, getContentSource } from "./activity";
+import {
+  getAllDoenetmlVersions,
+  getContentSource,
+  getDescendantIds,
+} from "./activity";
 import {
   InvalidRequestError,
   PermissionDeniedRedirectError,
 } from "../utils/error";
 import { StatusCodes } from "http-status-codes";
+import { getPublicShareViolations } from "../access";
 
 /**
  * Gets the general metadata relevant to editing for an activity.
@@ -394,11 +399,22 @@ export async function getEditorShareStatus({
     parentSharedWith = processSharedWith(results.parent.sharedWith).sharedWith;
   }
 
+  const descendantIds = await getDescendantIds(contentId, {
+    excludeAssignments: true,
+  });
+  const contentIds = [contentId, ...descendantIds];
+  const publicShareViolations = await getPublicShareViolations({ contentIds });
+  const publicShareIssues = [
+    ...new Set(publicShareViolations.flatMap((violation) => violation.issues)),
+  ];
+
   return {
     isPublic: results.isPublic,
     visibility: results.visibility,
     parentIsPublic: results.parent?.isPublic ?? false,
     parentVisibility: results.parent?.visibility ?? "private",
+    canSharePublicly: publicShareViolations.length === 0,
+    publicShareIssues,
     sharedWith,
     parentSharedWith,
   };

--- a/apps/api/src/query/explore.ts
+++ b/apps/api/src/query/explore.ts
@@ -16,6 +16,30 @@ import { getClassificationInfo } from "./classification";
 import { getAllCategories } from "../categories";
 import { getAuthorInfo } from "./user";
 
+function returnExploreVisibilityWhere(loggedInUserId: Uint8Array) {
+  return {
+    OR: [
+      { visibility: "public" as const },
+      {
+        AND: [
+          { visibility: "private" as const },
+          { sharedWith: { some: { userId: loggedInUserId } } },
+        ],
+      },
+    ],
+  };
+}
+
+function returnExploreVisibilityWhereClause(loggedInUserId: Uint8Array) {
+  return Prisma.sql`
+    content.visibility = 'public'
+    OR (
+      content.visibility = 'private'
+      AND content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+    )
+  `;
+}
+
 export async function searchSharedContent({
   query,
   isCurated,
@@ -76,8 +100,7 @@ export async function searchSharedContent({
     content.isDeletedOn IS NULL
     AND users.isLibrary = ${isCurated ? Prisma.sql`TRUE` : Prisma.sql`FALSE`}
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND
     (
@@ -181,10 +204,7 @@ export async function browseSharedContent({
     where: {
       isDeletedOn: null,
       owner: { isLibrary: isCurated },
-      OR: [
-        { isPublic: true },
-        { sharedWith: { some: { userId: loggedInUserId } } },
-      ],
+      OR: [...returnExploreVisibilityWhere(loggedInUserId).OR],
       AND: categoriesToRequire.map((category) => ({
         categories: { some: { code: category } },
       })),
@@ -264,8 +284,7 @@ export async function browseTrendingContent({
     content.isDeletedOn IS NULL
     AND content.ownerId <> ${libraryId}
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     ${returnClassificationFilterWhereClauses({ systemId, categoryId, subCategoryId, classificationId, isUnclassified })}
     ${returnCategoryWhereClauses(categories)}
@@ -360,8 +379,7 @@ export async function searchUsersWithSharedContent({
         ${returnCategoryJoins(categories)}
         WHERE
           isDeletedOn IS NULL AND (
-            isPublic = TRUE
-            OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+            ${returnExploreVisibilityWhereClause(loggedInUserId)}
           )
           ${returnClassificationFilterWhereClauses({ systemId, categoryId, subCategoryId, classificationId, isUnclassified })}
           ${returnCategoryWhereClauses(categories)}
@@ -445,8 +463,7 @@ export async function browseUsersWithSharedContent({
           WHERE
             content.isDeletedOn IS NULL
             AND (
-              content.isPublic = TRUE
-              OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+              ${returnExploreVisibilityWhereClause(loggedInUserId)}
             )
             AND (
               MATCH(content.name) AGAINST(${query_as_prefixes} IN BOOLEAN MODE)
@@ -497,8 +514,7 @@ export async function browseUsersWithSharedContent({
           WHERE
             content.isDeletedOn IS NULL
             AND (
-              content.isPublic = TRUE
-              OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+              ${returnExploreVisibilityWhereClause(loggedInUserId)}
             )
             ${returnClassificationFilterWhereClauses({ systemId, categoryId, subCategoryId, classificationId, isUnclassified })}
             ${returnCategoryWhereClauses(categories)}
@@ -592,8 +608,7 @@ export async function searchClassificationsWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND
     (
@@ -690,8 +705,7 @@ export async function searchClassificationSubCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND
     ${returnClassificationMatchClauses({ query_as_prefixes, matchSubCategory: true })}
@@ -775,8 +789,7 @@ export async function searchClassificationCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND
     ${returnClassificationMatchClauses({ query_as_prefixes, matchCategory: true })}
@@ -830,10 +843,7 @@ export async function browseClassificationSharedContent({
   const results = await prisma.content.findMany({
     where: {
       isDeletedOn: null,
-      OR: [
-        { isPublic: true },
-        { sharedWith: { some: { userId: loggedInUserId } } },
-      ],
+      OR: [...returnExploreVisibilityWhere(loggedInUserId).OR],
       AND: categoriesToRequire.map((category) => ({
         categories: { some: { code: category } },
       })),
@@ -894,10 +904,7 @@ export async function browseClassificationSubCategorySharedContent({
                 some: {
                   content: {
                     isDeletedOn: null,
-                    OR: [
-                      { isPublic: true },
-                      { sharedWith: { some: { userId: loggedInUserId } } },
-                    ],
+                    OR: [...returnExploreVisibilityWhere(loggedInUserId).OR],
                     AND: categoriesToRequire.map((category) => ({
                       categories: { some: { code: category } },
                     })),
@@ -919,10 +926,7 @@ export async function browseClassificationSubCategorySharedContent({
                   where: {
                     content: {
                       isDeletedOn: null,
-                      OR: [
-                        { isPublic: true },
-                        { sharedWith: { some: { userId: loggedInUserId } } },
-                      ],
+                      OR: [...returnExploreVisibilityWhere(loggedInUserId).OR],
                       AND: categoriesToRequire.map((category) => ({
                         categories: { some: { code: category } },
                       })),
@@ -994,8 +998,7 @@ export async function browseClassificationCategorySharedContent({
                       content: {
                         isDeletedOn: null,
                         OR: [
-                          { isPublic: true },
-                          { sharedWith: { some: { userId: loggedInUserId } } },
+                          ...returnExploreVisibilityWhere(loggedInUserId).OR,
                         ],
                         AND: categoriesToRequire.map((category) => ({
                           categories: { some: { code: category } },
@@ -1035,8 +1038,7 @@ export async function browseClassificationCategorySharedContent({
                       content: {
                         isDeletedOn: null,
                         OR: [
-                          { isPublic: true },
-                          { sharedWith: { some: { userId: loggedInUserId } } },
+                          ...returnExploreVisibilityWhere(loggedInUserId).OR,
                         ],
                         AND: categoriesToRequire.map((category) => ({
                           categories: { some: { code: category } },
@@ -1059,12 +1061,7 @@ export async function browseClassificationCategorySharedContent({
                       where: {
                         content: {
                           isDeletedOn: null,
-                          OR: [
-                            { isPublic: true },
-                            {
-                              sharedWith: { some: { userId: loggedInUserId } },
-                            },
-                          ],
+                          ...returnExploreVisibilityWhere(loggedInUserId),
                           AND: categoriesToRequire.map((category) => ({
                             categories: { some: { code: category } },
                           })),
@@ -1177,8 +1174,7 @@ export async function browseClassificationsWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND (
       MATCH(content.name) AGAINST(${query_as_prefixes} IN BOOLEAN MODE)
@@ -1242,8 +1238,7 @@ export async function browseClassificationsWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     ${returnClassificationFilterWhereClauses({ subCategoryId })}
     ${returnCategoryWhereClauses(categories)}
@@ -1343,8 +1338,7 @@ export async function browseClassificationSubCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND (
       MATCH(content.name) AGAINST(${query_as_prefixes} IN BOOLEAN MODE)
@@ -1402,8 +1396,7 @@ export async function browseClassificationSubCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     ${returnClassificationFilterWhereClauses({ categoryId })}
     ${returnCategoryWhereClauses(categories)}
@@ -1493,8 +1486,7 @@ export async function browseClassificationCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND (
       MATCH(content.name) AGAINST(${query_as_prefixes} IN BOOLEAN MODE)
@@ -1547,8 +1539,7 @@ export async function browseClassificationCategoriesWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     ${returnClassificationFilterWhereClauses({ systemId })}
     ${returnCategoryWhereClauses(categories)}
@@ -1630,8 +1621,7 @@ export async function browseClassificationSystemsWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     AND (
       MATCH(content.name) AGAINST(${query_as_prefixes} IN BOOLEAN MODE)
@@ -1681,8 +1671,7 @@ export async function browseClassificationSystemsWithSharedContent({
   WHERE
     content.isDeletedOn IS NULL
     AND (
-       content.isPublic = TRUE
-       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+       ${returnExploreVisibilityWhereClause(loggedInUserId)}
     )
     ${returnCategoryWhereClauses(categories)}
     ${ownerId === undefined ? Prisma.empty : Prisma.sql`AND content.ownerId=${ownerId}`}
@@ -1774,8 +1763,7 @@ export async function getSharedContentMatchCount({
       WHERE
         content.isDeletedOn IS NULL
         AND (
-           content.isPublic = TRUE
-           OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+           ${returnExploreVisibilityWhereClause(loggedInUserId)}
         )
         AND
         (
@@ -1817,8 +1805,7 @@ export async function getSharedContentMatchCount({
       WHERE
         content.isDeletedOn IS NULL
         AND (
-           content.isPublic = TRUE
-           OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+           ${returnExploreVisibilityWhereClause(loggedInUserId)}
         )
         ${returnClassificationFilterWhereClauses({ systemId, categoryId, subCategoryId, classificationId, isUnclassified })}
         ${returnCategoryWhereClauses(categories)}
@@ -1934,8 +1921,7 @@ export async function countMatchingContentByCategory({
       WHERE
         content.isDeletedOn IS NULL
         AND (
-           content.isPublic = TRUE
-           OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+           ${returnExploreVisibilityWhereClause(loggedInUserId)}
         )
         AND
         (
@@ -1993,8 +1979,7 @@ export async function countMatchingContentByCategory({
       WHERE
         content.isDeletedOn IS NULL
         AND (
-           content.isPublic = TRUE
-           OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
+           ${returnExploreVisibilityWhereClause(loggedInUserId)}
         )
         ${returnClassificationFilterWhereClauses({ systemId, categoryId, subCategoryId, classificationId, isUnclassified })}
         ${returnCategoryWhereClauses(newCategories)}

--- a/apps/api/src/query/explore.ts
+++ b/apps/api/src/query/explore.ts
@@ -20,12 +20,7 @@ function returnExploreVisibilityWhere(loggedInUserId: Uint8Array) {
   return {
     OR: [
       { visibility: "public" as const },
-      {
-        AND: [
-          { visibility: "private" as const },
-          { sharedWith: { some: { userId: loggedInUserId } } },
-        ],
-      },
+      { sharedWith: { some: { userId: loggedInUserId } } },
     ],
   };
 }
@@ -33,10 +28,7 @@ function returnExploreVisibilityWhere(loggedInUserId: Uint8Array) {
 function returnExploreVisibilityWhereClause(loggedInUserId: Uint8Array) {
   return Prisma.sql`
     content.visibility = 'public'
-    OR (
-      content.visibility = 'private'
-      AND content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
-    )
+    OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
   `;
 }
 

--- a/apps/api/src/query/explore.ts
+++ b/apps/api/src/query/explore.ts
@@ -12,7 +12,8 @@ import { processContent, returnContentSelect } from "../utils/contentStructure";
 import { fromUUID } from "../utils/uuid";
 import { getLibraryAccountId, maskLibraryUserInfo } from "./curate";
 import { PartialContentClassification, UserInfo } from "../types";
-import { getAllCategories, getClassificationInfo } from "./classification";
+import { getClassificationInfo } from "./classification";
+import { getAllCategories } from "../categories";
 import { getAuthorInfo } from "./user";
 
 export async function searchSharedContent({

--- a/apps/api/src/query/remix.ts
+++ b/apps/api/src/query/remix.ts
@@ -12,6 +12,7 @@ import {
 import { createContentRevision } from "./activity";
 import { getContent } from "./activity_edit_view";
 import { maskLibraryUserInfo } from "./curate";
+import { resetContentAuditFields } from "../content-audit";
 
 /**
  * Get the `source` and, if a Doc, `doenetMLVersion`, from the content with `contentId` viewable by `loggedInUserId`.
@@ -584,7 +585,11 @@ export async function updateRemixedContentToOrigin({
     // update remixed content (already checked permissions)
     await prisma.content.update({
       where: { id: remixContentId },
-      data: { source: newSource, doenetmlVersionId: newDoenetmlVersionId },
+      data: {
+        source: newSource,
+        doenetmlVersionId: newDoenetmlVersionId,
+        ...resetContentAuditFields,
+      },
     });
 
     // The second revision is also manual, as it would be expected in revision list.
@@ -735,7 +740,11 @@ export async function updateOriginContentToRemix({
     // update origin content (already checked permissions)
     await prisma.content.update({
       where: { id: originContentId },
-      data: { source: newSource, doenetmlVersionId: newDoenetmlVersionId },
+      data: {
+        source: newSource,
+        doenetmlVersionId: newDoenetmlVersionId,
+        ...resetContentAuditFields,
+      },
     });
 
     // The second revision is also manual, as it would be expected in revision list.

--- a/apps/api/src/query/share.ts
+++ b/apps/api/src/query/share.ts
@@ -8,13 +8,13 @@ import { UserInfoWithEmail } from "../types";
 import { getDescendantIds } from "./activity";
 
 /**
- * @deprecated Superceded by {@link updateVisibility}
+ * @deprecated Superseded by {@link updateVisibility}
  *
  * Set the `isPublic` flag on a content `id` along with all of its children.
  * Recurses to grandchildren/subfolders.
  * Skips assignments since they cannot be made public.
  *
- * If parent is public, however, it does not allow the content to be set to private.
+ * If parent is not private, however, it does not allow the content to be set to private.
  */
 export async function setContentIsPublic({
   contentId,
@@ -48,9 +48,9 @@ export async function setContentIsPublic({
     throw new InvalidRequestError("Assignment visibility cannot be changed");
   }
 
-  if (!isPublic && content.parent?.visibility === "public") {
+  if (!isPublic && content.parent && content.parent.visibility !== "private") {
     throw new InvalidRequestError(
-      "If content has a public parent, cannot make it private",
+      "If content has a non-private parent, cannot make it private",
     );
   }
 

--- a/apps/api/src/query/share.ts
+++ b/apps/api/src/query/share.ts
@@ -6,6 +6,7 @@ import { isEqualUUID } from "../utils/uuid";
 import { InvalidRequestError } from "../utils/error";
 import { UserInfoWithEmail } from "../types";
 import { getDescendantIds } from "./activity";
+import { isAssignment } from "../assignments";
 
 /**
  * @deprecated Superseded by {@link updateVisibility}
@@ -34,6 +35,7 @@ export async function setContentIsPublic({
       isAssignmentRoot: true,
       parent: {
         select: {
+          isAssignmentRoot: true,
           visibility: true,
         },
       },
@@ -44,7 +46,7 @@ export async function setContentIsPublic({
     throw new InvalidRequestError("Content not found", StatusCodes.NOT_FOUND);
   }
 
-  if (content.isAssignmentRoot) {
+  if (isAssignment(content)) {
     throw new InvalidRequestError("Assignment visibility cannot be changed");
   }
 

--- a/apps/api/src/query/share.ts
+++ b/apps/api/src/query/share.ts
@@ -1,6 +1,6 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, type Visibility } from "@prisma/client";
+import { StatusCodes } from "http-status-codes";
 import { prisma } from "../model";
-import { updateVisibility } from "../access";
 import { filterEditableContent } from "../utils/permissions";
 import { isEqualUUID } from "../utils/uuid";
 import { InvalidRequestError } from "../utils/error";
@@ -25,16 +25,64 @@ export async function setContentIsPublic({
   loggedInUserId: Uint8Array;
   isPublic: boolean;
 }) {
-  const visibility = isPublic ? "public" : "private";
-  const result = await updateVisibility({
-    contentId,
-    loggedInUserId,
-    visibility,
+  const visibility: Visibility = isPublic ? "public" : "private";
+
+  const content = await prisma.content.findFirst({
+    where: { id: contentId, isDeletedOn: null },
+    select: {
+      ownerId: true,
+      isAssignmentRoot: true,
+      parent: {
+        select: {
+          visibility: true,
+        },
+      },
+    },
   });
 
+  if (!content || !isEqualUUID(content.ownerId, loggedInUserId)) {
+    throw new InvalidRequestError("Content not found", StatusCodes.NOT_FOUND);
+  }
+
+  if (content.isAssignmentRoot) {
+    throw new InvalidRequestError("Assignment visibility cannot be changed");
+  }
+
+  if (!isPublic && content.parent?.visibility === "public") {
+    throw new InvalidRequestError(
+      "If content has a public parent, cannot make it private",
+    );
+  }
+
+  const descendantIds = await getDescendantIds(contentId, {
+    excludeAssignments: true,
+  });
+  const contentIds = [contentId, ...descendantIds];
+  const publiclySharedAt = isPublic ? new Date() : null;
+
+  const updateTimestamp = prisma.content.updateMany({
+    where: {
+      id: { in: contentIds },
+      NOT: { visibility },
+    },
+    data: { publiclySharedAt },
+  });
+
+  const updateContent = prisma.content.updateMany({
+    where: {
+      id: { in: contentIds },
+    },
+    data: {
+      visibility,
+      isPublic,
+    },
+  });
+
+  await prisma.$transaction([updateTimestamp, updateContent]);
+
   return {
-    isPublic: result.visibility === "public",
-    visibility: result.visibility,
+    isPublic,
+    visibility,
   };
 }
 

--- a/apps/api/src/query/share.ts
+++ b/apps/api/src/query/share.ts
@@ -1,15 +1,15 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../model";
-import {
-  filterEditableContent,
-  filterExcludeAssignments,
-} from "../utils/permissions";
+import { updateVisibility } from "../access";
+import { filterEditableContent } from "../utils/permissions";
 import { isEqualUUID } from "../utils/uuid";
 import { InvalidRequestError } from "../utils/error";
-import { getDescendantIds } from "./activity";
 import { UserInfoWithEmail } from "../types";
+import { getDescendantIds } from "./activity";
 
 /**
+ * @deprecated Superceded by {@link updateVisibility}
+ *
  * Set the `isPublic` flag on a content `id` along with all of its children.
  * Recurses to grandchildren/subfolders.
  * Skips assignments since they cannot be made public.
@@ -26,46 +26,16 @@ export async function setContentIsPublic({
   isPublic: boolean;
 }) {
   const visibility = isPublic ? "public" : "private";
-
-  // select content to make sure it is exists and is editable by loggedInUserId
-  const content = await prisma.content.findUniqueOrThrow({
-    where: { id: contentId, ...filterEditableContent(loggedInUserId) },
-    select: { parent: { select: { isPublic: true } } },
+  const result = await updateVisibility({
+    contentId,
+    loggedInUserId,
+    visibility,
   });
 
-  if (!isPublic) {
-    if (content.parent !== null && content.parent.isPublic) {
-      throw new InvalidRequestError(
-        "Content has a public parent -- cannot make it private.",
-      );
-    }
-  }
-
-  const descendantIds = await getDescendantIds(contentId);
-
-  // Update share timestamp for those whose share status is changing
-  const updateTimestamp = prisma.content.updateMany({
-    where: {
-      id: { in: [contentId, ...descendantIds] },
-      isPublic: !isPublic,
-      ...filterExcludeAssignments,
-    },
-    data: { publiclySharedAt: isPublic ? new Date() : null },
-  });
-
-  // Make public/private
-  const updateContent = prisma.content.updateMany({
-    where: {
-      id: { in: [contentId, ...descendantIds] },
-      ...filterExcludeAssignments,
-    },
-    data: { isPublic, visibility },
-  });
-
-  // Note: updateTimestamp first because it checks `isPublic` status
-  await prisma.$transaction([updateTimestamp, updateContent]);
-
-  return { isPublic, visibility };
+  return {
+    isPublic: result.visibility === "public",
+    visibility: result.visibility,
+  };
 }
 
 export async function unshareContent({

--- a/apps/api/src/routes/content.route.ts
+++ b/apps/api/src/routes/content.route.ts
@@ -1,11 +1,16 @@
 import express from "express";
 import { queryLoggedIn } from "../middleware/queryMiddleware";
-import { updateVisibilitySchema } from "../access/visibility.schema";
-import { updateVisibility } from "../access/visibility";
+import { updateContentAudit, updateContentAuditSchema } from "../content-audit";
+import { updateVisibility, updateVisibilitySchema } from "../access";
 
 export const contentRouter = express.Router();
 
 contentRouter.patch(
   "/:contentId/access",
   queryLoggedIn(updateVisibility, updateVisibilitySchema),
+);
+
+contentRouter.put(
+  "/:contentId/audit",
+  queryLoggedIn(updateContentAudit, updateContentAuditSchema),
 );

--- a/apps/api/src/routes/infoRoutes.ts
+++ b/apps/api/src/routes/infoRoutes.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { getAllCategories } from "../query/classification";
+import { getAllCategories } from "../categories";
 import {
   getAllDoenetmlVersions,
   getContentDescription,

--- a/apps/api/src/test/activity.test.ts
+++ b/apps/api/src/test/activity.test.ts
@@ -120,6 +120,12 @@ test("New activity starts out private, then delete it", async () => {
   expect(sharing).eqls({
     isPublic: false,
     visibility: "private",
+    canSharePublicly: false,
+    publicShareIssues: [
+      "errorsCheckPending",
+      "accessibilityCheckPending",
+      "missingRequiredCategories",
+    ],
     sharedWith: [],
     parentIsPublic: false,
     parentVisibility: "private",

--- a/apps/api/src/test/search.test.ts
+++ b/apps/api/src/test/search.test.ts
@@ -33,6 +33,7 @@ import {
 import { searchMyContent } from "../query/content_list";
 import { updateUser } from "../query/user";
 import { Content } from "../types";
+import { updateVisibility } from "../access";
 
 describe("searchSharedContent Tests", function () {
   test("searchSharedContent returns public/shared activities and folders matching the query", async () => {
@@ -290,6 +291,46 @@ describe("searchSharedContent Tests", function () {
       publicFolderName,
       sharedFolderName,
     ]);
+  });
+
+  test("searchSharedContent keeps directly shared unlisted content discoverable", async () => {
+    const owner = await createTestUser();
+    const recipient = await createTestUser();
+
+    const code = Date.now().toString();
+    const sharedActivityName = `shared unlisted activity ${code}`;
+
+    const { contentId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+    await updateContent({
+      contentId,
+      name: sharedActivityName,
+      loggedInUserId: owner.userId,
+    });
+    await modifyContentSharedWith({
+      action: "share",
+      contentId,
+      loggedInUserId: owner.userId,
+      users: [recipient.userId],
+    });
+    await updateVisibility({
+      contentId,
+      loggedInUserId: owner.userId,
+      visibility: "unlisted",
+    });
+
+    const searchResults = await searchSharedContent({
+      query: code,
+      isCurated: false,
+      loggedInUserId: recipient.userId,
+    });
+
+    expect(
+      searchResults.some((result) => isEqualUUID(result.contentId, contentId)),
+    ).toBe(true);
   });
 
   test("searchSharedContent, document source matches", async () => {

--- a/apps/api/src/test/share.test.ts
+++ b/apps/api/src/test/share.test.ts
@@ -22,6 +22,7 @@ import { isEqualUUID } from "../utils/uuid";
 import { createAssignment } from "../query/assign";
 import { DateTime } from "luxon";
 import { prisma } from "../model";
+import { updateVisibility } from "../access";
 
 describe("Share tests", () => {
   test("setContentIsPublic sets content to public/private and returns result", async () => {
@@ -62,6 +63,33 @@ describe("Share tests", () => {
     });
     expect(content.isPublic).eq(false);
     expect(content.visibility).eq("private");
+  });
+
+  test("setContentIsPublic remains permissive while access updates stay strict", async () => {
+    const owner = await createTestUser();
+    const ownerId = owner.userId;
+
+    const { contentId } = await createContent({
+      loggedInUserId: ownerId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    const legacyResult = await setContentIsPublic({
+      contentId,
+      isPublic: true,
+      loggedInUserId: ownerId,
+    });
+
+    expect(legacyResult).toEqual({ isPublic: true, visibility: "public" });
+
+    await expect(
+      updateVisibility({
+        contentId,
+        loggedInUserId: ownerId,
+        visibility: "public",
+      }),
+    ).rejects.toThrow("required categories are filled out");
   });
 
   test("shareContentWithEmail/unshareContent shares/unshares content and returns result", async () => {

--- a/apps/api/src/test/share.test.ts
+++ b/apps/api/src/test/share.test.ts
@@ -92,6 +92,35 @@ describe("Share tests", () => {
     ).rejects.toThrow("required categories are filled out");
   });
 
+  test("setContentIsPublic cannot make a child private under an unlisted parent", async () => {
+    const owner = await createTestUser();
+    const { contentId: parentId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+
+    await updateVisibility({
+      contentId: parentId,
+      loggedInUserId: owner.userId,
+      visibility: "unlisted",
+    });
+
+    const { contentId: childId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId,
+    });
+
+    await expect(
+      setContentIsPublic({
+        contentId: childId,
+        isPublic: false,
+        loggedInUserId: owner.userId,
+      }),
+    ).rejects.toThrow("non-private parent");
+  });
+
   test("shareContentWithEmail/unshareContent shares/unshares content and returns result", async () => {
     const owner = await createTestUser();
     const ownerId = owner.userId;
@@ -2144,6 +2173,73 @@ describe("setContentIsPublic()", () => {
 
     expect(folderMetric).toBeNull();
     expect(childMetric).toBeNull();
+  });
+});
+
+describe("getSharedContent()", () => {
+  test("opens unlisted folders by link and includes unlisted children", async () => {
+    const owner = await createTestUser();
+    const recipient = await createTestUser();
+
+    const { contentId: folderId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+    const { contentId: childId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId: folderId,
+    });
+
+    await updateVisibility({
+      contentId: folderId,
+      loggedInUserId: owner.userId,
+      visibility: "unlisted",
+    });
+
+    const shared = await getSharedContent({
+      ownerId: owner.userId,
+      loggedInUserId: recipient.userId,
+      parentId: folderId,
+    });
+
+    expect(shared.parent?.contentId).toEqual(folderId);
+    expect(shared.content.map((item) => item.contentId)).toEqual([childId]);
+    expect(shared.content[0]?.visibility).toBe("unlisted");
+  });
+
+  test("includes explicitly shared unlisted content in the base shared view", async () => {
+    const owner = await createTestUser();
+    const recipient = await createTestUser();
+
+    const { contentId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    await updateVisibility({
+      contentId,
+      loggedInUserId: owner.userId,
+      visibility: "unlisted",
+    });
+    await modifyContentSharedWith({
+      action: "share",
+      contentId,
+      loggedInUserId: owner.userId,
+      users: [recipient.userId],
+    });
+
+    const shared = await getSharedContent({
+      ownerId: owner.userId,
+      loggedInUserId: recipient.userId,
+      parentId: null,
+    });
+
+    expect(
+      shared.content.some((item) => isEqualUUID(item.contentId, contentId)),
+    ).toBe(true);
   });
 });
 

--- a/apps/api/src/utils/permissions.ts
+++ b/apps/api/src/utils/permissions.ts
@@ -134,7 +134,7 @@ const filterActivity = {
  *
  * For content to be viewable, one of these conditions must be true:
  * 1. `loggedInUserId` is the owner
- * 2. The content is public
+ * 2. The content is public or unlisted (link-visible)
  * 3. The content is shared with `loggedInUserId`
  * 4. `loggedInUserId` is an editor and the content is in the library.
  *
@@ -234,7 +234,7 @@ export function filterViewableRootAssignment({
  *
  * For content to be viewable, one of these conditions must be true:
  * 1. `loggedInUserId` is the owner
- * 2. The content is public
+ * 2. The content is public or unlisted (link-visible)
  * 3. The content is shared with `loggedInUserId`
  * 4. `loggedInUserId` is an editor and the content is in the library.
  *
@@ -272,7 +272,7 @@ export function filterViewableContent(
  *
  * For content to be viewable, one of these conditions must be true:
  * 1. `loggedInUserId` is the owner
- * 2. The content is public
+ * 2. The content is public or unlisted (link-visible)
  * 3. The content is shared with `loggedInUserId`
  * 4. `loggedInUserId` is an editor and the content is in the library.
  *

--- a/apps/api/src/utils/permissions.ts
+++ b/apps/api/src/utils/permissions.ts
@@ -246,10 +246,10 @@ export function filterViewableContent(
 ) {
   const visibilityOptions: (
     | { ownerId: Uint8Array }
-    | { isPublic: boolean }
+    | { visibility: { in: ["public", "unlisted"] } }
     | { sharedWith: { some: { userId: Uint8Array } } }
     | { owner: { isLibrary: boolean } }
-  )[] = [{ isPublic: true }];
+  )[] = [{ visibility: { in: ["public", "unlisted"] } }];
 
   if (loggedInUserId) {
     visibilityOptions.push({ ownerId: loggedInUserId });
@@ -284,7 +284,7 @@ export function viewableContentWhere(
 ) {
   let visibilityOptions = Prisma.sql`
       content.ownerId = ${loggedInUserId}
-      OR content.isPublic = TRUE
+      OR content.visibility <> 'private'
       OR content.id IN (SELECT contentId FROM contentShares WHERE userId = ${loggedInUserId})
   `;
 

--- a/apps/api/src/utils/prismaSelect.ts
+++ b/apps/api/src/utils/prismaSelect.ts
@@ -1,0 +1,122 @@
+import type { Prisma } from "@prisma/client";
+import {
+  deepmerge,
+  type DeepMergeBuiltInMetaData,
+  type DeepMergeFunctionsDefaultURIs,
+  type DeepMergeHKT,
+} from "deepmerge-ts";
+
+type MergedSelect<
+  TSelect extends object,
+  T extends readonly [TSelect, ...TSelect[]],
+> = DeepMergeHKT<T, DeepMergeFunctionsDefaultURIs, DeepMergeBuiltInMetaData>;
+
+/**
+ * Resolve the result type produced by Prisma for a given `content` select object.
+ * This is useful when a `select` is defined separately from the query and you want
+ * to reuse the corresponding payload type elsewhere in the codebase.
+ *
+ * ```ts
+ * const mySelect = contentSelect({
+ *   id: true,
+ *   name: true,
+ * });
+ *
+ * type MyContent = ContentPayload<typeof mySelect>;
+ * // MyContent is { id: Uuid; name: string }
+ * ```
+ *
+ * @see `contentSelect` for creating strongly typed select objects
+ * @see `mergeContentSelects` for combining multiple select objects into one
+ */
+export type ContentPayload<T extends Prisma.contentSelect> =
+  Prisma.contentGetPayload<{ select: T }>;
+
+/**
+ * Create typed helpers for defining and merging Prisma `select` objects.
+ * Use this when you want a small pair of reusable utilities for a specific Prisma
+ * model or relation shape: one helper to define a typed `select`, and one helper
+ * to merge several `select` objects into a single value.
+ *
+ * ```ts
+ * const assignmentSelectHelpers =
+ *   createPrismaSelectHelpers<Prisma.assignmentSelect>();
+ *
+ * const assignmentBaseSelect = assignmentSelectHelpers.select({
+ *   id: true,
+ *   label: true,
+ * });
+ *
+ * const assignmentOwnerSelect = assignmentSelectHelpers.select({
+ *   owner: {
+ *     select: {
+ *       id: true,
+ *     },
+ *   },
+ * });
+ *
+ * const assignmentSelect = assignmentSelectHelpers.mergeSelects(
+ *   assignmentBaseSelect,
+ *   assignmentOwnerSelect,
+ * );
+ * ```
+ *
+ * @returns An object with `select` and `mergeSelects` helpers for the provided Prisma select type
+ */
+export function createPrismaSelectHelpers<TSelect extends object>() {
+  const select = <const T extends TSelect>(value: T) => value;
+
+  const mergeSelects = <const T extends readonly [TSelect, ...TSelect[]]>(
+    ...selects: T
+  ): MergedSelect<TSelect, T> =>
+    deepmerge(...selects) as MergedSelect<TSelect, T>;
+
+  return {
+    select,
+    mergeSelects,
+  };
+}
+
+const contentSelectHelpers = createPrismaSelectHelpers<Prisma.contentSelect>();
+
+/**
+ * Create a `select` statement for fields in the `content` table.
+ * This object is strongly typed and works well with Prisma.
+ *
+ * ```ts
+ * // specify which fields to select
+ * const mySelect = contentSelect({
+ *   id: true,
+ *   name: true,
+ * });
+ * // use the select in a Prisma query
+ * // result is type { id: number; name: string }
+ * const result = await prisma.content.findMany({
+ *   select: mySelect,
+ * });
+ * ```
+ *
+ * @see `mergeContentSelects` for combining multiple select statements into one
+ * @see `ContentPayload` for the resulting type
+ */
+export const contentSelect = contentSelectHelpers.select;
+
+/**
+ * @description
+ * Combine `select` statements into a single `select` for fields in the `content` table.
+ *
+ * @example
+ * ```ts
+ * const select1 = contentSelect({ id: true });
+ * const select2 = contentSelect({ name: true });
+ * // merge the selects into one
+ * const mergedSelect = mergeContentSelects(select1, select2);
+ * // use it in a Prisma query
+ * // result is type { id: number; name: string }
+ * const result = await prisma.content.findMany({ select: mergedSelect });
+ * ```
+ *
+ * @see `contentSelect` for creating individual select statements
+ * @see `ContentPayload` for the resulting type
+ */
+export const mergeContentSelects = contentSelectHelpers.mergeSelects;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "wick-a11y": "^2.5.0"
       },
       "engines": {
-        "node": "24.15"
+        "node": "~24.15.0"
       }
     },
     "apps/api": {
@@ -55,6 +55,7 @@
         "bcryptjs": "^3.0.3",
         "body-parser": "^1.20.4",
         "cookie-parser": "^1.4.7",
+        "deepmerge-ts": "^7.1.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
@@ -10382,6 +10383,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -23430,7 +23440,8 @@
         "ipfs-only-hash": "^4.0.0"
       },
       "devDependencies": {
-        "@doenet-tools/eslint-config": "*"
+        "@doenet-tools/eslint-config": "*",
+        "vitest": "^3.2.4"
       }
     }
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,6 +25,7 @@
     "ipfs-only-hash": "^4.0.0"
   },
   "devDependencies": {
-    "@doenet-tools/eslint-config": "*"
+    "@doenet-tools/eslint-config": "*",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,8 @@
     "dev": "tsc --build --watch --preserveWatchOutput --force",
     "lint": "eslint --fix",
     "lint:check": "eslint",
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "test": "vitest run"
   },
   "dependencies": {
     "ipfs-only-hash": "^4.0.0"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from "./utils/ipfs.js";
 export * from "./utils/test.js";
 export * from "./apiTypes.js";
 export * from "./logic/browsable.js";
+export * from "./logic/categoryRules.js";

--- a/packages/shared/src/logic/categoryRules.test.ts
+++ b/packages/shared/src/logic/categoryRules.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { getCategoryIssues, hasRequiredCategories } from "./categoryRules.js";
+import type { Category, CategoryGroup } from "../types/categories.js";
+
+function createCategory(code: string): Category {
+  return {
+    code,
+    term: `term-${code}`,
+    description: `description-${code}`,
+  };
+}
+
+function createGroup({
+  name,
+  isRequired,
+  codes,
+}: {
+  name: string;
+  isRequired: boolean;
+  codes: string[];
+}): CategoryGroup {
+  return {
+    name,
+    isRequired,
+    isExclusive: false,
+    categories: codes.map(createCategory),
+  };
+}
+
+describe("category rules", () => {
+  test("passes when each required group has a selected category", () => {
+    const allCategories = [
+      createGroup({
+        name: "Scope",
+        isRequired: true,
+        codes: ["isWidget", "isProblemSet"],
+      }),
+      createGroup({
+        name: "Mode",
+        isRequired: true,
+        codes: ["isPractice", "isAssessment"],
+      }),
+      createGroup({
+        name: "Audience",
+        isRequired: false,
+        codes: ["middleSchool"],
+      }),
+    ];
+
+    const categories = [
+      createCategory("isProblemSet"),
+      createCategory("isAssessment"),
+    ];
+
+    expect(getCategoryIssues({ allCategories, categories })).toEqual([]);
+    expect(hasRequiredCategories({ allCategories, categories })).toBe(true);
+  });
+
+  test("reports an issue when any required category group is missing", () => {
+    const allCategories = [
+      createGroup({
+        name: "Scope",
+        isRequired: true,
+        codes: ["isWidget", "isProblemSet"],
+      }),
+      createGroup({
+        name: "Mode",
+        isRequired: true,
+        codes: ["isPractice", "isAssessment"],
+      }),
+    ];
+
+    const categories = [createCategory("isProblemSet")];
+
+    expect(getCategoryIssues({ allCategories, categories })).toEqual([
+      "missingRequiredCategories",
+    ]);
+    expect(hasRequiredCategories({ allCategories, categories })).toBe(false);
+  });
+
+  test("matches selected categories by code and ignores optional groups", () => {
+    const allCategories = [
+      createGroup({
+        name: "Scope",
+        isRequired: true,
+        codes: ["isWidget"],
+      }),
+      createGroup({
+        name: "Audience",
+        isRequired: false,
+        codes: ["middleSchool"],
+      }),
+    ];
+
+    const categories: Category[] = [
+      {
+        code: "isWidget",
+        term: "Different term",
+        description: "Different description",
+      },
+    ];
+
+    expect(getCategoryIssues({ allCategories, categories })).toEqual([]);
+    expect(hasRequiredCategories({ allCategories, categories })).toBe(true);
+  });
+});

--- a/packages/shared/src/logic/categoryRules.ts
+++ b/packages/shared/src/logic/categoryRules.ts
@@ -1,0 +1,58 @@
+import type { Category, CategoryGroup } from "../types/categories.js";
+
+// __________________________________________________________________________
+//
+//
+//                     Exported types and functions
+//
+// __________________________________________________________________________
+//
+
+/**
+ * Issues related to category selection
+ */
+export type CategoryIssue = "missingRequiredCategories";
+
+export function hasRequiredCategories({
+  allCategories,
+  categories,
+}: CategoryRulesData) {
+  const existingCodes = new Set(categories.map((c) => c.code));
+
+  for (const group of allCategories.filter((g) => g.isRequired)) {
+    const hasMatch = group.categories.some((category) =>
+      existingCodes.has(category.code),
+    );
+    if (!hasMatch) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function getCategoryIssues({
+  allCategories,
+  categories,
+}: CategoryRulesData): CategoryIssue[] {
+  const issues: CategoryIssue[] = [];
+
+  if (!hasRequiredCategories({ allCategories, categories })) {
+    issues.push("missingRequiredCategories");
+  }
+
+  return issues;
+}
+
+// __________________________________________________________________________
+//
+//
+//                 Internal types and helper functions
+//
+//___________________________________________________________________________
+//
+
+type CategoryRulesData = {
+  allCategories: CategoryGroup[];
+  categories: Category[];
+};


### PR DESCRIPTION
## Summary
- add the new sharing-related API surface for visibility updates and document audit updates while keeping existing sharing flows working during the rollout
- introduce backend support for public-share checks, audit state tracking, category-rule helpers, and the share-status data the migrated frontend will consume
- squash the diagnostics migration so the SQL matches the current Prisma schema and keep temporary `@doenet-tools/shared` compatibility in place until the follow-up cleanup

## Notes
- This PR is the expansion step for the stacked rollout.
- The frontend migration PR is built on top of this branch.
- Follow-up cleanup is tracked in #2900.