### PR TITLE
fix(infra): update IAM OIDC trusted repos after rename to DoenetApps

### DIFF
--- a/infra/cloudformation/dev3-doenet-repositories.params
+++ b/infra/cloudformation/dev3-doenet-repositories.params
@@ -13,6 +13,6 @@
   },
   {
     "ParameterKey": "GitHubRepos",
-    "ParameterValue": "repo:Doenet/DoenetTools:*,repo:cqnykamp/DoenetTools:*"
+    "ParameterValue": "repo:Doenet/DoenetApps:*"
   }
 ]

--- a/infra/cloudformation/prod-doenet-repositories.params
+++ b/infra/cloudformation/prod-doenet-repositories.params
@@ -13,6 +13,6 @@
   },
   {
     "ParameterKey": "GitHubRepos",
-    "ParameterValue": "repo:Doenet/DoenetTools:main,repo:cqnykamp/DoenetTools:*"
+    "ParameterValue": "repo:Doenet/DoenetApps:main"
   }
 ]


### PR DESCRIPTION
>[!NOTE]
> These changes have already been deployed to both `dev3` and `prod`.

## Summary
- Updates `GitHubRepos` in `dev3-doenet-repositories.params` and `prod-doenet-repositories.params` from `DoenetTools` → `DoenetApps`
- Removes the fork from the trusted repos list — only `Doenet/DoenetApps` is trusted

## Test plan
- [x] Redeploy the `repositories` CloudFormation stack for dev3 and prod
- [x] Confirm dev deploy GitHub Action succeeds after stack update

🤖 Generated with [Claude Code](https://claude.com/claude-code)