### PR TITLE
fix: prevent long title wrapping glitch in editor; improve breadcrumb tooltips

### DIFF
--- a/apps/app/src/paths/editor/EditorHeader.tsx
+++ b/apps/app/src/paths/editor/EditorHeader.tsx
@@ -380,7 +380,7 @@ export function EditorHeader() {
           icon={folderIcon}
           size="sm"
           variant="ghost"
-          aria-label={"Folder"}
+          aria-label={`Go to folder: ${folderName}`}
           to={folderLink}
           data-test="Folder Breadcrumb Icon"
         />
@@ -391,6 +391,7 @@ export function EditorHeader() {
           as={ReactRouterLink}
           to={folderLink}
           _hover={{ fontWeight: "bold", textDecoration: "none" }}
+          data-test="Folder Breadcrumb Link"
         >
           <HStack spacing="0.3rem">
             {folderIcon}
@@ -427,7 +428,7 @@ export function EditorHeader() {
           icon={outerActivityIcon}
           size="sm"
           variant="ghost"
-          aria-label={"Problem set"}
+          aria-label={`Go to problem set: ${parent!.name!}`}
           to={`/compoundEditor/${parent!.contentId}/${tab}`}
         />
       </Show>
@@ -436,6 +437,7 @@ export function EditorHeader() {
           as={ReactRouterLink}
           to={`/compoundEditor/${parent!.contentId}/${tab}`}
           _hover={{ fontWeight: "bold", textDecoration: "none" }}
+          data-test="Problem Set Breadcrumb Link"
         >
           <HStack spacing="0.3rem">
             {outerActivityIcon}

--- a/apps/app/src/widgets/NameBar.cy.tsx
+++ b/apps/app/src/widgets/NameBar.cy.tsx
@@ -341,6 +341,38 @@ describe("NameBar", { tags: ["@group4"] }, () => {
       cy.checkAccessibility("body");
     });
 
+    it("long name is clipped to single line without showing second line", () => {
+      const longName =
+        "A very long activity title that should not wrap ".repeat(5);
+      const fetcher = createMockFetcher();
+
+      cy.viewport(800, 600);
+
+      cy.mount(
+        <NameBar
+          contentId="test-id"
+          contentName={longName}
+          isEditable={true}
+          leftIcon={defaultIcon}
+          dataTest="Long Title Editable"
+          fetcher={fetcher}
+        />,
+      );
+
+      cy.get('[data-test="Editable Title"]')
+        .should("have.css", "white-space", "nowrap")
+        .and("have.css", "overflow", "hidden")
+        .and("have.css", "text-overflow", "ellipsis");
+
+      // Height should be approximately one line (lineHeight 1.2 × default font size ~16px ≈ 19px).
+      // Two lines would be ~38px. We verify the element is not taller than ~32px.
+      cy.get('[data-test="Editable Title"]')
+        .invoke("prop", "clientHeight")
+        .should("be.lessThan", 32);
+
+      cy.checkAccessibility("body");
+    });
+
     it("handles empty string as initial name", () => {
       const fetcher = createMockFetcher();
 

--- a/apps/app/src/widgets/NameBar.tsx
+++ b/apps/app/src/widgets/NameBar.tsx
@@ -132,7 +132,11 @@ export function NameBar({
           as={EditablePreview}
           className="editable-name"
           data-test="Editable Title"
-          noOfLines={1}
+          display="block"
+          width="100%"
+          whiteSpace="nowrap"
+          overflow="hidden"
+          textOverflow="ellipsis"
           lineHeight="1.2"
           pl={{ base: "0rem", md: "1.8rem" }}
           rounded="none"


### PR DESCRIPTION
## Summary

Addresses two open issues:

**Issue #2733 — Long title shows tops of second-line letters alongside ellipsis**
- The `EditablePreview` in `NameBar` used `noOfLines={1}` (CSS `-webkit-line-clamp`), but this conflicted with `EditablePreview`'s default `display: inline-block` style. The container height was still sized for the full wrapped text, making the tops of second-line letters visible below the ellipsis.
- Fix: replace `noOfLines={1}` with explicit single-line truncation CSS (`whiteSpace="nowrap"`, `overflow="hidden"`, `textOverflow="ellipsis"`, `display="block"`, `width="100%"`). This prevents any line wrapping so there is no second line to bleed through.
- New Cypress test in `NameBar.cy.tsx` verifies the CSS properties are applied and the element's `clientHeight` is bounded to a single line.

**Issue #2657 — Folder icon tooltip was not descriptive; wide-screen link lacked a test handle**
- The narrow-screen `IconButton` for the folder breadcrumb had `aria-label="Folder"` — tooltip just said "Folder", giving no indication of where clicking navigates.
- Changed to `aria-label=\`Go to folder: ${folderName}\`` so the tooltip names the destination.
- Same fix applied to the problem-set breadcrumb icon (`"Problem set"` → `"Go to problem set: <name>"`).
- Added `data-test` attributes to the wide-screen `ChakraLink` breadcrumbs for future testability.
- Note: the original reported inconsistency (icon not clickable on wide screens) appears to have already been fixed in a prior commit — the current code wraps both icon and folder name in a `ChakraLink` on wide screens.

## Test plan

- [x] CI: `component-tests (group4)` runs the new `NameBar` test (`long name is clipped to single line without showing second line`) and all existing NameBar tests.
- [x] Manually: open an activity in the editor, give it a very long title, and verify no second-line letter tops are visible (only the ellipsis).
- [x] Manually: on a narrow-screen viewport (md–xl), hover over the folder breadcrumb icon and verify the tooltip reads "Go to folder: \<folder name\>".
- [x] Manually: on a wide-screen viewport (xl+), click the folder icon or name in the breadcrumb and verify it navigates to the parent folder.

https://claude.ai/code/session_01KQ8ACkodpdgH8GmQVnXJLo