### PR TITLE
fix(cypress): defer @doenet/v06-to-v07 import to fix component-test dev-server timeout

### DIFF
--- a/apps/app/src/paths/editor/DoenetMLVersionComponents.tsx
+++ b/apps/app/src/paths/editor/DoenetMLVersionComponents.tsx
@@ -18,7 +18,6 @@ import {
 import { DoenetmlVersion } from "../../types";
 import axios from "axios";
 import { optimistic } from "../../utils/optimistic_ui";
-import { updateSyntaxFromV06toV07 } from "@doenet/v06-to-v07";
 
 /**
  * Renders a DoenetML version selector.
@@ -153,6 +152,8 @@ async function performSyntaxUpgrade(
   fetcher: FetcherWithComponents<any>,
   newVersionId: number,
 ) {
+  const { updateSyntaxFromV06toV07 } = await import("@doenet/v06-to-v07");
+
   const { data } = await axios.get(
     `/api/activityEditView/getContentSource/${contentId}`,
   );


### PR DESCRIPTION
## Summary
- The 13 MB `@doenet/v06-to-v07` module was loaded eagerly at the top of `DoenetMLVersionComponents.tsx`. In CI, Cypress' Vite dev server intermittently failed to serve it in time when transitioning to `DoenetMLVersionComponents.cy.tsx`, surfacing as `TypeError: Failed to fetch dynamically imported module: …/cypress/support/component.tsx`.
- Moved the import inside `performSyntaxUpgrade` so it only loads when a user clicks "Upgrade to version 0.7". The render path no longer touches the heavy module, eliminating the dev-server timeout and also code-splitting it out of the initial production bundle.

## Test plan
- [x] Run `npm run test:group1 --workspace @doenet-tools/app` locally — 139/139 passing, including `DoenetMLVersionComponents.cy.tsx` (7/7) and the test that clicks the Upgrade button (`is accessible when button is disabled`)
- [x] CI `component-tests (group1)` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)