### PR TITLE
Polish issue-template chooser with emoji and shorter copy

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: file-issue
+description: File a GitHub issue against Doenet/DoenetApps using the project's official issue templates (bug, feature, docs). Use when the user asks to "open an issue", "file a bug", "report a feature request", or "track this as an issue" against the upstream repo.
+---
+
+# file-issue
+
+Use this skill when the user asks you to file a GitHub issue against `Doenet/DoenetApps`. It enforces the project's issue-template conventions defined in `.github/ISSUE_TEMPLATE/`.
+
+## When to invoke
+
+Trigger phrases:
+
+- "open an issue", "file an issue", "create a GitHub issue"
+- "report this bug", "track this as a bug"
+- "feature request for ...", "request a feature"
+- "file a docs issue", "the docs say ... but ..."
+
+Do **not** invoke for: questions ("how does X work?"), TODOs that belong inline in code, or unfinished work in the current PR. If the user is still mid-task on something doable now, finish the work — don't farm it out to an issue.
+
+## Pick the right template
+
+Read the matching file under `.github/ISSUE_TEMPLATE/` _before_ drafting — the exact fields may have changed since this skill was written. Then map the user's intent:
+
+| User intent                                  | Template file         | Issue type / label set |
+| -------------------------------------------- | --------------------- | ---------------------- |
+| Defect, crash, regression, wrong behavior    | `bug_report.yml`      | type: Bug              |
+| New capability, UX improvement, API addition | `feature_request.yml` | type: Feature          |
+| Wrong / missing / unclear documentation      | `documentation.yml`   | label: `layer:docs`    |
+
+The repo uses **GitHub issue types** (not labels) for Bug/Feature/Project categorization. The templates set the type via the YAML `type:` field — don't add `bug` / `enhancement` / `triage` labels; those don't exist in this repo.
+
+If the user's request doesn't cleanly fit one of these, ask before guessing. Important reroutes:
+
+- **Instructor- or author-style bug reports without a developer-grade repro** go to the **Get Help** category on the [Doenet community forum](https://community.doenet.org), not Issues. Maintainers actively monitor Get Help and promote confirmed bugs into issues themselves. Most of Doenet's user base is instructors using the forum, not developers using GitHub.
+- **Unshaped ideas or pain points without a proposed fix** go to the [Discussion category](https://community.doenet.org/c/discussion/15) on the forum.
+- **DoenetML language bugs** belong in `Doenet/doenetml`, not this repo.
+
+File a GitHub issue here only when (a) the user has a concrete reproduction (for bugs) or a shaped proposal (for features), and (b) wants the work tracked as developer work. When in doubt, point at the forum and let a maintainer promote.
+
+Blank issues are enabled for cases that don't fit any template — tracking issues, RFCs, dependency bumps, postmortems, meta-issues. Prefer a template when one fits; reach for blank only when forcing the fit would distort the issue.
+
+## Fill the template properly
+
+Each YAML template defines required fields (`validations.required: true`). The CLI must satisfy all of them.
+
+Before filing:
+
+1. **Search for duplicates.** Run `gh issue list --repo Doenet/DoenetApps --search "<key terms>" --state all` and surface anything that looks related. Ask the user whether to file new, comment on existing, or skip.
+2. **Pin down area and layer.** The repo uses two label families:
+   - `area:*` — user-facing surface: `area:editor`, `area:assignments`, `area:browsing`, `area:folder-view`, `area:library`, `area:blog`, `area:discussions`. Pick exactly one if applicable.
+   - `layer:*` — codebase layer: `layer:frontend`, `layer:api`, `layer:database`, `layer:infra`, `layer:docs`. Pick all that apply.
+
+   Infer from context (recent files edited, error origin, the directory the user is in). The template dropdowns guide the user's selection; when filing via CLI, **pass these as `--label` flags directly** so the issue arrives already labeled — saves the maintainer a triage step.
+
+3. **For bugs:** capture concrete repro steps, expected vs actual, the commit SHA (`git rev-parse --short HEAD`), and browser/OS or Node version where relevant. Don't paste secrets, tokens, or private URLs into logs.
+4. **For features:** lead with the _problem_ (who hurts, when, why) before the proposed solution. A feature request that's only a solution gets bounced.
+5. **For docs:** include the exact file path or URL and quote the confusing passage.
+
+## File it
+
+Use `gh issue create` against the upstream repo, passing the inferred area/layer labels directly:
+
+```bash
+gh issue create \
+  --repo Doenet/DoenetApps \
+  --template bug_report.yml \
+  --title "[Bug]: <short summary>" \
+  --label "area:editor" \
+  --label "layer:frontend" \
+  --body "$(cat <<'EOF'
+<filled-in template body in markdown — match the template's section headings>
+EOF
+)"
+```
+
+Notes:
+
+- `--template` selects the template; `--title` overrides the template's default prefix — keep the `[Bug]:` / `[Feature]:` / `[Docs]:` prefix.
+- The issue **type** (Bug / Feature) is set by the template's `type:` field — don't try to pass it via flag.
+- Pass one `--label area:*` and one or more `--label layer:*` matching what you inferred. For docs issues, `layer:docs` is auto-applied by the template.
+- After creating, print the returned URL so the user can review.
+
+## Confirm before filing
+
+Always show the user the drafted title and body and get explicit confirmation before calling `gh issue create`. Filing a public issue is visible to the world and not easily reversible — match the scope of action to what was requested.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report a defect or unexpected behavior in Doenet.
+title: "[Bug]: "
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for bugs with a **concrete reproduction** that should be tracked as developer work.
+
+        Not sure if it's a bug, or hit something unexpected as an instructor or author? Post in [**Get Help** on the Doenet community forum](https://community.doenet.org/c/support/5) — maintainers monitor it and will open an issue here once a bug is confirmed.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched [existing issues](https://github.com/Doenet/DoenetApps/issues?q=is%3Aissue) and did not find a duplicate.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which user-facing surface is affected? Maps to the repo's `area:*` labels — a maintainer will apply the matching label at triage.
+      options:
+        - Editor
+        - Assignments
+        - Browsing
+        - Folder view
+        - Library
+        - Blog
+        - Discussions
+        - Other / not user-facing
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Layer
+      description: Which layer of the stack is affected? Maps to the repo's `layer:*` labels. Pick all you know — leave blank if unsure.
+      multiple: true
+      options:
+        - Frontend (apps/app)
+        - API (apps/api)
+        - Database / Prisma
+        - Infrastructure / CI
+        - Docs
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+      placeholder: "When I do X, Y happens instead of Z."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal, step-by-step recipe. If reproducing requires specific seed data or DoenetML content, include it here or link to it.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages, stack traces, or screenshots if available.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Doenet version or commit
+      description: A release version, branch name, or commit SHA. Run `git rev-parse HEAD` if running locally.
+      placeholder: "e.g. main @ abc1234, or v0.7.2"
+  - type: input
+    id: environment
+    attributes:
+      label: Browser / OS / Node version
+      description: Only fill out what's relevant (e.g. browser+OS for UI bugs, Node version for build/dev-server bugs).
+      placeholder: "Chrome 131 on macOS 15.1, Node 24.15"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant server logs, browser console output, or terminal output. Will be rendered as a code block.
+      render: shell
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Anything else that might help — workarounds you've tried, related issues, suspected root cause, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a defect or unexpected behavior in Doenet.
+name: 🐛 Bug report
+description: Something is broken and you can reproduce it.
 title: "[Bug]: "
 type: Bug
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Something not working? (Get Help on the community forum)
+  - name: 🆘 Something seems broken (Get Help on the forum)
     url: https://community.doenet.org/c/support/5
-    about: If you're an instructor or author and something seems wrong, post in the Get Help category. Maintainers monitor it and will open an issue here once a bug is confirmed. This is usually the right starting place unless you already have a developer-grade reproduction.
-  - name: Share an idea or pain point (Discussion on the community forum)
+    about: Usually the right starting place if you're not a developer with a repro. Maintainers monitor this category and promote confirmed bugs into issues here.
+  - name: 💡 Share an idea or pain point (Discussion on the forum)
     url: https://community.doenet.org/c/discussion/15
-    about: For feature wishes, ideas, or pain points without a concrete proposal, start a thread in the Discussion category.
-  - name: Questions & community chat
+    about: Feature wishes, ideas, or pain points without a concrete proposal.
+  - name: 💬 Ask a question or chat (Discord)
     url: https://discord.gg/PUduwtKJ5h
-    about: Ask questions, get real-time help, or chat with the Doenet community on Discord.
-  - name: DoenetML language bugs
+    about: Real-time help and community chat.
+  - name: 🔤 DoenetML language bug
     url: https://github.com/Doenet/doenetml/issues
-    about: Bugs in the DoenetML markup language itself belong in the DoenetML repository.
+    about: Bugs in the DoenetML markup language itself belong in the doenetml repo.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Something not working? (Get Help on the community forum)
+    url: https://community.doenet.org/c/support/5
+    about: If you're an instructor or author and something seems wrong, post in the Get Help category. Maintainers monitor it and will open an issue here once a bug is confirmed. This is usually the right starting place unless you already have a developer-grade reproduction.
+  - name: Share an idea or pain point (Discussion on the community forum)
+    url: https://community.doenet.org/c/discussion/15
+    about: For feature wishes, ideas, or pain points without a concrete proposal, start a thread in the Discussion category.
+  - name: Questions & community chat
+    url: https://discord.gg/PUduwtKJ5h
+    about: Ask questions, get real-time help, or chat with the Doenet community on Discord.
+  - name: DoenetML language bugs
+    url: https://github.com/Doenet/doenetml/issues
+    about: Bugs in the DoenetML markup language itself belong in the DoenetML repository.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation issue
+description: Report unclear, missing, or incorrect documentation.
+title: "[Docs]: "
+labels: ["layer:docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Docs are code too — thanks for helping us improve them.
+  - type: input
+    id: location
+    attributes:
+      label: Where are the docs?
+      description: URL, file path, or section title of the affected documentation.
+      placeholder: "README.md > Dev Environment Setup, or apps/api/AGENTS.md"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: Quote the confusing passage or describe what is missing.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: If you have a proposed rewrite or addition, include it here. A PR is even better!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,5 @@
-name: Documentation issue
-description: Report unclear, missing, or incorrect documentation.
+name: 📝 Documentation
+description: Docs are unclear, missing, or wrong.
 title: "[Docs]: "
 labels: ["layer:docs"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Suggest a new feature or improvement.
+title: "[Feature]: "
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when you have a **concrete, developer-actionable proposal** — a known problem and at least a rough idea of the change.
+
+        Still figuring out the idea, or sharing an instructor-facing wish? Please post in the [Doenet community forum](https://community.doenet.org/c/discussion/15) instead. Threads there can be promoted to issues once the shape is clear.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched [existing issues](https://github.com/Doenet/DoenetApps/issues?q=is%3Aissue) and did not find a duplicate request.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which user-facing surface does this affect? Maps to the repo's `area:*` labels.
+      options:
+        - Editor
+        - Assignments
+        - Browsing
+        - Folder view
+        - Library
+        - Blog
+        - Discussions
+        - Developer experience / tooling
+        - Cross-cutting / not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Layer
+      description: Which layer of the stack would this touch? Maps to the repo's `layer:*` labels. Pick all that apply — leave blank if unsure.
+      multiple: true
+      options:
+        - Frontend (apps/app)
+        - API (apps/api)
+        - Database / Prisma
+        - Infrastructure / CI
+        - Docs
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user need or pain point does this address? Who experiences it, and when?
+      placeholder: "As a [teacher / student / author / developer], I want to ..., because ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should thiswork ? Include UX sketches, API shape, or example DoenetML if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why this one is preferred.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, related issues, links to discussions, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
-name: Feature request
-description: Suggest a new feature or improvement.
+name: ✨ Feature request
+description: Propose a concrete new capability or improvement.
 title: "[Feature]: "
 type: Feature
 body:


### PR DESCRIPTION
## Summary

Follow-up to #2945 — purely cosmetic changes to the issue-template chooser at https://github.com/Doenet/DoenetApps/issues/new/choose:

- Emoji prefix on each template: 🐛 Bug report, ✨ Feature request, 📝 Documentation
- Emoji prefix on each contact link: 🆘 Get Help, 💡 Discussion, 💬 Discord, 🔤 DoenetML language bug
- Shortened the `description` and `about` strings so the chooser is easier to scan
- No changes to template fields, types, labels, or routing

**Note:** this PR stacks on top of #2945; until that merges, GitHub will show the combined diff. The chooser-screen changes themselves are isolated to template `name`/`description` and config `name`/`about`.

## Test plan

- [ ] After merge: visit https://github.com/Doenet/DoenetApps/issues/new/choose and verify each template + contact link displays its emoji and shortened copy
- [ ] Confirm the existing form fields and labels still work end-to-end (filing #2945's test plan still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)