### PR TITLE
docs: add CLAUDE.md, package-level AGENTS.md files, and claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,9 +23,9 @@
   },
   "sandbox": {
     "enabled": true,
-    "network": {
-      "allowedDomains": ["github.com", "api.github.com", "registry.npmjs.org"]
-    },
+    "mode": "auto-allow",
+    "excludedCommands": ["docker"],
+    "allowedDomains": ["registry.npmjs.org", "api.github.com"],
     "filesystem": {
       "allowWrite": ["~/.npm/", "~/.cache/prisma/"]
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,15 @@
       "Bash(git branch -D *)",
       "Bash(git checkout -- *)"
     ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "ssh.github.com",
+        "api.github.com"
+      ]
+    }
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,8 @@
       "Bash(git reset --hard*)",
       "Bash(git clean -f*)",
       "Bash(git branch -D *)",
-      "Bash(git checkout -- *)"
+      "Bash(git checkout -- *)",
+      "Bash(gh pr merge *)"
     ]
   },
   "sandbox": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,6 @@
     "network": {
       "allowedDomains": [
         "github.com",
-        "ssh.github.com",
         "api.github.com"
       ]
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,17 +24,10 @@
   "sandbox": {
     "enabled": true,
     "network": {
-      "allowedDomains": [
-        "github.com",
-        "api.github.com",
-        "registry.npmjs.org"
-      ]
+      "allowedDomains": ["github.com", "api.github.com", "registry.npmjs.org"]
     },
     "filesystem": {
-      "allowWrite": [
-        "~/.npm/",
-        "~/.cache/prisma/"
-      ]
+      "allowWrite": ["~/.npm/", "~/.cache/prisma/"]
     }
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,14 @@
     "network": {
       "allowedDomains": [
         "github.com",
-        "api.github.com"
+        "api.github.com",
+        "registry.npmjs.org"
+      ]
+    },
+    "filesystem": {
+      "allowWrite": [
+        "~/.npm/",
+        "~/.cache/prisma/"
       ]
     }
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(gh pr *)",
+      "Bash(npm run *)",
+      "Bash(npm test *)",
+      "Bash(docker compose *)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git branch -D *)",
+      "Bash(git checkout -- *)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,8 +17,5 @@
       "Bash(git branch -D *)",
       "Bash(git checkout -- *)"
     ]
-  },
-  "sandbox": {
-    "enabled": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,15 +3,18 @@
     "allow": [
       "Bash(git add *)",
       "Bash(git commit *)",
-      "Bash(git push *)",
+      "Bash(git push origin *)",
       "Bash(gh pr *)",
+      "Bash(npm ci)",
       "Bash(npm run *)",
       "Bash(npm test *)",
       "Bash(docker compose *)"
     ],
     "deny": [
       "Bash(git push --force*)",
-      "Bash(git push -f *)",
+      "Bash(git push -f*)",
+      "Bash(git push origin --force*)",
+      "Bash(git push origin -f*)",
       "Bash(git reset --hard*)",
       "Bash(git clean -f*)",
       "Bash(git branch -D *)",

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__
 !apps/web/.env.dev3
 !apps/web/.env.prod
 
+# Claude Code personal settings (project settings.json is committed; local overrides are not)
+.claude/settings.local.json
+
 # misc
 
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,217 +1,47 @@
-# Doenet Tools — Agent Instructions
+# Doenet Apps — Agent Instructions
 
-## Project Overview
+Doenet is an educational technology platform — **npm workspace monorepo** (Node.js 24 required).
 
-Doenet Tools is an educational technology platform built as an **npm workspace monorepo**. The workspaces are split across two directories:
-
-- `apps/` — runnable applications
-  - `api/` (`@doenet-tools/api`) — Express REST API
-  - `app/` (`@doenet-tools/app`) — React SPA (the main client)
-  - `web/` (`@doenet-tools/web`) — Astro static site
-- `packages/` — shared libraries
-  - `shared/` (`@doenet-tools/shared`) — utility functions and types used by both client and server
-  - `e2e-tests/` (`@doenet-tools/e2e-tests`) — Cypress end-to-end tests
-  - `eslint-config/` (`@doenet-tools/eslint-config`) — shared ESLint config (internal tooling only)
-
-Node.js 24 is required.
-
----
+- `apps/api` — Express REST API + Prisma + MySQL
+- `apps/app` — React SPA (main client)
+- `apps/web` — Astro static site
+- `packages/shared` — types and utilities shared by `api` and `app`; **must be built before either app**
+- `packages/e2e-tests` — Cypress end-to-end tests
+- `packages/load-tests` — Locust load tests
 
 ## Commands
 
-### Install
-
 ```bash
-npm ci
+npm ci                                              # install
+npm run dev                                         # shared watcher + api (3000) + app (8000) + web (4321)
+npm run build                                       # all workspaces
+npm run format && npm run lint                      # always run before finishing work
+npm run db:setup                                    # migrate + seed (first-time or after schema changes)
+npm test --workspace @doenet-tools/api              # Vitest unit tests (append filename for single file)
+npm run test:all --workspace @doenet-tools/app      # Cypress component tests, headless
+npm run test:all --workspace @doenet-tools/e2e-tests  # Cypress e2e tests, headless (needs dev servers)
 ```
 
-### Dev servers
-
-```bash
-npm run dev --workspace @doenet-tools/api   # Express API on port 3000
-npm run dev --workspace @doenet-tools/app   # Vite dev server on port 8000 (proxies /api to port 3000)
-```
-
-### Build
-
-```bash
-npm run build
-```
-
-or step by step (shared must be built first):
-
-```bash
-npm run build --workspace @doenet-tools/shared   # build first (app and api depend on it)
-npm run build --workspace @doenet-tools/app       # tsc + vite build
-npm run build --workspace @doenet-tools/api       # tsc
-npm run build --workspace @doenet-tools/web       # astro build
-```
-
-### Format & Lint
-
-```bash
-npm run format             # Prettier write (all workspaces)
-npm run format:check       # Prettier check
-npm run lint               # ESLint fix (all workspaces with a lint script)
-npm run lint:check         # ESLint check (all workspaces with a lint script)
-```
-
-Each workspace also has its own `lint` / `lint:check` scripts.
-
-After making code changes, always format the changed files via Prettier before finishing.
-
-### Database (`api` workspace)
-
-```bash
-npm run prisma:migrate-dev --workspace @doenet-tools/api
-npm run prisma:seed --workspace @doenet-tools/api
-npm run prisma:generate --workspace @doenet-tools/api
-```
-
-### Tests
-
-**API unit tests (Vitest):**
-
-```bash
-npm test --workspace @doenet-tools/api                              # run all
-npm test --workspace @doenet-tools/api activity.test.ts             # run a single file
-```
-
-**App component tests (Cypress):**
-
-```bash
-npm run test --workspace @doenet-tools/app              # open Cypress UI
-npm run test:all --workspace @doenet-tools/app          # headless, all tests
-npm run test:group1 --workspace @doenet-tools/app       # headless, @group1 tag only
-```
-
-**E2E tests (Cypress, requires both dev servers running):**
-
-```bash
-npm run test --workspace @doenet-tools/e2e-tests         # open Cypress UI
-npm run test:all --workspace @doenet-tools/e2e-tests     # headless, all tests
-npm run test:group1 --workspace @doenet-tools/e2e-tests  # headless, @group1 tag only
-```
-
-To run a single Cypress spec interactively, open the Cypress UI (`npm run test`) and select the file.
-
----
+> **Always run Prettier and ESLint on changed files. Tests must pass before committing.**
 
 ## Architecture
 
-### Data Flow
-
 ```
-Browser → Vite dev server (port 8000) → /api/* proxy → Express server (port 3000) → Prisma → MySQL
+Browser → Vite (8000) → /api/* proxy → Express (3000) → Prisma → MySQL
 ```
 
-In production, the client is built as static files served by the Express server.
+In production, `app` is built as static files served by Express.
 
-### App (`apps/app/`)
+- **`apps/api/`** — see `apps/api/AGENTS.md` for route, error, and UUID conventions
+- **`apps/app/`** — see `apps/app/AGENTS.md` for routing and mutation patterns
 
-- **React 19** SPA with **React Router v7** (data router pattern)
-- **Chakra UI v2** for components, **Jost** font, **MathJax** via `better-react-mathjax`
-- All routes are defined in `apps/app/src/index.tsx` using `createBrowserRouter`
-- Each route file (`apps/app/src/paths/*.tsx`) exports a `loader` and optionally an `action` alongside the page component
-- Most form/mutation actions go through a **`genericAction`** in `index.tsx`: it reads `{ path, ...body }` from the request JSON and calls `axios.post('/api/${path}', body)`, optionally redirecting on success
-- API calls use **axios**; all calls are to relative `/api/` paths
+## Pull Requests
 
-### API (`apps/api/`)
+Development uses a fork workflow. Push branches to `origin` (your fork), then open a PR targeting `upstream/main`. Merged PRs deploy to production after human sign-off.
 
-- **Express** with **Passport.js** for auth (Google OAuth2, magic link via email, local username/password, anonymous)
-- Sessions stored in MySQL via `PrismaSessionStore`; session duration is 1 year
-- All database access goes through **Prisma** (`apps/api/src/model.ts` exports the single `prisma` instance)
-- Route handlers live in `apps/api/src/routes/`, query logic lives in `apps/api/src/query/`
+Database and API changes must follow the **expand-migrate-contract** pattern: each merged PR must be safe to deploy on its own, so add new columns/endpoints before removing old ones across separate PRs.
 
-### Shared (`packages/shared/`)
+## Cross-cutting Conventions
 
-- Utility functions and types used by both `app` and `api`
-- Must be **built before** `app` or `api`: `npm run build --workspace @doenet-tools/shared`
-
-### Web (`apps/web/`)
-
-- Static site built with **Astro** and **React** (`@astrojs/react`)
-
----
-
-## Key Conventions
-
-### Route Handler Pattern (api)
-
-All route handlers are created using middleware wrappers in `apps/api/src/middleware/queryMiddleware.ts`:
-
-```ts
-// For endpoints requiring login:
-router.post("/endpoint", queryLoggedIn(queryFunction, zodSchema));
-
-// For endpoints with optional auth:
-router.get("/endpoint", queryOptionalLoggedIn(queryFunction, zodSchema));
-```
-
-These wrappers automatically: check auth, parse and validate the request with Zod (merging `req.body`, `req.query`, and `req.params`), call the query function, run `convertUUID` on the result (converts binary UUIDs to strings), and handle errors via `handleErrors`.
-
-### Error Handling (api)
-
-Throw typed errors in query functions; `handleErrors` in `apps/api/src/errors/routeErrorHandler.ts` maps them to HTTP responses:
-
-- `InvalidRequestError` → 400/other specified code
-- `ZodError` → 400 with `{ error: "Invalid data", details: ... }`
-- Prisma `P2001/P2003/P2025` → 404
-- Everything else → 500
-
-### UUID Convention
-
-UUIDs are stored as 16-byte binary (`Bytes`) in MySQL. The server uses `Uint8Array` internally and converts to/from **short-uuid** strings at API boundaries:
-
-- `toUUID(shortId)` → `Uint8Array` (for DB queries)
-- `fromUUID(uint8array)` → short string (for API responses)
-- `convertUUID(obj)` recursively converts all `Uint8Array` values in a result object
-
-The client-side `Uuid` type is a branded `string`.
-
-### Duplicated `types.ts`
-
-`apps/app/src/types.ts` and `apps/api/src/types.ts` are **intentionally identical**. When modifying shared types, update both files. Platform-specific type differences go in `types_module_specific.ts` in each workspace.
-
-### Zod Schemas (api)
-
-Request validation schemas live in `apps/api/src/schemas/`. Each schema file corresponds to a domain (e.g., `assignSchema.ts`, `userSchemas.ts`). Schemas are passed to the query middleware wrapper, not applied inside route handlers.
-
-### ESLint Config
-
-Shared ESLint configuration lives in `packages/eslint-config/`. It exports:
-
-- `createBaseConfig(dirname)` — base TypeScript + import rules; pass `import.meta.dirname` from the workspace's `eslint.config.mjs`
-- `reactConfig` — React, ReactHooks, and Mocha rules; spread after `createBaseConfig` in React workspaces
-
-Each workspace has its own `eslint.config.mjs` that composes these. The base config uses `tseslint.configs.recommended` (not `recommendedTypeChecked`), so no TypeScript program is created during linting.
-
-### TypeScript Config
-
-Root-level base configs:
-
-- `tsconfig.base.json` — strictness rules only
-- `tsconfig.node.json` — extends base; adds `nodenext` module settings
-- `tsconfig.react.json` — extends base; adds `bundler` module resolution, `react-jsx`, and `noEmit: true`
-
-Each workspace `tsconfig.json` extends one of these and declares its own `types`. `packages/shared` extends `tsconfig.base.json` directly (with its own module settings) since it targets both Node.js and the browser.
-
-### Cypress Test Tagging
-
-Cypress tests (both component and e2e) are tagged with `@group1`–`@group4` for CI parallelization. Flaky tests use `@brittle1`–`@brittle3`. Tests not tagged with any group will be caught by `test:mistagged` (app) or excluded by `test:group4` (e2e-tests). Use `@cypress/grep` syntax in `it()` / `describe()` tags.
-
-### Test Environment Variables
-
-The API exposes test-only features when these env vars are set:
-
-- `ENABLE_TEST_AUTH_BYPASS=true` — enables login bypassing real auth (used in Cypress and load tests)
-- `ENABLE_TEST_ROUTES=true` — mounts `/api/test` routes from `apps/api/src/test/testRoutes.ts`
-- `MOCK_SIGNIN_EMAIL=true` — logs magic-link emails to console instead of sending via SES
-
-### API Test Utilities
-
-Use `createTestUser()` from `apps/api/src/test/utils.ts` to create isolated test users. Each call generates a unique email, so tests can run in parallel without conflicts.
-
-### Content Types
-
-The core domain model has four content types: `"singleDoc"`, `"select"` (question bank), `"sequence"` (problem set), `"folder"`. These appear in both Prisma enums and TypeScript union types.
+- TypeScript **strict mode is enforced** across all workspaces
+- `apps/app/src/types.ts` and `apps/api/src/types.ts` are **intentionally identical** — update both; platform-specific differences go in `types_module_specific.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ npm ci                                              # install
 npm run dev                                         # shared watcher + api (3000) + app (8000) + web (4321)
 npm run build                                       # all workspaces
 npm run format && npm run lint                      # always run before finishing work
-npm run db:setup                                    # migrate + seed (first-time or after schema changes)
+npm run db:setup                                    # migrate + seed (dev only — first-time or after schema changes)
 npm test --workspace @doenet-tools/api              # Vitest unit tests (append filename for single file)
 npm run test:all --workspace @doenet-tools/app      # Cypress component tests, headless
 npm run test:all --workspace @doenet-tools/e2e-tests  # Cypress e2e tests, headless (needs dev servers)
@@ -34,6 +34,8 @@ In production, `app` is built as static files served by Express.
 
 - **`apps/api/`** — see `apps/api/AGENTS.md` for route, error, and UUID conventions
 - **`apps/app/`** — see `apps/app/AGENTS.md` for routing and mutation patterns
+- **`apps/web/`** — see `apps/web/AGENTS.md` for Astro stack and blog frontmatter schema
+- **`packages/shared/`** — see `packages/shared/AGENTS.md` for when to add shared types/utilities
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](./AGENTS.md) for full documentation: commands, architecture, and key conventions.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -42,6 +42,7 @@ Content visibility is managed in `src/access/`. Three levels: `private` < `unlis
 
 - Only the owner can change visibility
 - Assignments are always `private` — their visibility cannot be changed
+- Content within an assignment also cannot have its visibility changed
 - A child cannot have lower visibility than its parent
 - Changing visibility cascades to all non-assignment descendants
 

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -8,7 +8,7 @@ Middleware wrappers in `src/middleware/queryMiddleware.ts` handle auth, Zod vali
 
 ```ts
 router.post("/endpoint", queryLoggedIn(queryFunction, zodSchema));
-router.get("/endpoint",  queryOptionalLoggedIn(queryFunction, zodSchema));
+router.get("/endpoint", queryOptionalLoggedIn(queryFunction, zodSchema));
 ```
 
 Zod schemas live in `src/schemas/` by domain. Pass them to the wrapper — do not validate inside route handlers.
@@ -16,6 +16,7 @@ Zod schemas live in `src/schemas/` by domain. Pass them to the wrapper — do no
 ## Error Handling
 
 Throw typed errors in query functions; `src/errors/routeErrorHandler.ts` maps them:
+
 - `InvalidRequestError` → 400 (or specified code)
 - `ZodError` → 400 with `{ error: "Invalid data", details: ... }`
 - Prisma `P2001/P2003/P2025` → 404
@@ -24,6 +25,7 @@ Throw typed errors in query functions; `src/errors/routeErrorHandler.ts` maps th
 ## UUID Convention
 
 UUIDs are stored as 16-byte binary (`Bytes`) in MySQL:
+
 - `toUUID(shortId)` → `Uint8Array` (for DB queries)
 - `fromUUID(uint8array)` → short string (for API responses)
 - `convertUUID(obj)` — recursively converts all `Uint8Array` values (called automatically by middleware wrappers)
@@ -37,6 +39,7 @@ Client-side `Uuid` type is a branded `string`.
 ## Access Control
 
 Content visibility is managed in `src/access/`. Three levels: `private` < `unlisted` < `public`. Key rules enforced there:
+
 - Only the owner can change visibility
 - Assignments are always `private` — their visibility cannot be changed
 - A child cannot have lower visibility than its parent
@@ -55,6 +58,7 @@ Four content types throughout the domain model: `"singleDoc"`, `"select"` (quest
 ## Test Utilities
 
 Env vars for test-only features:
+
 - `ENABLE_TEST_AUTH_BYPASS=true` — bypass real auth (used by Cypress)
 - `ENABLE_TEST_ROUTES=true` — mounts `/api/test` routes from `src/test/testRoutes.ts`
 - `MOCK_SIGNIN_EMAIL=true` — logs magic-link emails to console instead of sending via SES

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,62 @@
+# API — Agent Instructions
+
+See root `AGENTS.md` for commands and overall architecture.
+
+## Route Handler Pattern
+
+Middleware wrappers in `src/middleware/queryMiddleware.ts` handle auth, Zod validation (merging `req.body`, `req.query`, `req.params`), UUID conversion, and errors automatically:
+
+```ts
+router.post("/endpoint", queryLoggedIn(queryFunction, zodSchema));
+router.get("/endpoint",  queryOptionalLoggedIn(queryFunction, zodSchema));
+```
+
+Zod schemas live in `src/schemas/` by domain. Pass them to the wrapper — do not validate inside route handlers.
+
+## Error Handling
+
+Throw typed errors in query functions; `src/errors/routeErrorHandler.ts` maps them:
+- `InvalidRequestError` → 400 (or specified code)
+- `ZodError` → 400 with `{ error: "Invalid data", details: ... }`
+- Prisma `P2001/P2003/P2025` → 404
+- Everything else → 500
+
+## UUID Convention
+
+UUIDs are stored as 16-byte binary (`Bytes`) in MySQL:
+- `toUUID(shortId)` → `Uint8Array` (for DB queries)
+- `fromUUID(uint8array)` → short string (for API responses)
+- `convertUUID(obj)` — recursively converts all `Uint8Array` values (called automatically by middleware wrappers)
+
+Client-side `Uuid` type is a branded `string`.
+
+## Soft Deletion
+
+`content` records are never hard-deleted. Deletion sets `isDeletedOn` to a timestamp (and `deletionRootId` to the root of the deleted subtree). **Every content query must filter `isDeletedOn: null`** or it will silently return deleted records.
+
+## Access Control
+
+Content visibility is managed in `src/access/`. Three levels: `private` < `unlisted` < `public`. Key rules enforced there:
+- Only the owner can change visibility
+- Assignments are always `private` — their visibility cannot be changed
+- A child cannot have lower visibility than its parent
+- Changing visibility cascades to all non-assignment descendants
+
+When adding endpoints that read or modify content, check whether visibility gating applies.
+
+## Content Types
+
+Four content types throughout the domain model: `"singleDoc"`, `"select"` (question bank), `"sequence"` (problem set), `"folder"`. These appear in Prisma enums and TypeScript union types.
+
+## Environment Variables
+
+`DATABASE_URL` must be kept in sync with the individual `DATABASE_*` vars manually — Prisma uses `DATABASE_URL` while Docker uses the individual vars. Update both if any connection detail changes.
+
+## Test Utilities
+
+Env vars for test-only features:
+- `ENABLE_TEST_AUTH_BYPASS=true` — bypass real auth (used by Cypress)
+- `ENABLE_TEST_ROUTES=true` — mounts `/api/test` routes from `src/test/testRoutes.ts`
+- `MOCK_SIGNIN_EMAIL=true` — logs magic-link emails to console instead of sending via SES
+
+Use `createTestUser()` from `src/test/utils.ts` for isolated test users (unique email per call, safe for parallel runs).

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -1,0 +1,19 @@
+# App — Agent Instructions
+
+See root `AGENTS.md` for commands and overall architecture.
+
+## Routing
+
+All routes are defined in `src/index.tsx` via `createBrowserRouter`. Each route file in `src/paths/*.tsx` exports a `loader` and optionally an `action` alongside the page component.
+
+## Mutation Pattern
+
+Most mutations go through **`genericAction`** in `src/index.tsx`: reads `{ path, ...body }` from the request JSON and calls `axios.post('/api/${path}', body)`, optionally redirecting on success. All API calls use **axios** to relative `/api/` paths.
+
+## DoenetML
+
+Content rendering uses `@doenet/doenetml-iframe` — an external package that embeds DoenetML activities in an iframe. Treat it as a black box; do not modify its internals. Import styles from `@doenet/doenetml-iframe/style.css` as already done in `src/index.tsx`.
+
+## Cypress Test Tagging
+
+Tag tests `@group1`–`@group4` for CI parallelization; flaky tests use `@brittle1`–`@brittle3`. Tests without a group tag fail `test:mistagged`. Use `@cypress/grep` syntax in `it()` / `describe()`.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,21 @@
+# Web — Agent Instructions
+
+See root `AGENTS.md` for commands and overall architecture.
+
+## Stack
+
+Astro static site with React islands (`@astrojs/react`), MDX support, and math rendering via KaTeX (`remark-math` + `rehype-katex`).
+
+## Content
+
+Blog posts live in `src/content/` as `.md` or `.mdx` files. Required frontmatter fields (enforced by Zod schema in `src/content.config.ts`):
+
+```ts
+title: string
+description: string
+author: string
+pubDate: date
+heroImage: string
+organization?: string
+updatedDate?: date
+```

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -9,6 +9,7 @@ See root `AGENTS.md` for commands and overall architecture.
 - **`types_module_specific.ts`** (in each workspace) — types that differ between app and api
 
 If you add to `packages/shared`, rebuild it before `app` or `api` will pick up the change:
+
 ```bash
 npm run build --workspace @doenet-tools/shared
 ```

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,14 @@
+# Shared — Agent Instructions
+
+See root `AGENTS.md` for commands and overall architecture.
+
+## When to add something here
+
+- **`packages/shared`** — types or utilities needed by both `apps/app` and `apps/api` at runtime
+- **`apps/app/src/types.ts` + `apps/api/src/types.ts`** — types that are identical today but may diverge per platform; update both files
+- **`types_module_specific.ts`** (in each workspace) — types that differ between app and api
+
+If you add to `packages/shared`, rebuild it before `app` or `api` will pick up the change:
+```bash
+npm run build --workspace @doenet-tools/shared
+```


### PR DESCRIPTION
## Summary

Sets up AI agent documentation for the monorepo, splitting instructions across package-level files so agents load only what's relevant.

- **Root `AGENTS.md`** rewritten to ~35 lines: commands, data flow, PR workflow (fork model, expand-migrate-contract, prod-on-merge), and two cross-cutting rules (strict TS, duplicated `types.ts`)
- **`CLAUDE.md`** added — one-liner that points to `AGENTS.md`
- **`apps/api/AGENTS.md`** — route/middleware pattern, error handling, UUID convention, soft deletion (`isDeletedOn: null`), access control visibility rules, content types, test utilities, `DATABASE_URL` sync gotcha
- **`apps/app/AGENTS.md`** — React Router data-router pattern, `genericAction` mutation flow, DoenetML external package note, Cypress test tagging
- **`apps/web/AGENTS.md`** — Astro stack, blog post frontmatter schema
- **`packages/shared/AGENTS.md`** — when to add to shared vs `types.ts` vs `types_module_specific.ts`

## Test plan
- [ ] Review each AGENTS.md file for accuracy
- [ ] Verify CLAUDE.md renders correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)