### PR TITLE
fix(accessibility): nested interactive elements in ContributorsMenu (#2928)

### DIFF
--- a/apps/app/src/dropdowns/ContributorsMenu.tsx
+++ b/apps/app/src/dropdowns/ContributorsMenu.tsx
@@ -125,21 +125,12 @@ export default function ContributorsMenu({
             data-test={"contributors menu item author"}
             padding="0px"
             paddingRight="12px"
-            cursor="default"
+            as={ReactRouterLink}
+            to={`/sharedActivities/${activity.owner.userId}`}
+            aria-label={`Go to ${ownerAvatarName}'s shared activities`}
           >
-            <Tooltip
-              label={`Go to ${ownerAvatarName}'s shared activities`}
-              openDelay={1000}
-            >
-              <ChakraLink
-                as={ReactRouterLink}
-                to={`/sharedActivities/${activity.owner.userId}`}
-                aria-label={`Go to ${ownerAvatarName}'s shared activities`}
-              >
-                {avatars[0]}{" "}
-              </ChakraLink>
-            </Tooltip>
-            <HStack cursor="default">
+            {avatars[0]}{" "}
+            <HStack>
               <Text noOfLines={1} maxWidth="400px">
                 {activity.name}
               </Text>{" "}
@@ -150,8 +141,6 @@ export default function ContributorsMenu({
             const menuText = `${contrib_hist.originContent.name} by ${createNameCheckCurateTag(contrib_hist.originContent.owner)}`;
             const activityRef = `/activityViewer/${contrib_hist.originContent.contentId}`;
             const activityLabel = `Go to ${contrib_hist.originContent.name}`;
-            const userRef = `/sharedActivities/${contrib_hist.originContent.owner.userId}`;
-            const userLabel = `Go to ${createNameNoTag(contrib_hist.originContent.owner)}'s shared activities`;
             return (
               <MenuItem
                 key={`mi${i}`}
@@ -161,25 +150,7 @@ export default function ContributorsMenu({
                 to={activityRef}
                 aria-label={activityLabel}
               >
-                <Tooltip label={userLabel} openDelay={1000}>
-                  <ChakraLink
-                    as={ReactRouterLink}
-                    to={userRef}
-                    aria-label={userLabel}
-                  >
-                    {avatars[i + 1]}{" "}
-                  </ChakraLink>
-                </Tooltip>
-
-                <Tooltip label={activityLabel} openDelay={1000}>
-                  <ChakraLink
-                    as={ReactRouterLink}
-                    to={activityRef}
-                    aria-label={activityLabel}
-                  >
-                    <Text padding="10px 0px">{menuText}</Text>
-                  </ChakraLink>
-                </Tooltip>
+                {avatars[i + 1]} <Text padding="10px 0px">{menuText}</Text>
               </MenuItem>
             );
           })}


### PR DESCRIPTION
## Summary
- Collapses each `ContributorsMenu` menu item into a single interactive element by promoting `as={ReactRouterLink}` to the `MenuItem` itself and removing the inner `ChakraLink`/`Tooltip` wrappers.
- Eliminates the axe-core `nested-interactive` violation (critical) that was failing `checkAccessibility` in the `ContributorsMenu` "opens menu when clicked" Cypress test and blocking unrelated PRs.

Fixes #2928.

## Test plan
- [x] `npm run test:all --workspace @doenet-tools/app` filtered to `ContributorsMenu.cy.tsx` — all 10 tests pass, including the `checkAccessibility` assertions on the expanded menu.
- [x] Verify in the running app that clicking the author menu item still navigates to the owner's shared activities and clicking a contributor history item still navigates to the activity viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)