### PR TITLE
fix: prevent checkIfContentContains requests from bleeding between Cypress component tests

### DIFF
--- a/apps/app/src/popups/AddContentToMenu.cy.tsx
+++ b/apps/app/src/popups/AddContentToMenu.cy.tsx
@@ -94,6 +94,8 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
     cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Add To Problem Set"]').should("be.visible");
     cy.get('[data-test="Add To Folder"]').should("be.visible");
@@ -128,6 +130,7 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
     cy.wait("@getRecentContent");
     cy.wait("@checkContains");
     cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Add To Problem Set"]').should("be.disabled");
     cy.get('[data-test="Add To Folder"]').should("not.be.disabled");
@@ -159,6 +162,7 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
     cy.wait("@checkContains");
     cy.wait("@checkContains");
 
@@ -211,6 +215,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.contains("Recent").should("be.visible");
     cy.get('[data-test="Recent Item"]').should("have.length", 2);
@@ -254,6 +261,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Recent Item"]').should("be.disabled");
   });
@@ -276,6 +286,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Load into Scratch Pad"]').should("be.visible");
     cy.get('[data-test="Load into Scratch Pad"]').should("not.be.disabled");
@@ -317,6 +330,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Load into Scratch Pad"]').should("be.disabled");
   });
@@ -372,6 +388,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Load into Scratch Pad"]').should("not.exist");
   });
@@ -394,6 +413,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Load into Scratch Pad"]').click();
     cy.get("@onNavigate").should(
@@ -421,6 +443,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Suggest this to be curated"]').should("be.visible");
   });
@@ -444,6 +469,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Suggest this to be curated"]').click();
 
@@ -477,6 +505,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Suggest this to be curated"]').click();
     cy.get('[data-test="Copy Header"]').should("be.visible");
@@ -524,6 +555,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
     cy.get('[data-test="Add To"]').click();
     cy.wait("@getRecentContent");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
+    cy.wait("@checkContains");
 
     cy.get('[data-test="Recent Item"]')
       .eq(0)
@@ -568,6 +602,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
       cy.get('[data-test="Add To"]').click();
       cy.wait("@getRecentContent");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
       cy.checkAccessibility("body");
     });
 
@@ -609,6 +646,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
       cy.get('[data-test="Add To"]').click();
       cy.wait("@getRecentContent");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
       cy.checkAccessibility("body");
     });
 
@@ -631,6 +671,9 @@ describe("AddContentToMenu component tests", { tags: ["@group2"] }, () => {
 
       cy.get('[data-test="Add To"]').click();
       cy.wait("@getRecentContent");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
+      cy.wait("@checkContains");
       cy.get('[data-test="Suggest this to be curated"]').click();
       cy.checkAccessibility("body");
     });

--- a/apps/app/src/popups/AddContentToMenu.tsx
+++ b/apps/app/src/popups/AddContentToMenu.tsx
@@ -201,7 +201,9 @@ export function AddContentToMenu({
         }),
       ),
     );
-    const foundTypes = contentTypes.filter((_, i) => results[i].data.containsType);
+    const foundTypes = contentTypes.filter(
+      (_, i) => results[i].data.containsType,
+    );
 
     setBaseContains(foundTypes);
   }

--- a/apps/app/src/popups/AddContentToMenu.tsx
+++ b/apps/app/src/popups/AddContentToMenu.tsx
@@ -193,18 +193,15 @@ export function AddContentToMenu({
       setRecentContent(rc);
     }
 
-    const foundTypes: ContentType[] = [];
-
-    for (const ct of ["folder", "sequence", "select"]) {
-      const { data: containsFolderData } = await axios.get(
-        `/api/copyMove/checkIfContentContains`,
-        { params: { contentType: ct } },
-      );
-
-      if (containsFolderData.containsType) {
-        foundTypes.push(ct as ContentType);
-      }
-    }
+    const contentTypes = ["folder", "sequence", "select"] as ContentType[];
+    const results = await Promise.all(
+      contentTypes.map((ct) =>
+        axios.get(`/api/copyMove/checkIfContentContains`, {
+          params: { contentType: ct },
+        }),
+      ),
+    );
+    const foundTypes = contentTypes.filter((_, i) => results[i].data.containsType);
 
     setBaseContains(foundTypes);
   }


### PR DESCRIPTION
## Summary
**Problem:** Some Cypress *component* tests weren't catching and subbing network calls. This caused them to fail (intermittently).

**Root cause:** `handleMenuOpen()` in `AddContentToMenu.tsx` called `checkIfContentContains` three times sequentially (folder → sequence → select). Tests only waited for `@getRecentContent`, leaving the three `checkContains` requests in-flight when each test ended. Cypress removes its intercepts at test teardown, so these late requests escaped to Vite's proxy, hit `ECONNREFUSED` (no backend in component tests), and Axios threw an uncaught exception that failed the *next* test — making flakiness depend on CI timing.

**Fix:**
- **`AddContentToMenu.tsx`** — replace the sequential `for...of await` loop with `Promise.all`, firing all three requests in parallel and shrinking the in-flight window at test teardown.
- **`AddContentToMenu.cy.tsx`** — add `cy.wait("@checkContains")` × 3 to every test that opens the menu, ensuring all requests are drained within the test that started them.

## Test Coverage

All 18 tests in `AddContentToMenu.cy.tsx` pass, including the previously-flaky *"disables recent item when source content includes itself"*. No new application code paths were added (pure test-isolation fix + parallelization).

## Pre-Landing Review

No issues found. Changes are a 2-file, focused fix with no security, SQL, or LLM trust-boundary concerns.

## Test plan
- [x] All 18 `AddContentToMenu.cy.tsx` component tests pass (Firefox headless)
- [x] Previously failing test "disables recent item when source content includes itself" now passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)