### PR TITLE
Image upload MVP: backend (#2943)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,6 +92,15 @@ jobs:
       # Enable test features for CI
       ENABLE_TEST_AUTH_BYPASS: "true"
       ENABLE_TEST_ROUTES: "true"
+      # Media storage — local mode is fine for CI; the existing e2e tests
+      # don't actually upload images, but loadMediaConfig() must succeed at
+      # API boot so the server starts.
+      MEDIA_S3_MODE: "local"
+      MEDIA_S3_REGION: "us-east-1"
+      MEDIA_S3_BUCKET: "doenet-media"
+      MEDIA_S3_LOCAL_ENDPOINT: "http://localhost:9090"
+      MEDIA_S3_LOCAL_ACCESS_KEY_ID: "ci"
+      MEDIA_S3_LOCAL_SECRET_ACCESS_KEY: "ci"
 
     steps:
       # Checkout repo

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -192,6 +192,15 @@ jobs:
       MOCK_SIGNIN_EMAIL: "true"
       ENABLE_TEST_AUTH_BYPASS: "true"
       ENABLE_TEST_ROUTES: "true"
+      # Media storage — local mode is fine for CI; the existing brittle tests
+      # don't actually upload images, but loadMediaConfig() must succeed at
+      # API boot so the server starts.
+      MEDIA_S3_MODE: "local"
+      MEDIA_S3_REGION: "us-east-1"
+      MEDIA_S3_BUCKET: "doenet-media"
+      MEDIA_S3_LOCAL_ENDPOINT: "http://localhost:9090"
+      MEDIA_S3_LOCAL_ACCESS_KEY_ID: "ci"
+      MEDIA_S3_LOCAL_SECRET_ACCESS_KEY: "ci"
 
     strategy:
       fail-fast: false

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,6 +23,20 @@ EMAIL_SES_REGION="us-east-1"
 EMAIL_SES_ARN="arn:aws:ses:us-east-1:123456789012:identity/example.com"
 EMAIL_SES_FROM_ADDRESS="no-reply@example.com"
 
+#Media storage (image upload)
+# MEDIA_S3_MODE is an explicit toggle: "local" or "aws". Required at runtime.
+#   - "local": API talks to the s3mock service from docker-compose.yml.
+#   - "aws":   API talks to real S3 using the task's IAM role.
+# REGION and BUCKET are needed in both modes. The MEDIA_S3_LOCAL_* vars are
+# only consulted when MEDIA_S3_MODE=local (and required in that case);
+# deployed environments should leave them unset.
+MEDIA_S3_MODE="local"
+MEDIA_S3_REGION="us-east-1"
+MEDIA_S3_BUCKET="doenet-media"
+MEDIA_S3_LOCAL_ENDPOINT="http://localhost:9090"
+MEDIA_S3_LOCAL_ACCESS_KEY_ID="test"
+MEDIA_S3_LOCAL_SECRET_ACCESS_KEY="test"
+
 #Login credentials
 SESSION_SECRET="mysecret"
 GOOGLE_CLIENT_ID="mysecret"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1053.0",
     "@aws-sdk/client-ses": "^3.777.0",
     "@doenet-tools/shared": "*",
     "@prisma/client": "6.4.1",
@@ -38,7 +39,9 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "http-status-codes": "^2.3.0",
+    "image-size": "^1.2.1",
     "luxon": "^3.7.1",
+    "multer": "^2.1.1",
     "multiformats": "^9.9.0",
     "nanoid": "^5.1.5",
     "passport": "^0.7.0",
@@ -56,6 +59,7 @@
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.3",
     "@types/express-session": "^1.18.2",
+    "@types/multer": "^1.4.13",
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-local": "^1.0.38",

--- a/apps/api/prisma/migrations/20260526134022_add_image_content_type/migration.sql
+++ b/apps/api/prisma/migrations/20260526134022_add_image_content_type/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: extend ContentType enum with `image` and add image-metadata columns
+ALTER TABLE `content`
+  MODIFY `type` ENUM('singleDoc', 'select', 'sequence', 'folder', 'image') NOT NULL DEFAULT 'singleDoc',
+  ADD COLUMN `mimeType` VARCHAR(64) NULL,
+  ADD COLUMN `sizeBytes` BIGINT NULL,
+  ADD COLUMN `imageWidth` INT NULL,
+  ADD COLUMN `imageHeight` INT NULL,
+  ADD COLUMN `s3Key` VARCHAR(255) NULL;

--- a/apps/api/prisma/migrations/20260528000000_rename_image_s3_key_to_storage_key/migration.sql
+++ b/apps/api/prisma/migrations/20260528000000_rename_image_s3_key_to_storage_key/migration.sql
@@ -1,0 +1,3 @@
+-- Generalize the storage-key column name. The value is still the object key
+-- used by whatever storage adapter is wired up (currently S3).
+ALTER TABLE `content` CHANGE COLUMN `s3Key` `storageKey` VARCHAR(255) NULL;

--- a/apps/api/prisma/migrations/20260528120000_add_user_can_upload_images/migration.sql
+++ b/apps/api/prisma/migrations/20260528120000_add_user_can_upload_images/migration.sql
@@ -1,0 +1,3 @@
+-- Early-access flag for the experimental image-upload feature.
+ALTER TABLE `users`
+  ADD COLUMN `canUploadImages` BOOLEAN NOT NULL DEFAULT FALSE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -58,7 +58,14 @@ model content {
   // ====== Selects (obsolete) =========
   numToSelect            Int                      @default(1) @db.UnsignedSmallInt
   selectByVariant        Boolean                  @default(false)
-  // 
+  //
+  // ====== Images =========
+  mimeType               String?                  @db.VarChar(64)
+  sizeBytes              BigInt?
+  imageWidth             Int?
+  imageHeight            Int?
+  storageKey             String?                  @db.VarChar(255)
+  //
   // ===== Code ==========
   // Course or assignment code
   // All courses have a code, and all one-off assignments have a code.
@@ -121,6 +128,7 @@ enum ContentType {
   select
   sequence
   folder
+  image
 }
 
 enum Visibility {
@@ -356,6 +364,9 @@ model users {
   isLibrary          Boolean                @default(false)
   isEditor           Boolean                @default(false)
   isAuthor           Boolean                @default(false)
+  // Early-access flag for the experimental image-upload feature. Flip with
+  // `apps/api/scripts/enable-image-upload.ts`.
+  canUploadImages    Boolean                @default(false)
   // For now, premium refers to the instructor accounts
   // A premium account means: any assignment I create can be taken by normal (non-anonymous and non-scoped) users
   isPremium          Boolean                @default(false)

--- a/apps/api/scripts/enable-image-upload.ts
+++ b/apps/api/scripts/enable-image-upload.ts
@@ -1,0 +1,53 @@
+// Grants the image-upload early-access flag to a user, looked up by email.
+// Idempotent: running it on an already-enabled account succeeds and reports
+// "already enabled".
+// -----
+// Local dev (from apps/api, requires tsx):
+//   npx tsx scripts/enable-image-upload.ts <email>
+//
+// Production (inside the running ECS Fargate task, cwd is /DoenetTools/apps/api):
+//   node dist/scripts/enable-image-upload.js <email>
+//
+// To reach the prod container: run `infra/scripts/exec.sh -s prod` from the
+// repo root, pick the api service/task, then run the command above.
+// -----
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.error("Usage: npx tsx scripts/enable-image-upload.ts <email>");
+    process.exit(2);
+  }
+
+  const user = await prisma.users.findUnique({
+    where: { email },
+    select: { userId: true, canUploadImages: true },
+  });
+  if (!user) {
+    console.error(`No user with email ${email}`);
+    process.exit(1);
+  }
+
+  if (user.canUploadImages) {
+    console.log(`${email} already has image uploads enabled.`);
+    return;
+  }
+
+  await prisma.users.update({
+    where: { email },
+    data: { canUploadImages: true },
+  });
+  console.log(`Enabled image uploads for ${email}.`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/content-tree/content-tree.ts
+++ b/apps/api/src/content-tree/content-tree.ts
@@ -1,3 +1,4 @@
+import { Visibility } from "@prisma/client";
 import { prisma } from "../model";
 import { InvalidRequestError } from "../utils/error";
 import { getNextSortIndexForParent } from "../utils/sort";
@@ -14,8 +15,9 @@ import { getNextSortIndexForParent } from "../utils/sort";
  *
  * Returns:
  *   - `sortIndex`     — next position at the end of the parent's children
- *   - `isPublic`      — inherited from the parent (false at root)
- *   - `licenseCode`   — inherited when the parent is public or shared
+ *   - `visibility`    — inherited from the parent ("private" at root)
+ *   - `isPublic`      — true when inherited visibility is "public"
+ *   - `licenseCode`   — inherited when the parent is non-private or shared
  *   - `sharedWith`    — userIds the parent is shared with
  *   - `courseRootId`  — inherited from the parent
  *
@@ -31,6 +33,7 @@ export async function prepareNewChild({
 }): Promise<{
   sortIndex: Awaited<ReturnType<typeof getNextSortIndexForParent>>;
   isPublic: boolean;
+  visibility: Visibility;
   licenseCode: string | null | undefined;
   sharedWith: Uint8Array[];
   courseRootId: Uint8Array | null;
@@ -38,6 +41,7 @@ export async function prepareNewChild({
   const sortIndex = await getNextSortIndexForParent(ownerId, parentId);
 
   let isPublic = false;
+  let visibility: Visibility = "private";
   let licenseCode: string | null | undefined = undefined;
   let sharedWith: Uint8Array[] = [];
   let courseRootId: Uint8Array | null = null;
@@ -52,6 +56,7 @@ export async function prepareNewChild({
       },
       select: {
         isPublic: true,
+        visibility: true,
         licenseCode: true,
         sharedWith: { select: { userId: true } },
         isAssignmentRoot: true,
@@ -68,8 +73,9 @@ export async function prepareNewChild({
 
     courseRootId = parent.courseRootId;
 
-    if (parent.isPublic) {
-      isPublic = true;
+    if (parent.visibility !== "private") {
+      visibility = parent.visibility;
+      isPublic = parent.visibility === "public";
       if (parent.licenseCode) {
         licenseCode = parent.licenseCode;
       }
@@ -83,5 +89,12 @@ export async function prepareNewChild({
     }
   }
 
-  return { sortIndex, isPublic, licenseCode, sharedWith, courseRootId };
+  return {
+    sortIndex,
+    isPublic,
+    visibility,
+    licenseCode,
+    sharedWith,
+    courseRootId,
+  };
 }

--- a/apps/api/src/content-tree/content-tree.ts
+++ b/apps/api/src/content-tree/content-tree.ts
@@ -1,0 +1,87 @@
+import { prisma } from "../model";
+import { InvalidRequestError } from "../utils/error";
+import { getNextSortIndexForParent } from "../utils/sort";
+
+/**
+ * Validates that `parentId` is a legal place for `ownerId` to add a new child,
+ * and returns the fields that child should be created with.
+ *
+ * Validates:
+ *   - parent exists, is owned by `ownerId`, and isn't soft-deleted
+ *   - parent is a container type (folder, sequence, or select) — never a leaf
+ *     (`singleDoc`, `image`)
+ *   - parent isn't an assignment root, and isn't directly under one
+ *
+ * Returns:
+ *   - `sortIndex`     — next position at the end of the parent's children
+ *   - `isPublic`      — inherited from the parent (false at root)
+ *   - `licenseCode`   — inherited when the parent is public or shared
+ *   - `sharedWith`    — userIds the parent is shared with
+ *   - `courseRootId`  — inherited from the parent
+ *
+ * Throws `InvalidRequestError` (assigned placement) or prisma's `NotFoundError`
+ * (parent missing / not owned / soft-deleted / wrong type).
+ */
+export async function prepareNewChild({
+  ownerId,
+  parentId,
+}: {
+  ownerId: Uint8Array;
+  parentId: Uint8Array | null;
+}): Promise<{
+  sortIndex: Awaited<ReturnType<typeof getNextSortIndexForParent>>;
+  isPublic: boolean;
+  licenseCode: string | null | undefined;
+  sharedWith: Uint8Array[];
+  courseRootId: Uint8Array | null;
+}> {
+  const sortIndex = await getNextSortIndexForParent(ownerId, parentId);
+
+  let isPublic = false;
+  let licenseCode: string | null | undefined = undefined;
+  let sharedWith: Uint8Array[] = [];
+  let courseRootId: Uint8Array | null = null;
+
+  if (parentId !== null) {
+    const parent = await prisma.content.findUniqueOrThrow({
+      where: {
+        id: parentId,
+        type: { in: ["folder", "sequence", "select"] },
+        isDeletedOn: null,
+        ownerId,
+      },
+      select: {
+        isPublic: true,
+        licenseCode: true,
+        sharedWith: { select: { userId: true } },
+        isAssignmentRoot: true,
+        courseRootId: true,
+        parent: { select: { isAssignmentRoot: true } },
+      },
+    });
+
+    if (parent.isAssignmentRoot || parent.parent?.isAssignmentRoot) {
+      throw new InvalidRequestError(
+        "Cannot add content to an assigned activity",
+      );
+    }
+
+    courseRootId = parent.courseRootId;
+
+    if (parent.isPublic) {
+      isPublic = true;
+      if (parent.licenseCode) {
+        licenseCode = parent.licenseCode;
+      }
+    }
+
+    if (parent.sharedWith.length > 0) {
+      sharedWith = parent.sharedWith.map((cs) => cs.userId);
+      if (parent.licenseCode) {
+        licenseCode = parent.licenseCode;
+      }
+    }
+  }
+
+  return { sortIndex, isPublic, licenseCode, sharedWith, courseRootId };
+}

--- a/apps/api/src/content-tree/index.ts
+++ b/apps/api/src/content-tree/index.ts
@@ -1,0 +1,12 @@
+/**
+ * This module owns the shape and invariants of the content tree — the
+ * parent/child structure that holds docs, folders, sequences, selects, and
+ * images.
+ *
+ * It does not own per-node concerns (sharing, licensing, course membership,
+ * audits, etc.); it consults those systems where its invariants depend on
+ * them — for example, `prepareNewChild` reads parent visibility and sharing
+ * to compute what a new child inherits.
+ */
+
+export * from "./content-tree";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -49,12 +49,18 @@ import { generateHandle } from "./utils/names";
 import { codeRouter } from "./routes/code";
 import { metricsRouter } from "./routes/metricsRoutes";
 import { contentRouter } from "./routes/content.route";
+import { loadMediaConfig, mediaRouter } from "./media";
+import { getEnvVar } from "./utils/env";
 
 // Type assertion to work around passport type declaration issues
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const passport = passportLib as any;
 
 dotenv.config();
+
+// Validate media-storage env vars at startup so a misconfigured deployment
+// crashes here rather than on the first upload/serve request.
+loadMediaConfig();
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -74,19 +80,6 @@ app.use(function (req, res, next) {
   }
   next();
 });
-
-function getEnvVar(name: string, required: true): string;
-function getEnvVar(name: string, required?: boolean): string | undefined;
-function getEnvVar(name: string, required = false): string | undefined {
-  const value = process.env[name]?.trim();
-  if (value) {
-    return value;
-  }
-  if (required) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return undefined;
-}
 
 const mockSigninEmail =
   process.env.MOCK_SIGNIN_EMAIL?.trim().toLowerCase() === "true";
@@ -330,6 +323,7 @@ passport.serializeUser(async (req: any, user: any, done: any) => {
     let isAnonymous = true;
     let isEditor = false;
     let isAuthor = false;
+    let canUploadImages = false;
 
     if (
       process.env.ENABLE_TEST_AUTH_BYPASS &&
@@ -346,6 +340,7 @@ passport.serializeUser(async (req: any, user: any, done: any) => {
 
         isEditor = Boolean(req.body.isEditor);
         isAuthor = Boolean(req.body.isAuthor);
+        canUploadImages = Boolean(req.body.canUploadImages);
         isAnonymous = false;
       }
     }
@@ -357,6 +352,7 @@ passport.serializeUser(async (req: any, user: any, done: any) => {
       isAnonymous,
       isEditor,
       isAuthor,
+      canUploadImages,
     });
     return done(undefined, fromUUID(u.userId));
   }
@@ -418,6 +414,7 @@ app.use("/api/editor", editorRouter);
 app.use("/api/code", codeRouter);
 app.use("/api/metrics", metricsRouter);
 app.use("/api/content", contentRouter);
+app.use("/api/media", mediaRouter);
 
 // Discourse uses this endpoint to sign on
 app.use("/api/discourse", discourseRouter);

--- a/apps/api/src/media/config.test.ts
+++ b/apps/api/src/media/config.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// loadMediaConfig caches its result at module scope, so each test must reload
+// the module to get a clean slate.
+async function loadFresh() {
+  vi.resetModules();
+  const mod = await import("./config.js");
+  return mod.loadMediaConfig;
+}
+
+const ALL_VARS = [
+  "MEDIA_S3_MODE",
+  "MEDIA_S3_REGION",
+  "MEDIA_S3_BUCKET",
+  "MEDIA_S3_LOCAL_ENDPOINT",
+  "MEDIA_S3_LOCAL_ACCESS_KEY_ID",
+  "MEDIA_S3_LOCAL_SECRET_ACCESS_KEY",
+] as const;
+
+describe("loadMediaConfig", () => {
+  beforeEach(() => {
+    for (const v of ALL_VARS) vi.stubEnv(v, "");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("throws when MEDIA_S3_MODE is missing", async () => {
+    const loadMediaConfig = await loadFresh();
+    expect(() => loadMediaConfig()).toThrow(/MEDIA_S3_MODE/);
+  });
+
+  test("throws when MEDIA_S3_MODE is an unknown value", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "minio");
+    const loadMediaConfig = await loadFresh();
+    expect(() => loadMediaConfig()).toThrow(/MEDIA_S3_MODE/);
+  });
+
+  test("aws mode requires REGION and BUCKET", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "aws");
+    const loadMediaConfig = await loadFresh();
+    expect(() => loadMediaConfig()).toThrow(/MEDIA_S3_REGION/);
+
+    vi.stubEnv("MEDIA_S3_REGION", "us-east-1");
+    const loadMediaConfig2 = await loadFresh();
+    expect(() => loadMediaConfig2()).toThrow(/MEDIA_S3_BUCKET/);
+  });
+
+  test("aws mode returns the aws-shaped config and ignores local-only vars", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "aws");
+    vi.stubEnv("MEDIA_S3_REGION", "us-east-1");
+    vi.stubEnv("MEDIA_S3_BUCKET", "doenet-media");
+    // Local vars set but should be ignored in aws mode.
+    vi.stubEnv("MEDIA_S3_LOCAL_ENDPOINT", "http://localhost:9090");
+    vi.stubEnv("MEDIA_S3_LOCAL_ACCESS_KEY_ID", "ignored");
+    vi.stubEnv("MEDIA_S3_LOCAL_SECRET_ACCESS_KEY", "ignored");
+
+    const loadMediaConfig = await loadFresh();
+    expect(loadMediaConfig()).toEqual({
+      mode: "aws",
+      region: "us-east-1",
+      bucket: "doenet-media",
+    });
+  });
+
+  test("local mode requires the LOCAL_* vars", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "local");
+    vi.stubEnv("MEDIA_S3_REGION", "us-east-1");
+    vi.stubEnv("MEDIA_S3_BUCKET", "doenet-media");
+
+    const loadMediaConfig = await loadFresh();
+    expect(() => loadMediaConfig()).toThrow(/MEDIA_S3_LOCAL_ENDPOINT/);
+
+    vi.stubEnv("MEDIA_S3_LOCAL_ENDPOINT", "http://localhost:9090");
+    const loadMediaConfig2 = await loadFresh();
+    expect(() => loadMediaConfig2()).toThrow(/MEDIA_S3_LOCAL_ACCESS_KEY_ID/);
+
+    vi.stubEnv("MEDIA_S3_LOCAL_ACCESS_KEY_ID", "test");
+    const loadMediaConfig3 = await loadFresh();
+    expect(() => loadMediaConfig3()).toThrow(
+      /MEDIA_S3_LOCAL_SECRET_ACCESS_KEY/,
+    );
+  });
+
+  test("local mode returns the local-shaped config when fully configured", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "local");
+    vi.stubEnv("MEDIA_S3_REGION", "us-east-1");
+    vi.stubEnv("MEDIA_S3_BUCKET", "doenet-media");
+    vi.stubEnv("MEDIA_S3_LOCAL_ENDPOINT", "http://localhost:9090");
+    vi.stubEnv("MEDIA_S3_LOCAL_ACCESS_KEY_ID", "test");
+    vi.stubEnv("MEDIA_S3_LOCAL_SECRET_ACCESS_KEY", "test");
+
+    const loadMediaConfig = await loadFresh();
+    expect(loadMediaConfig()).toEqual({
+      mode: "local",
+      region: "us-east-1",
+      bucket: "doenet-media",
+      endpoint: "http://localhost:9090",
+      accessKeyId: "test",
+      secretAccessKey: "test",
+    });
+  });
+
+  test("caches the resolved config across calls", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "aws");
+    vi.stubEnv("MEDIA_S3_REGION", "us-east-1");
+    vi.stubEnv("MEDIA_S3_BUCKET", "doenet-media");
+
+    const loadMediaConfig = await loadFresh();
+    const a = loadMediaConfig();
+    const b = loadMediaConfig();
+    expect(a).toBe(b);
+  });
+
+  test("treats a whitespace-only value as missing", async () => {
+    vi.stubEnv("MEDIA_S3_MODE", "aws");
+    vi.stubEnv("MEDIA_S3_REGION", "   ");
+    vi.stubEnv("MEDIA_S3_BUCKET", "doenet-media");
+
+    const loadMediaConfig = await loadFresh();
+    expect(() => loadMediaConfig()).toThrow(/MEDIA_S3_REGION/);
+  });
+});

--- a/apps/api/src/media/config.ts
+++ b/apps/api/src/media/config.ts
@@ -1,0 +1,47 @@
+// Validated media-storage config. `loadMediaConfig` is the single source of
+// truth — every consumer in `src/media/` calls it (and `src/index.ts` calls
+// it at startup) so a misconfigured deployment crashes immediately rather
+// than failing the first upload request.
+import { getEnvVar } from "../utils/env";
+
+export type MediaConfig =
+  | { mode: "aws"; region: string; bucket: string }
+  | {
+      mode: "local";
+      region: string;
+      bucket: string;
+      endpoint: string;
+      accessKeyId: string;
+      secretAccessKey: string;
+    };
+
+let cached: MediaConfig | undefined;
+
+export function loadMediaConfig(): MediaConfig {
+  if (cached) return cached;
+
+  const mode = getEnvVar("MEDIA_S3_MODE");
+  if (mode !== "local" && mode !== "aws") {
+    throw new Error(
+      `MEDIA_S3_MODE must be "local" or "aws" (got ${JSON.stringify(mode ?? null)})`,
+    );
+  }
+
+  const region = getEnvVar("MEDIA_S3_REGION", true);
+  const bucket = getEnvVar("MEDIA_S3_BUCKET", true);
+
+  if (mode === "aws") {
+    cached = { mode, region, bucket };
+    return cached;
+  }
+
+  cached = {
+    mode,
+    region,
+    bucket,
+    endpoint: getEnvVar("MEDIA_S3_LOCAL_ENDPOINT", true),
+    accessKeyId: getEnvVar("MEDIA_S3_LOCAL_ACCESS_KEY_ID", true),
+    secretAccessKey: getEnvVar("MEDIA_S3_LOCAL_SECRET_ACCESS_KEY", true),
+  };
+  return cached;
+}

--- a/apps/api/src/media/imageContent.test.ts
+++ b/apps/api/src/media/imageContent.test.ts
@@ -1,0 +1,462 @@
+import { describe, expect, test } from "vitest";
+import { prisma } from "../model";
+import { createContent } from "../query/activity";
+import { setContentLicense } from "../query/license";
+import { setContentIsPublic, shareContentWithEmail } from "../query/share";
+import { createTestUser } from "../test/utils";
+import { InvalidRequestError } from "../utils/error";
+import {
+  createImageContent,
+  deleteImageContent,
+  findViewableImage,
+  setImageStorageKey,
+} from "./imageContent";
+
+async function getContent(contentId: Uint8Array) {
+  return prisma.content.findUniqueOrThrow({
+    where: { id: contentId },
+    select: {
+      type: true,
+      ownerId: true,
+      parentId: true,
+      name: true,
+      isPublic: true,
+      visibility: true,
+      licenseCode: true,
+      courseRootId: true,
+      mimeType: true,
+      sizeBytes: true,
+      imageWidth: true,
+      imageHeight: true,
+      storageKey: true,
+      sharedWith: { select: { userId: true } },
+    },
+  });
+}
+
+describe("createImageContent", () => {
+  test("creates an image row at root with the expected metadata", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "donut.png",
+      mimeType: "image/png",
+      sizeBytes: 1024,
+      imageWidth: 100,
+      imageHeight: 80,
+    });
+
+    const row = await getContent(contentId);
+    expect(row.type).toBe("image");
+    expect(row.ownerId).toEqual(owner.userId);
+    expect(row.parentId).toBeNull();
+    expect(row.name).toBe("donut.png");
+    expect(row.mimeType).toBe("image/png");
+    expect(row.sizeBytes).toBe(1024n);
+    expect(row.imageWidth).toBe(100);
+    expect(row.imageHeight).toBe(80);
+    expect(row.storageKey).toBeNull();
+    expect(row.isPublic).toBe(false);
+    expect(row.visibility).toBe("private");
+    expect(row.courseRootId).toBeNull();
+    expect(row.sharedWith).toEqual([]);
+  });
+
+  test("inherits public visibility and license from a public parent", async () => {
+    const owner = await createTestUser();
+    const { contentId: folderId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+    await setContentLicense({
+      contentId: folderId,
+      loggedInUserId: owner.userId,
+      licenseCode: "CCBYSA",
+    });
+    await setContentIsPublic({
+      contentId: folderId,
+      isPublic: true,
+      loggedInUserId: owner.userId,
+    });
+
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: folderId,
+      name: "in-public.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    const row = await getContent(contentId);
+    expect(row.isPublic).toBe(true);
+    expect(row.visibility).toBe("public");
+    expect(row.licenseCode).toBe("CCBYSA");
+  });
+
+  test("inherits sharedWith from a shared parent", async () => {
+    const owner = await createTestUser();
+    const friend = await createTestUser();
+    if (!friend.email) throw new Error("friend should have email");
+
+    const { contentId: folderId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+    await shareContentWithEmail({
+      contentId: folderId,
+      loggedInUserId: owner.userId,
+      email: friend.email,
+    });
+
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: folderId,
+      name: "shared.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    const row = await getContent(contentId);
+    expect(row.sharedWith).toEqual([{ userId: friend.userId }]);
+  });
+
+  test("inherits courseRootId from the parent", async () => {
+    const owner = await createTestUser();
+    const { contentId: folderId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+    // Mark the folder itself as the course root.
+    await prisma.content.update({
+      where: { id: folderId },
+      data: { courseRootId: folderId },
+    });
+
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: folderId,
+      name: "in-course.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    const row = await getContent(contentId);
+    expect(row.courseRootId).toEqual(folderId);
+  });
+
+  test("rejects upload under an assigned activity", async () => {
+    const owner = await createTestUser();
+    const { contentId: psetId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "sequence",
+      parentId: null,
+    });
+    // Mark the sequence as an assignment root — same trigger
+    // prepareNewChild checks against.
+    await prisma.content.update({
+      where: { id: psetId },
+      data: { isAssignmentRoot: true },
+    });
+
+    await expect(
+      createImageContent({
+        loggedInUserId: owner.userId,
+        parentId: psetId,
+        name: "nope.png",
+        mimeType: "image/png",
+        sizeBytes: 1,
+        imageWidth: 1,
+        imageHeight: 1,
+      }),
+    ).rejects.toBeInstanceOf(InvalidRequestError);
+  });
+
+  test("rejects when parent is a singleDoc (docs are leaves, not containers)", async () => {
+    const owner = await createTestUser();
+    const { contentId: docId } = await createContent({
+      loggedInUserId: owner.userId,
+      contentType: "singleDoc",
+      parentId: null,
+    });
+
+    await expect(
+      createImageContent({
+        loggedInUserId: owner.userId,
+        parentId: docId,
+        name: "child.png",
+        mimeType: "image/png",
+        sizeBytes: 1,
+        imageWidth: 1,
+        imageHeight: 1,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects when parent is an image (images are leaves, not containers)", async () => {
+    const owner = await createTestUser();
+    const { contentId: parentImageId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "parent.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await expect(
+      createImageContent({
+        loggedInUserId: owner.userId,
+        parentId: parentImageId,
+        name: "child.png",
+        mimeType: "image/png",
+        sizeBytes: 1,
+        imageWidth: 1,
+        imageHeight: 1,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects when parent belongs to a different owner", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const { contentId: theirFolder } = await createContent({
+      loggedInUserId: stranger.userId,
+      contentType: "folder",
+      parentId: null,
+    });
+
+    await expect(
+      createImageContent({
+        loggedInUserId: owner.userId,
+        parentId: theirFolder,
+        name: "trespass.png",
+        mimeType: "image/png",
+        sizeBytes: 1,
+        imageWidth: 1,
+        imageHeight: 1,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("setImageStorageKey", () => {
+  test("updates the storage key for the owner's image", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await setImageStorageKey({
+      contentId,
+      ownerId: owner.userId,
+      storageKey: "images/abc.png",
+    });
+
+    const row = await getContent(contentId);
+    expect(row.storageKey).toBe("images/abc.png");
+  });
+
+  test("refuses to update another user's image", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await expect(
+      setImageStorageKey({
+        contentId,
+        ownerId: stranger.userId,
+        storageKey: "evil",
+      }),
+    ).rejects.toThrow();
+
+    const row = await getContent(contentId);
+    expect(row.storageKey).toBeNull();
+  });
+});
+
+describe("deleteImageContent", () => {
+  test("deletes the owner's image row", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await deleteImageContent({ contentId, ownerId: owner.userId });
+
+    const row = await prisma.content.findUnique({ where: { id: contentId } });
+    expect(row).toBeNull();
+  });
+
+  test("refuses to delete another user's image", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await expect(
+      deleteImageContent({ contentId, ownerId: stranger.userId }),
+    ).rejects.toThrow();
+
+    const row = await prisma.content.findUnique({ where: { id: contentId } });
+    expect(row).not.toBeNull();
+  });
+});
+
+describe("findViewableImage", () => {
+  async function makeReadyImage(ownerId: Uint8Array) {
+    const { contentId } = await createImageContent({
+      loggedInUserId: ownerId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 42,
+      imageWidth: 4,
+      imageHeight: 4,
+    });
+    await setImageStorageKey({
+      contentId,
+      ownerId,
+      storageKey: "images/x.png",
+    });
+    return contentId;
+  }
+
+  test("returns serving metadata when the owner views their ready image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+
+    const result = await findViewableImage({
+      contentId,
+      loggedInUserId: owner.userId,
+    });
+    expect(result).toEqual({
+      storageKey: "images/x.png",
+      mimeType: "image/png",
+      sizeBytes: 42n,
+    });
+  });
+
+  test("returns null when a stranger views a private image", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+
+    expect(
+      await findViewableImage({
+        contentId,
+        loggedInUserId: stranger.userId,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for an anonymous viewer on a private image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+
+    expect(await findViewableImage({ contentId })).toBeNull();
+  });
+
+  test("returns metadata for an anonymous viewer on a public image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { visibility: "public", isPublic: true },
+    });
+
+    const result = await findViewableImage({ contentId });
+    expect(result?.storageKey).toBe("images/x.png");
+  });
+
+  test("returns null when the row has no storage key yet", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+    // Note: no setImageStorageKey — simulates the brief window between row
+    // insert and storage PUT.
+
+    expect(
+      await findViewableImage({
+        contentId,
+        loggedInUserId: owner.userId,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when the content is not type=image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { type: "folder" },
+    });
+
+    expect(
+      await findViewableImage({
+        contentId,
+        loggedInUserId: owner.userId,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when the content has been soft-deleted", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeReadyImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { isDeletedOn: new Date() },
+    });
+
+    expect(
+      await findViewableImage({
+        contentId,
+        loggedInUserId: owner.userId,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/media/imageContent.ts
+++ b/apps/api/src/media/imageContent.ts
@@ -41,8 +41,14 @@ export async function createImageContent({
   imageHeight: number;
 }) {
   const ownerId = loggedInUserId;
-  const { sortIndex, isPublic, licenseCode, sharedWith, courseRootId } =
-    await prepareNewChild({ ownerId, parentId });
+  const {
+    sortIndex,
+    isPublic,
+    visibility,
+    licenseCode,
+    sharedWith,
+    courseRootId,
+  } = await prepareNewChild({ ownerId, parentId });
 
   const content = await prisma.content.create({
     data: {
@@ -51,7 +57,7 @@ export async function createImageContent({
       parentId,
       name,
       isPublic,
-      visibility: isPublic ? "public" : "private",
+      visibility,
       licenseCode,
       sortIndex,
       courseRootId,

--- a/apps/api/src/media/imageContent.ts
+++ b/apps/api/src/media/imageContent.ts
@@ -1,0 +1,145 @@
+import { prisma } from "../model";
+import { prepareNewChild } from "../content-tree";
+import { filterViewableContent } from "../utils/permissions";
+
+/**
+ * Whether a user is in the early-access cohort for image uploads. The image
+ * feature is gated while it's experimental — see
+ * `apps/api/scripts/enable-image-upload.ts` for the admin grant.
+ */
+export async function canUserUploadImages(
+  userId: Uint8Array,
+): Promise<boolean> {
+  const row = await prisma.users.findUnique({
+    where: { userId },
+    select: { canUploadImages: true },
+  });
+  return row?.canUploadImages ?? false;
+}
+
+/**
+ * Creates a new image content row in `parentId` of `loggedInUserId`'s tree.
+ * Inherits visibility / share / license / course context from the parent via
+ * `prepareNewChild`. The id is auto-generated; the storage key is set
+ * later by `setImageStorageKey` once the bytes land in storage.
+ */
+export async function createImageContent({
+  loggedInUserId,
+  parentId,
+  name,
+  mimeType,
+  sizeBytes,
+  imageWidth,
+  imageHeight,
+}: {
+  loggedInUserId: Uint8Array;
+  parentId: Uint8Array | null;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+  imageWidth: number;
+  imageHeight: number;
+}) {
+  const ownerId = loggedInUserId;
+  const { sortIndex, isPublic, licenseCode, sharedWith, courseRootId } =
+    await prepareNewChild({ ownerId, parentId });
+
+  const content = await prisma.content.create({
+    data: {
+      ownerId,
+      type: "image",
+      parentId,
+      name,
+      isPublic,
+      visibility: isPublic ? "public" : "private",
+      licenseCode,
+      sortIndex,
+      courseRootId,
+      mimeType,
+      sizeBytes: BigInt(sizeBytes),
+      imageWidth,
+      imageHeight,
+      sharedWith: {
+        createMany: { data: sharedWith.map((userId) => ({ userId })) },
+      },
+    },
+  });
+
+  return {
+    contentId: content.id,
+    name: content.name,
+    contentType: content.type,
+  };
+}
+
+/**
+ * Records the opaque storage key for an image row. The key is whatever the
+ * storage adapter (currently `s3.ts`) uses to address the bytes — this layer
+ * does not care.
+ */
+export async function setImageStorageKey({
+  contentId,
+  ownerId,
+  storageKey,
+}: {
+  contentId: Uint8Array;
+  ownerId: Uint8Array;
+  storageKey: string;
+}) {
+  await prisma.content.update({
+    where: { id: contentId, ownerId, type: "image" },
+    data: { storageKey },
+  });
+}
+
+export async function deleteImageContent({
+  contentId,
+  ownerId,
+}: {
+  contentId: Uint8Array;
+  ownerId: Uint8Array;
+}) {
+  await prisma.content.delete({
+    where: { id: contentId, ownerId, type: "image" },
+  });
+}
+
+/**
+ * Returns the image row's serving metadata if the caller may view it and the
+ * bytes are ready (storage key present). Returns null in every other case —
+ * row missing, wrong type, soft-deleted, not viewable, or not yet uploaded.
+ *
+ * Owns the full read-side gate so callers don't reimplement it.
+ */
+export async function findViewableImage({
+  contentId,
+  loggedInUserId,
+}: {
+  contentId: Uint8Array;
+  loggedInUserId?: Uint8Array;
+}): Promise<{
+  storageKey: string;
+  mimeType: string;
+  sizeBytes: bigint | null;
+} | null> {
+  const row = await prisma.content.findFirst({
+    where: {
+      id: contentId,
+      type: "image",
+      ...filterViewableContent(loggedInUserId),
+    },
+    select: {
+      mimeType: true,
+      storageKey: true,
+      sizeBytes: true,
+    },
+  });
+
+  if (!row || !row.storageKey || !row.mimeType) return null;
+
+  return {
+    storageKey: row.storageKey,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+  };
+}

--- a/apps/api/src/media/index.ts
+++ b/apps/api/src/media/index.ts
@@ -1,0 +1,13 @@
+// `media` — image uploads, storage, and serving.
+//
+//   config       — env validation (`loadMediaConfig`)
+//   imageContent — DB layer (the only file here that touches prisma)
+//   s3           — storage adapter
+//   upload       — POST /api/media/image
+//   serve        — GET /api/media/:contentId
+//   router       — wires the handlers above
+//
+// Import from here, not from a source file.
+
+export { loadMediaConfig } from "./config";
+export { mediaRouter } from "./router";

--- a/apps/api/src/media/router.ts
+++ b/apps/api/src/media/router.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import { handleServeImage } from "./serve";
+import {
+  handleUploadError,
+  handleUploadImage,
+  uploadImageMulter,
+} from "./upload";
+
+export const mediaRouter = express.Router();
+
+mediaRouter.post(
+  "/image",
+  uploadImageMulter.single("file"),
+  handleUploadError,
+  handleUploadImage,
+);
+
+mediaRouter.get("/:contentId", handleServeImage);

--- a/apps/api/src/media/s3.ts
+++ b/apps/api/src/media/s3.ts
@@ -1,0 +1,65 @@
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import type { Readable } from "stream";
+import { loadMediaConfig } from "./config";
+
+const config = loadMediaConfig();
+const client =
+  config.mode === "aws"
+    ? new S3Client({ region: config.region })
+    : new S3Client({
+        region: config.region,
+        endpoint: config.endpoint,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: config.accessKeyId,
+          secretAccessKey: config.secretAccessKey,
+        },
+      });
+
+export async function putImage({
+  key,
+  body,
+  contentType,
+}: {
+  key: string;
+  body: Buffer;
+  contentType: string;
+}) {
+  await client.send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    }),
+  );
+}
+
+export async function getImageStream(key: string): Promise<{
+  body: Readable;
+  contentType?: string;
+  contentLength?: number;
+}> {
+  const response = await client.send(
+    new GetObjectCommand({ Bucket: config.bucket, Key: key }),
+  );
+  if (!response.Body) {
+    throw new Error(`Empty body for ${key}`);
+  }
+  return {
+    body: response.Body as Readable,
+    contentType: response.ContentType,
+    contentLength: response.ContentLength,
+  };
+}
+
+export async function deleteImage(key: string) {
+  await client.send(
+    new DeleteObjectCommand({ Bucket: config.bucket, Key: key }),
+  );
+}

--- a/apps/api/src/media/serve.schema.ts
+++ b/apps/api/src/media/serve.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { uuidSchema } from "../schemas/uuid";
+
+// Accepts either ":contentId" or ":contentId.ext" — the optional extension is
+// only for nicer URLs; we ignore it and serve based on stored mimeType.
+const idAndExt = /^([0-9A-Za-z_-]{22,})(?:\.[A-Za-z0-9]+)?$/;
+
+export const serveImageParamSchema = z.object({
+  contentId: z
+    .string()
+    .transform((val) => val.match(idAndExt)?.[1] ?? val)
+    .pipe(uuidSchema),
+});

--- a/apps/api/src/media/serve.test.ts
+++ b/apps/api/src/media/serve.test.ts
@@ -1,0 +1,287 @@
+import { PassThrough } from "stream";
+import type { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Replace the s3 module so importing serve.ts does not trigger loadMediaConfig
+// at module load time (it would demand real env vars). Tests drive the mock
+// directly via the imported module reference below.
+vi.mock("./s3", () => ({
+  getImageStream: vi.fn(),
+  putImage: vi.fn(),
+  deleteImage: vi.fn(),
+}));
+
+import { prisma } from "../model";
+import { fromUUID } from "../utils/uuid";
+import { createTestUser } from "../test/utils";
+import { createImageContent, setImageStorageKey } from "./imageContent";
+import * as s3 from "./s3";
+import { handleServeImage } from "./serve";
+
+type MockRes = PassThrough & {
+  statusCode: number;
+  headers: Record<string, string | number>;
+  jsonBody: unknown;
+  headersSent: boolean;
+  status: (code: number) => MockRes;
+  json: (body: unknown) => MockRes;
+  setHeader: (name: string, value: string | number) => MockRes;
+};
+
+function mockRes(): MockRes {
+  const res = new PassThrough() as MockRes;
+  res.statusCode = 200;
+  res.headers = {};
+  res.jsonBody = undefined;
+  res.headersSent = false;
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.jsonBody = body;
+    return res;
+  };
+  res.setHeader = (name, value) => {
+    res.headers[name] = value;
+    return res;
+  };
+  return res;
+}
+
+function mockReq({
+  contentId,
+  userId,
+}: {
+  contentId: Uint8Array;
+  userId?: Uint8Array;
+}) {
+  return {
+    params: { contentId: fromUUID(contentId) },
+    user: userId ? { userId } : undefined,
+  } as unknown as Request;
+}
+
+async function call(req: Request, res: MockRes) {
+  await handleServeImage(req, res as unknown as Response);
+  // Drain the piped body so 'finish' fires deterministically.
+  await new Promise<void>((resolve) => {
+    if (res.writableEnded) resolve();
+    else res.on("finish", () => resolve());
+    // For 404 paths the response is closed via .json() — no pipe attached.
+    // Resolve on next tick if no data path is active.
+    setImmediate(() => resolve());
+  });
+}
+
+function mockBody(bytes: Buffer = Buffer.from([1, 2, 3])) {
+  const body = new PassThrough();
+  setImmediate(() => body.end(bytes));
+  return body;
+}
+
+async function makeImage(
+  ownerId: Uint8Array,
+  opts: { withStorageKey?: boolean } = {},
+) {
+  const withStorageKey = opts.withStorageKey ?? true;
+  const { contentId } = await createImageContent({
+    loggedInUserId: ownerId,
+    parentId: null,
+    name: "img.png",
+    mimeType: "image/png",
+    sizeBytes: 7,
+    imageWidth: 4,
+    imageHeight: 4,
+  });
+  if (withStorageKey) {
+    await setImageStorageKey({
+      contentId,
+      ownerId,
+      storageKey: `images/${fromUUID(contentId)}.png`,
+    });
+  }
+  return contentId;
+}
+
+describe("handleServeImage", () => {
+  beforeEach(() => {
+    vi.mocked(s3.getImageStream).mockReset();
+  });
+  afterEach(() => {
+    vi.mocked(s3.getImageStream).mockReset();
+  });
+
+  test("owner can fetch their own private image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    vi.mocked(s3.getImageStream).mockResolvedValue({
+      body: mockBody(),
+      contentType: "image/png",
+      contentLength: 7,
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Content-Type"]).toBe("image/png");
+    expect(res.headers["Content-Length"]).toBe(7);
+    expect(res.headers["Cache-Control"]).toBe("private, max-age=300");
+  });
+
+  test("falls back to sizeBytes for Content-Length when stream lacks it", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    vi.mocked(s3.getImageStream).mockResolvedValue({
+      body: mockBody(),
+      contentType: "image/png",
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Content-Length"]).toBe("7");
+  });
+
+  test("stranger gets 404 on a private image", async () => {
+    const owner = await createTestUser();
+    const stranger = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: stranger.userId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.jsonBody).toEqual({ error: "Not found" });
+    expect(vi.mocked(s3.getImageStream)).not.toHaveBeenCalled();
+  });
+
+  test("anonymous request gets 404 on a private image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+
+    const res = mockRes();
+    await call(mockReq({ contentId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(vi.mocked(s3.getImageStream)).not.toHaveBeenCalled();
+  });
+
+  test("anonymous request can fetch a public image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { visibility: "public", isPublic: true },
+    });
+    vi.mocked(s3.getImageStream).mockResolvedValue({
+      body: mockBody(),
+      contentType: "image/png",
+      contentLength: 7,
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId }), res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("anonymous request can fetch an unlisted image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { visibility: "unlisted" },
+    });
+    vi.mocked(s3.getImageStream).mockResolvedValue({
+      body: mockBody(),
+      contentType: "image/png",
+      contentLength: 7,
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId }), res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("shared-with user can fetch a private image", async () => {
+    const owner = await createTestUser();
+    const friend = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    await prisma.contentShares.create({
+      data: { contentId, userId: friend.userId },
+    });
+    vi.mocked(s3.getImageStream).mockResolvedValue({
+      body: mockBody(),
+      contentType: "image/png",
+      contentLength: 7,
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: friend.userId }), res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("404 when the image has no storage key yet", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId, { withStorageKey: false });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(vi.mocked(s3.getImageStream)).not.toHaveBeenCalled();
+  });
+
+  test("404 when the content is not type=image", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { type: "folder" },
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(vi.mocked(s3.getImageStream)).not.toHaveBeenCalled();
+  });
+
+  test("404 when the content has been soft-deleted", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    await prisma.content.update({
+      where: { id: contentId },
+      data: { isDeletedOn: new Date() },
+    });
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  test("404 when the storage object is missing (NoSuchKey)", async () => {
+    const owner = await createTestUser();
+    const contentId = await makeImage(owner.userId);
+    // Construct a NoSuchKey error the way @aws-sdk/client-s3 raises it.
+    const { NoSuchKey } = await import("@aws-sdk/client-s3");
+    const noSuchKey = new NoSuchKey({
+      $metadata: {},
+      message: "The specified key does not exist.",
+    });
+    vi.mocked(s3.getImageStream).mockRejectedValue(noSuchKey);
+
+    const res = mockRes();
+    await call(mockReq({ contentId, userId: owner.userId }), res);
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.jsonBody).toEqual({ error: "Not found" });
+  });
+});

--- a/apps/api/src/media/serve.ts
+++ b/apps/api/src/media/serve.ts
@@ -1,0 +1,60 @@
+import type { Request, Response } from "express";
+import { NoSuchKey } from "@aws-sdk/client-s3";
+import { StatusCodes } from "http-status-codes";
+import { handleErrors } from "../errors/routeErrorHandler";
+import { findViewableImage } from "./imageContent";
+import { getImageStream } from "./s3";
+import { serveImageParamSchema } from "./serve.schema";
+
+export async function handleServeImage(req: Request, res: Response) {
+  try {
+    const { contentId } = serveImageParamSchema.parse(req.params);
+    const image = await findViewableImage({
+      contentId,
+      loggedInUserId: req.user?.userId,
+    });
+
+    if (!image) {
+      res.status(StatusCodes.NOT_FOUND).json({ error: "Not found" });
+      return;
+    }
+
+    let body, contentType, contentLength;
+    try {
+      ({ body, contentType, contentLength } = await getImageStream(
+        image.storageKey,
+      ));
+    } catch (err) {
+      // The row claims the object is ready, but storage disagrees. Surface
+      // this as 404 (matches what the client sees for a missing image) rather
+      // than 500.
+      if (err instanceof NoSuchKey) {
+        res.status(StatusCodes.NOT_FOUND).json({ error: "Not found" });
+        return;
+      }
+      throw err;
+    }
+
+    res.setHeader("Content-Type", contentType ?? image.mimeType);
+    if (contentLength) {
+      res.setHeader("Content-Length", contentLength);
+    } else if (image.sizeBytes) {
+      res.setHeader("Content-Length", image.sizeBytes.toString());
+    }
+    res.setHeader("Cache-Control", "private, max-age=300");
+
+    body.on("error", (err) => {
+      console.error("Media stream error", err);
+      if (!res.headersSent) {
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ error: "Stream error" });
+      } else {
+        res.destroy(err);
+      }
+    });
+    body.pipe(res);
+  } catch (e) {
+    handleErrors(res, e);
+  }
+}

--- a/apps/api/src/media/upload.schema.ts
+++ b/apps/api/src/media/upload.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { uuidSchema } from "../schemas/uuid";
+
+export const ALLOWED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_IMAGE_DIMENSION = 2560;
+
+// Multipart form fields arrive as strings. Treat empty / missing as "root".
+const optionalParentId = z.preprocess(
+  (v) => (v === "" || v === undefined || v === null ? null : v),
+  z.union([uuidSchema, z.null()]),
+);
+
+export const uploadImageBodySchema = z.object({
+  parentId: optionalParentId,
+  name: z.string().optional(),
+});
+
+export type UploadImageBody = z.infer<typeof uploadImageBodySchema>;

--- a/apps/api/src/media/upload.test.ts
+++ b/apps/api/src/media/upload.test.ts
@@ -1,0 +1,366 @@
+import type { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Replace the s3 module so importing upload.ts does not trigger
+// loadMediaConfig() at module load time (it would demand real env vars).
+vi.mock("./s3", () => ({
+  getImageStream: vi.fn(),
+  putImage: vi.fn(),
+  deleteImage: vi.fn(),
+}));
+// Mock image-size so dimension-handling branches are deterministic.
+vi.mock("image-size", () => ({ imageSize: vi.fn() }));
+
+import { imageSize } from "image-size";
+// `imageSize` has a sync overload `(input) => ISizeCalculationResult` and a
+// callback overload that returns `void`. vi.mocked resolves to the callback
+// overload, which makes mockReturnValue think it takes `void`. Pin the sync
+// overload here so test mocks line up with the call site in upload.ts.
+type SyncImageSize = (input: Uint8Array) => {
+  width?: number;
+  height?: number;
+  type?: string;
+};
+const mockedImageSize = imageSize as unknown as SyncImageSize;
+import { prisma } from "../model";
+import { createTestUser } from "../test/utils";
+import { toUUID } from "../utils/uuid";
+
+// Test users default to canUploadImages=false (matches real users). Use this
+// helper everywhere we want to test the happy path; bypass it to test the gate.
+async function createUploader() {
+  const user = await createTestUser();
+  await prisma.users.update({
+    where: { userId: user.userId },
+    data: { canUploadImages: true },
+  });
+  return user;
+}
+import * as s3 from "./s3";
+import { handleUploadImage } from "./upload";
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_DIMENSION,
+  uploadImageBodySchema,
+} from "./upload.schema";
+
+function mockReq({
+  user,
+  file,
+  body,
+}: {
+  user?: { userId: Uint8Array };
+  file?: Partial<Express.Multer.File>;
+  body?: Record<string, unknown>;
+}): Request {
+  return {
+    user,
+    file,
+    body: body ?? {},
+  } as unknown as Request;
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    jsonBody: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.jsonBody = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+function fileFor(buffer: Buffer): Partial<Express.Multer.File> {
+  return {
+    buffer,
+    size: buffer.byteLength,
+    mimetype: "image/png",
+    originalname: "donut.png",
+  };
+}
+
+const FAKE_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+describe("uploadImageBodySchema", () => {
+  test("accepts an empty parentId as null (upload to root)", () => {
+    const parsed = uploadImageBodySchema.parse({ parentId: "" });
+    expect(parsed.parentId).toBeNull();
+  });
+
+  test("accepts a missing parentId as null", () => {
+    const parsed = uploadImageBodySchema.parse({});
+    expect(parsed.parentId).toBeNull();
+  });
+
+  test("rejects a malformed parentId string", () => {
+    expect(() =>
+      uploadImageBodySchema.parse({ parentId: "not-a-uuid" }),
+    ).toThrow();
+  });
+
+  test("accepts an optional name", () => {
+    const parsed = uploadImageBodySchema.parse({ name: "donut" });
+    expect(parsed.name).toBe("donut");
+  });
+});
+
+describe("upload constants", () => {
+  test("MIME list matches RFC scope", () => {
+    expect([...ALLOWED_IMAGE_MIME_TYPES]).toEqual([
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "image/gif",
+    ]);
+  });
+
+  test("size and dimension caps match RFC", () => {
+    expect(MAX_IMAGE_BYTES).toBe(10 * 1024 * 1024);
+    expect(MAX_IMAGE_DIMENSION).toBe(2560);
+  });
+});
+
+describe("handleUploadImage", () => {
+  beforeEach(() => {
+    vi.mocked(s3.putImage).mockReset();
+    vi.mocked(s3.deleteImage).mockReset();
+    vi.mocked(mockedImageSize).mockReset();
+    vi.mocked(mockedImageSize).mockReturnValue({
+      width: 100,
+      height: 80,
+      type: "png",
+    });
+  });
+  afterEach(() => {
+    vi.mocked(s3.putImage).mockReset();
+    vi.mocked(s3.deleteImage).mockReset();
+    vi.mocked(mockedImageSize).mockReset();
+  });
+
+  test("403 when no user is on the request", async () => {
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({ file: fileFor(FAKE_PNG) }),
+      res as unknown as Response,
+    );
+    expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+  });
+
+  test("403 when the user is not in the image-upload early-access cohort", async () => {
+    const user = await createTestUser();
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+    expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+    expect((res.jsonBody as { code?: string }).code).toBe(
+      "IMAGE_UPLOAD_NOT_ENABLED",
+    );
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+    const orphans = await prisma.content.count({
+      where: { ownerId: user.userId, type: "image" },
+    });
+    expect(orphans).toBe(0);
+  });
+
+  test("415 when no file is on the request", async () => {
+    const user = await createUploader();
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({ user: { userId: user.userId } }),
+      res as unknown as Response,
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+  });
+
+  test("415 when image-size cannot read dimensions", async () => {
+    const user = await createUploader();
+    vi.mocked(mockedImageSize).mockReturnValue({ type: "png" });
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+    const orphans = await prisma.content.count({
+      where: { ownerId: user.userId, type: "image" },
+    });
+    expect(orphans).toBe(0);
+  });
+
+  test("415 when client-claimed MIME does not match detected format", async () => {
+    const user = await createUploader();
+    // Client says PNG, but the bytes (per image-size) are actually JPEG.
+    vi.mocked(mockedImageSize).mockReturnValue({
+      width: 100,
+      height: 80,
+      type: "jpg",
+    });
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+    const orphans = await prisma.content.count({
+      where: { ownerId: user.userId, type: "image" },
+    });
+    expect(orphans).toBe(0);
+  });
+
+  test("415 when detected format is not in the allowlist", async () => {
+    const user = await createUploader();
+    vi.mocked(mockedImageSize).mockReturnValue({
+      width: 100,
+      height: 80,
+      type: "bmp",
+    });
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+  });
+
+  test("422 when image dimensions exceed the cap", async () => {
+    const user = await createUploader();
+    vi.mocked(mockedImageSize).mockReturnValue({
+      width: MAX_IMAGE_DIMENSION + 1,
+      height: 100,
+      type: "png",
+    });
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+    expect(vi.mocked(s3.putImage)).not.toHaveBeenCalled();
+    const orphans = await prisma.content.count({
+      where: { ownerId: user.userId, type: "image" },
+    });
+    expect(orphans).toBe(0);
+  });
+
+  test("happy path: creates row, uploads to storage, patches storage key, returns 201", async () => {
+    const user = await createUploader();
+    vi.mocked(s3.putImage).mockResolvedValue(undefined);
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    const body = res.jsonBody as { contentId: string; name: string };
+    expect(body.name).toBe("donut.png");
+    expect(body.contentId).toMatch(/^[0-9A-Za-z_-]{22}$/);
+
+    expect(vi.mocked(s3.putImage)).toHaveBeenCalledTimes(1);
+    const putArgs = vi.mocked(s3.putImage).mock.calls[0][0];
+    expect(putArgs.contentType).toBe("image/png");
+    expect(putArgs.body).toBe(FAKE_PNG);
+    expect(putArgs.key).toBe(`images/${body.contentId}.png`);
+
+    const row = await prisma.content.findUniqueOrThrow({
+      where: { id: toUUID(body.contentId) },
+      select: {
+        type: true,
+        mimeType: true,
+        storageKey: true,
+        imageWidth: true,
+        imageHeight: true,
+        sizeBytes: true,
+        ownerId: true,
+      },
+    });
+    expect(row.type).toBe("image");
+    expect(row.mimeType).toBe("image/png");
+    expect(row.storageKey).toBe(`images/${body.contentId}.png`);
+    expect(row.imageWidth).toBe(100);
+    expect(row.imageHeight).toBe(80);
+    expect(row.sizeBytes).toBe(BigInt(FAKE_PNG.byteLength));
+    expect(row.ownerId).toEqual(user.userId);
+  });
+
+  test("uses a request-supplied name when present", async () => {
+    const user = await createUploader();
+    vi.mocked(s3.putImage).mockResolvedValue(undefined);
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+        body: { name: "Lemon" },
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect((res.jsonBody as { name: string }).name).toBe("Lemon");
+  });
+
+  test("rolls back the DB row and best-effort deletes S3 when putImage throws", async () => {
+    const user = await createUploader();
+    vi.mocked(s3.putImage).mockRejectedValue(new Error("S3 down"));
+
+    const res = mockRes();
+    await handleUploadImage(
+      mockReq({
+        user: { userId: user.userId },
+        file: fileFor(FAKE_PNG),
+      }),
+      res as unknown as Response,
+    );
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    const orphans = await prisma.content.count({
+      where: { ownerId: user.userId, type: "image" },
+    });
+    expect(orphans).toBe(0);
+    expect(vi.mocked(s3.deleteImage)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/media/upload.ts
+++ b/apps/api/src/media/upload.ts
@@ -1,0 +1,176 @@
+import type { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import multer from "multer";
+import { imageSize } from "image-size";
+import { handleErrors } from "../errors/routeErrorHandler";
+import { InvalidRequestError } from "../utils/error";
+import { fromUUID } from "../utils/uuid";
+import {
+  canUserUploadImages,
+  createImageContent,
+  deleteImageContent,
+  setImageStorageKey,
+} from "./imageContent";
+import { deleteImage, putImage } from "./s3";
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_DIMENSION,
+  uploadImageBodySchema,
+} from "./upload.schema";
+
+// Canonical descriptors keyed by `image-size`'s detected format identifier.
+// This is the source of truth — never trust `file.mimetype` (client-supplied)
+// for what the bytes actually are.
+const FORMAT_INFO: Record<string, { mime: string; ext: string }> = {
+  jpg: { mime: "image/jpeg", ext: "jpg" },
+  png: { mime: "image/png", ext: "png" },
+  webp: { mime: "image/webp", ext: "webp" },
+  gif: { mime: "image/gif", ext: "gif" },
+};
+
+export const uploadImageMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_IMAGE_BYTES, files: 1 },
+  fileFilter: (_req, file, cb) => {
+    if (
+      (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(file.mimetype)
+    ) {
+      cb(null, true);
+    } else {
+      cb(null, false);
+    }
+  },
+});
+
+export async function handleUploadImage(req: Request, res: Response) {
+  if (!req.user) {
+    res.status(StatusCodes.FORBIDDEN).json({ error: "Must be logged in" });
+    return;
+  }
+  if (!(await canUserUploadImages(req.user.userId))) {
+    res.status(StatusCodes.FORBIDDEN).json({
+      error: "Image uploads are not enabled for this account",
+      code: "IMAGE_UPLOAD_NOT_ENABLED",
+    });
+    return;
+  }
+  const file = req.file;
+  if (!file) {
+    res
+      .status(StatusCodes.UNSUPPORTED_MEDIA_TYPE)
+      .json({ error: "Unsupported or missing image" });
+    return;
+  }
+  try {
+    const body = uploadImageBodySchema.parse(req.body);
+
+    const dims = imageSize(file.buffer);
+    if (!dims.width || !dims.height) {
+      throw new InvalidRequestError(
+        "Could not read image dimensions",
+        StatusCodes.UNSUPPORTED_MEDIA_TYPE,
+      );
+    }
+    if (dims.width > MAX_IMAGE_DIMENSION || dims.height > MAX_IMAGE_DIMENSION) {
+      throw new InvalidRequestError(
+        `Image too large (max ${MAX_IMAGE_DIMENSION}px per side)`,
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    const format = dims.type && FORMAT_INFO[dims.type];
+    if (!format) {
+      throw new InvalidRequestError(
+        "Unsupported image format",
+        StatusCodes.UNSUPPORTED_MEDIA_TYPE,
+      );
+    }
+    if (file.mimetype !== format.mime) {
+      // Client-claimed MIME disagrees with what the bytes actually are.
+      throw new InvalidRequestError(
+        "Image MIME type does not match the file contents",
+        StatusCodes.UNSUPPORTED_MEDIA_TYPE,
+      );
+    }
+
+    const fallbackName =
+      file.originalname && file.originalname.trim()
+        ? file.originalname.trim()
+        : "Untitled Image";
+    const name = body.name?.trim() || fallbackName;
+
+    // DB row first (id auto-generated). On Prisma 6 + MySQL binary PKs the
+    // post-INSERT read fails when we pass an explicit id, so we let the DB
+    // assign one and patch in the storage key after the upload succeeds.
+    const { contentId, name: persistedName } = await createImageContent({
+      loggedInUserId: req.user.userId,
+      parentId: body.parentId,
+      name,
+      mimeType: format.mime,
+      sizeBytes: file.size,
+      imageWidth: dims.width,
+      imageHeight: dims.height,
+    });
+
+    const storageKey = `images/${fromUUID(contentId)}.${format.ext}`;
+
+    try {
+      await putImage({
+        key: storageKey,
+        body: file.buffer,
+        contentType: format.mime,
+      });
+      await setImageStorageKey({
+        contentId,
+        ownerId: req.user.userId,
+        storageKey,
+      });
+    } catch (storageErr) {
+      // Roll back: remove the row (and the storage object if the put succeeded).
+      try {
+        await deleteImage(storageKey);
+      } catch {
+        // ignore
+      }
+      try {
+        await deleteImageContent({
+          contentId,
+          ownerId: req.user.userId,
+        });
+      } catch {
+        // ignore
+      }
+      throw storageErr;
+    }
+
+    res.status(StatusCodes.CREATED).json({
+      contentId: fromUUID(contentId),
+      name: persistedName,
+    });
+  } catch (e) {
+    handleErrors(res, e);
+  }
+}
+
+export function handleUploadError(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: (err?: unknown) => void,
+) {
+  if (err instanceof multer.MulterError) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      res.status(StatusCodes.REQUEST_TOO_LONG).json({
+        error: "File too large",
+        details: `Max ${MAX_IMAGE_BYTES} bytes`,
+      });
+      return;
+    }
+    res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ error: "Upload error", details: err.message });
+    return;
+  }
+  next(err);
+}

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -1,4 +1,4 @@
-import { ContentType, Prisma, Visibility } from "@prisma/client";
+import { ContentType, Prisma } from "@prisma/client";
 import { prisma } from "../model";
 import { getLibraryAccountId } from "./curate";
 import {
@@ -14,6 +14,7 @@ import { getNextSortIndexForParent } from "../utils/sort";
 import { DateTime } from "luxon";
 import { getCidV1FromString } from "@doenet-tools/shared";
 import { getContent } from "./activity_edit_view";
+import { prepareNewChild } from "../content-tree";
 import { compileActivityFromContent } from "../utils/contentStructure";
 import { InvalidRequestError } from "../utils/error";
 import { ContentDescription } from "../types";
@@ -59,60 +60,10 @@ export async function createContent({
     ownerId = await getLibraryAccountId();
   }
 
-  const sortIndex = await getNextSortIndexForParent(ownerId, parentId);
+  const { sortIndex, isPublic, licenseCode, sharedWith, courseRootId } =
+    await prepareNewChild({ ownerId, parentId });
 
   const { defaultDoenetmlVersion } = await getDefaultDoenetmlVersion();
-
-  let isPublic = false;
-  let visibility: Visibility = "private";
-  let licenseCode = undefined;
-  let sharedWith: Uint8Array[] = [];
-  let courseRootId: Uint8Array | null = null;
-
-  // If parent isn't `null`, check if it is shared and get its license,
-  // and make sure it isn't assigned
-  if (parentId !== null) {
-    const parent = await prisma.content.findUniqueOrThrow({
-      where: {
-        id: parentId,
-        type: { not: "singleDoc" },
-        isDeletedOn: null,
-        ownerId,
-      },
-      select: {
-        isPublic: true,
-        visibility: true,
-        licenseCode: true,
-        sharedWith: { select: { userId: true } },
-        isAssignmentRoot: true,
-        courseRootId: true,
-        parent: { select: { isAssignmentRoot: true } },
-      },
-    });
-
-    if (parent.isAssignmentRoot || parent.parent?.isAssignmentRoot) {
-      throw new InvalidRequestError(
-        "Cannot add content to an assigned activity",
-      );
-    }
-
-    courseRootId = parent.courseRootId;
-
-    if (parent.visibility !== "private") {
-      visibility = parent.visibility;
-      isPublic = parent.visibility === "public";
-      if (parent.licenseCode) {
-        licenseCode = parent.licenseCode;
-      }
-    }
-
-    if (parent.sharedWith.length > 0) {
-      sharedWith = parent.sharedWith.map((cs) => cs.userId);
-      if (parent.licenseCode) {
-        licenseCode = parent.licenseCode;
-      }
-    }
-  }
 
   if (!name) {
     switch (contentType) {
@@ -132,6 +83,13 @@ export async function createContent({
         name = "Untitled Folder";
         break;
       }
+      case "image": {
+        // Images are created via the media module's POST /api/media/image
+        // endpoint (see src/media/imageContent.ts), not this path.
+        throw new InvalidRequestError(
+          "Use the image upload endpoint to create images",
+        );
+      }
     }
   }
 
@@ -142,7 +100,6 @@ export async function createContent({
       parentId,
       name,
       isPublic,
-      visibility,
       licenseCode,
       sortIndex,
       courseRootId,

--- a/apps/api/src/query/activity.ts
+++ b/apps/api/src/query/activity.ts
@@ -60,8 +60,14 @@ export async function createContent({
     ownerId = await getLibraryAccountId();
   }
 
-  const { sortIndex, isPublic, licenseCode, sharedWith, courseRootId } =
-    await prepareNewChild({ ownerId, parentId });
+  const {
+    sortIndex,
+    isPublic,
+    visibility,
+    licenseCode,
+    sharedWith,
+    courseRootId,
+  } = await prepareNewChild({ ownerId, parentId });
 
   const { defaultDoenetmlVersion } = await getDefaultDoenetmlVersion();
 
@@ -100,6 +106,7 @@ export async function createContent({
       parentId,
       name,
       isPublic,
+      visibility,
       licenseCode,
       sortIndex,
       courseRootId,

--- a/apps/api/src/query/activity_edit_view.ts
+++ b/apps/api/src/query/activity_edit_view.ts
@@ -182,7 +182,7 @@ export async function getContent({
     }
 
     for (const child of children) {
-      if (child.type !== "singleDoc") {
+      if (child.type !== "singleDoc" && child.type !== "image") {
         child.children = findDescendants(child.contentId);
       }
     }
@@ -190,7 +190,7 @@ export async function getContent({
     return children;
   }
 
-  if (activity.type !== "singleDoc") {
+  if (activity.type !== "singleDoc" && activity.type !== "image") {
     activity.children = findDescendants(activity.contentId);
   }
 

--- a/apps/api/src/query/user.ts
+++ b/apps/api/src/query/user.ts
@@ -63,7 +63,6 @@ export async function findOrCreateUser({
     isAnonymous: user.isAnonymous,
     isAuthor: user.isAuthor,
     isEditor: user.isEditor,
-    canUploadImages: user.canUploadImages,
   };
 }
 
@@ -175,7 +174,6 @@ export async function updateUser({
     isAnonymous: user.isAnonymous,
     isAuthor: user.isAuthor,
     isEditor: user.isEditor,
-    canUploadImages: user.canUploadImages,
   };
 }
 

--- a/apps/api/src/query/user.ts
+++ b/apps/api/src/query/user.ts
@@ -14,6 +14,7 @@ export async function findOrCreateUser({
   isAuthor = false,
   isAnonymous = false,
   isPremium,
+  canUploadImages = false,
 }: {
   email: string;
   firstNames: string | null;
@@ -22,6 +23,7 @@ export async function findOrCreateUser({
   isAuthor?: boolean;
   isAnonymous?: boolean;
   isPremium?: boolean;
+  canUploadImages?: boolean;
 }): Promise<UserInfoWithEmail> {
   // For now, make any non-anonymous user a premium user
   // We'll change this once we have the UI for non-premium users working
@@ -42,6 +44,7 @@ export async function findOrCreateUser({
       isAnonymous,
       isPremium,
       isAuthor,
+      canUploadImages,
     },
   });
 
@@ -60,6 +63,7 @@ export async function findOrCreateUser({
     isAnonymous: user.isAnonymous,
     isAuthor: user.isAuthor,
     isEditor: user.isEditor,
+    canUploadImages: user.canUploadImages,
   };
 }
 
@@ -89,6 +93,7 @@ export async function getMyUserInfo({
       isAnonymous: true,
       isEditor: true,
       isAuthor: true,
+      canUploadImages: true,
     },
   });
   return { user };
@@ -170,6 +175,7 @@ export async function updateUser({
     isAnonymous: user.isAnonymous,
     isAuthor: user.isAuthor,
     isEditor: user.isEditor,
+    canUploadImages: user.canUploadImages,
   };
 }
 

--- a/apps/api/src/schemas/contentSchema.ts
+++ b/apps/api/src/schemas/contentSchema.ts
@@ -11,6 +11,7 @@ export const contentTypeSchema = z.enum([
   "sequence",
   "select",
   "folder",
+  "image",
 ]);
 
 export const createContentSchema = z.object({

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -101,6 +101,7 @@ export type UserInfoWithEmail = UserInfo & {
   email: string | null;
   isAuthor?: boolean;
   isEditor?: boolean;
+  canUploadImages?: boolean;
 };
 
 export type ContentClassification = {
@@ -160,11 +161,16 @@ export type PartialContentClassification = {
   numCommunity?: number;
 };
 
-export type ContentType = "singleDoc" | "select" | "sequence" | "folder";
+export type ContentType =
+  | "singleDoc"
+  | "select"
+  | "sequence"
+  | "folder"
+  | "image";
 export function isContentType(type: unknown): type is ContentType {
   return (
     typeof type === "string" &&
-    ["singleDoc", "select", "sequence", "folder"].includes(type)
+    ["singleDoc", "select", "sequence", "folder", "image"].includes(type)
   );
 }
 
@@ -237,9 +243,17 @@ export type Folder = ContentBase & {
   children: Content[];
 };
 
+export type ImageItem = ContentBase & {
+  type: "image";
+  mimeType?: string;
+  sizeBytes?: number;
+  imageWidth?: number;
+  imageHeight?: number;
+};
+
 export type Activity = Doc | QuestionBank | ProblemSet;
 
-export type Content = Doc | QuestionBank | ProblemSet | Folder;
+export type Content = Doc | QuestionBank | ProblemSet | Folder | ImageItem;
 
 export type AssignmentInfo = {
   assignmentStatus: AssignmentStatus;

--- a/apps/api/src/utils/contentStructure.ts
+++ b/apps/api/src/utils/contentStructure.ts
@@ -538,6 +538,12 @@ export function processContent(
         ...baseContent,
       };
     }
+    case "image": {
+      return {
+        type: "image",
+        ...baseContent,
+      };
+    }
   }
 }
 
@@ -649,6 +655,9 @@ export function compileActivityFromContent(
     }
     case "folder": {
       throw Error("No folder here");
+    }
+    case "image": {
+      throw Error("No image here");
     }
   }
 }

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -1,0 +1,12 @@
+export function getEnvVar(name: string, required: true): string;
+export function getEnvVar(name: string, required?: boolean): string | undefined;
+export function getEnvVar(name: string, required = false): string | undefined {
+  const value = process.env[name]?.trim();
+  if (value) {
+    return value;
+  }
+  if (required) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return undefined;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,25 @@ services:
       timeout: 5s
       retries: 10
 
+  s3mock:
+    image: adobe/s3mock:latest
+    restart: unless-stopped
+    environment:
+      # Spring Boot properties on com.adobe.testing.s3mock.store.* — env-var
+      # form uses underscores and uppercase per Spring's relaxed binding.
+      COM_ADOBE_TESTING_S3MOCK_STORE_INITIALBUCKETS: doenet-media
+      COM_ADOBE_TESTING_S3MOCK_STORE_RETAINFILESONEXIT: "true"
+      COM_ADOBE_TESTING_S3MOCK_STORE_ROOT: /s3-data
+    ports:
+      - "${MEDIA_S3_PORT:-9090}:9090"
+    volumes:
+      - s3mock_data:/s3-data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 volumes:
   mysql_data:
+  s3mock_data:

--- a/infra/cloudformation/s3-hosted.yml
+++ b/infra/cloudformation/s3-hosted.yml
@@ -24,6 +24,11 @@ Parameters:
     Description: Service name for the site bucket (e.g., site)
     Default: site
 
+  MediaServiceName:
+    Type: String
+    Description: Service name for the media bucket (user-uploaded images)
+    Default: media
+
   LoadBalancerDnsName:
     Type: String
     Description: DNS name of the Application Load Balancer
@@ -48,6 +53,27 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+
+  # User-uploaded image storage. Private — only the API reads it server-side
+  # via SigV4. Not fronted by CloudFront so it can never accidentally serve
+  # private content to anonymous CloudFront traffic.
+  MediaBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${EnvironmentName}-${MediaServiceName}-${AWS::AccountId}-${AWS::Region}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  MediaBucketNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${EnvironmentName}/${MediaServiceName}/BucketName"
+      Type: String
+      Value: !Ref MediaBucket
+      Description: Bucket name for user-uploaded media (consumed by the API)
 
   AppOriginAccessControl:
     Type: AWS::CloudFront::OriginAccessControl
@@ -300,6 +326,10 @@ Outputs:
   SiteBucketName:
     Description: Name of the site S3 bucket
     Value: !Ref SiteBucket
+
+  MediaBucketName:
+    Description: Name of the media (user-uploads) S3 bucket
+    Value: !Ref MediaBucket
 
   WebsiteURL:
     Description: Website URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1053.0",
         "@aws-sdk/client-ses": "^3.777.0",
         "@doenet-tools/shared": "*",
         "@prisma/client": "6.4.1",
@@ -62,7 +63,9 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "http-status-codes": "^2.3.0",
+        "image-size": "^1.2.1",
         "luxon": "^3.7.1",
+        "multer": "^2.1.1",
         "multiformats": "^9.9.0",
         "nanoid": "^5.1.5",
         "passport": "^0.7.0",
@@ -80,6 +83,7 @@
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.3",
         "@types/express-session": "^1.18.2",
+        "@types/multer": "^1.4.13",
         "@types/passport": "^1.0.17",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-local": "^1.0.38",
@@ -949,6 +953,83 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -1074,6 +1155,35 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1053.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1053.0.tgz",
+      "integrity": "sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/credential-provider-node": "^3.972.44",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.15",
+        "@aws-sdk/middleware-expect-continue": "^3.972.13",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.21",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.42",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ses": {
       "version": "3.1038.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1038.0.tgz",
@@ -1126,24 +1236,31 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
-      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+      "version": "3.974.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
+      "integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.20",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.25",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1151,15 +1268,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
-      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
+      "integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1167,20 +1284,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
-      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
+      "integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1188,24 +1302,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
-      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
+      "integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-login": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/credential-provider-env": "^3.972.39",
+        "@aws-sdk/credential-provider-http": "^3.972.41",
+        "@aws-sdk/credential-provider-login": "^3.972.43",
+        "@aws-sdk/credential-provider-process": "^3.972.39",
+        "@aws-sdk/credential-provider-sso": "^3.972.43",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1213,18 +1326,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
-      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
+      "integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1232,22 +1343,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
-      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
+      "integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-ini": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.39",
+        "@aws-sdk/credential-provider-http": "^3.972.41",
+        "@aws-sdk/credential-provider-ini": "^3.972.43",
+        "@aws-sdk/credential-provider-process": "^3.972.39",
+        "@aws-sdk/credential-provider-sso": "^3.972.43",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1255,16 +1365,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
-      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
+      "integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1272,18 +1381,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
-      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
+      "integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/token-providers": "3.1038.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/token-providers": "3.1052.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1291,17 +1399,67 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
-      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
+      "integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.15.tgz",
+      "integrity": "sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz",
+      "integrity": "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.21.tgz",
+      "integrity": "sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1317,6 +1475,20 @@
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1354,24 +1526,31 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
-      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.42.tgz",
+      "integrity": "sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1398,49 +1577,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
-      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+      "version": "3.997.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
+      "integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1464,16 +1614,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
-      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+      "version": "3.996.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
+      "integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1481,17 +1630,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
-      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+      "version": "3.1052.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
+      "integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1499,24 +1647,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1589,14 +1725,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
-      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
+      "integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4872,20 +5008,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
+      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4893,15 +5022,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
+      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4909,15 +5036,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
+      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5062,14 +5187,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
+      "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5096,20 +5220,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5155,18 +5265,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
+      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5192,9 +5297,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5379,18 +5484,6 @@
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5835,6 +5928,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
@@ -6825,6 +6928,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -8924,6 +9033,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -9545,6 +9671,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -12137,9 +12278,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -12148,13 +12289,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -12164,7 +12306,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -13686,6 +13828,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -17346,6 +17503,18 @@
         "rimraf": "^6.0.1"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -17602,6 +17771,25 @@
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/multibase": {
       "version": "4.0.6",
@@ -19041,6 +19229,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -21344,6 +21541,14 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -21596,9 +21801,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -22214,6 +22419,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -23656,16 +23867,19 @@
         "node": ">=4"
       }
     },
-    "node_modules/write/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml-parser": {

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -41,11 +41,16 @@ export function isUserInfo(obj: unknown): obj is UserInfo {
   );
 }
 
-export type ContentType = "singleDoc" | "select" | "sequence" | "folder";
+export type ContentType =
+  | "singleDoc"
+  | "select"
+  | "sequence"
+  | "folder"
+  | "image";
 
 export function isContentType(type: unknown): type is ContentType {
   return (
     typeof type === "string" &&
-    ["singleDoc", "select", "sequence", "folder"].includes(type)
+    ["singleDoc", "select", "sequence", "folder", "image"].includes(type)
   );
 }

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -41,16 +41,11 @@ export function isUserInfo(obj: unknown): obj is UserInfo {
   );
 }
 
-export type ContentType =
-  | "singleDoc"
-  | "select"
-  | "sequence"
-  | "folder"
-  | "image";
+export type ContentType = "singleDoc" | "select" | "sequence" | "folder";
 
 export function isContentType(type: unknown): type is ContentType {
   return (
     typeof type === "string" &&
-    ["singleDoc", "select", "sequence", "folder", "image"].includes(type)
+    ["singleDoc", "select", "sequence", "folder"].includes(type)
   );
 }


### PR DESCRIPTION
Backend half of the image upload MVP. Parent: #2942. Closes #2943.

The frontend that uses these endpoints is in a separate PR (#2944 issue) — deploy this one first.

## Summary

- New `image` content type with nullable image-metadata columns. Three migrations: add columns, rename `s3Key` → `storageKey`, add the per-user `canUploadImages` flag.
- `POST /api/media/image` — multipart upload, MIME + size + dimension validation, S3 PUT, DB row, compensating rollback on failure. MIME is taken from `image-size` (authoritative) and verified against the client-claimed MIME.
- `GET /api/media/:contentId` — visibility-gated streaming. Owner / shared-with / public / unlisted → 200; every other case (including S3 `NoSuchKey`) → 404 with no existence oracle.
- New `media/` system module: `config.ts` (env validation at boot), `s3.ts` (storage adapter), `imageContent.ts` (DB layer), `upload.ts`, `serve.ts`, `router.ts`, `index.ts` barrel.
- New `content-tree/` system module: `prepareNewChild` shared invariants for new-child placement (ownership, container-type allowlist, soft-delete gate, assignment-root gate, visibility / share / license / course inheritance). Used by both `createContent` and `createImageContent`.
- `canUploadImages` early-access flag on users (default `false`). Gates the upload endpoint with `403 { code: "IMAGE_UPLOAD_NOT_ENABLED" }`. Admin grants via `apps/api/scripts/enable-image-upload.ts`.
- Local dev: `s3mock` service in `docker-compose.yml` with filesystem persistence; `docker compose -p doenet down -v` wipes DB + images together.
- CloudFormation: private `MediaBucket` added to `s3-hosted.yml`.

## Test plan

- [ ] `npm install` from the repo root picks up new deps (`@aws-sdk/client-s3`, `multer`, `image-size`).
- [ ] `npm run setup` (or the equivalent docker-compose lifecycle) brings up the new `s3mock` service alongside MySQL, healthchecks pass, and the `doenet-media` bucket is auto-created.
- [ ] Apply the three new migrations.
- [ ] `npx vitest run src/media/` from `apps/api/` — all suites green.
- [ ] Set a user's `canUploadImages=true` via `npx tsx scripts/enable-image-upload.ts <email>`. Verify:
  - [ ] `curl -X POST -F file=@some.png http://localhost:3001/api/media/image` with valid auth returns 201 `{ contentId, name }`.
  - [ ] Without the flag, returns 403 `{ code: "IMAGE_UPLOAD_NOT_ENABLED" }`.
  - [ ] Upload with mismatched MIME (claim `image/png`, body is JPEG) returns 415.
  - [ ] `curl http://localhost:3001/api/media/<contentId>` returns the bytes with correct headers.
  - [ ] Anonymous request for a private image returns 404; for a public image returns 200.
- [ ] On the AWS dev environment, set `MEDIA_S3_MODE=aws` + region + bucket on the API task; verify upload and serve work against real S3.

## Known follow-ups (already filed)

- #2936 EXIF metadata leakage
- #2937 S3 objects orphaned on content delete
- #2938 Upload window: listing race
- #2939 Public images served with `Cache-Control: private`
- #2940 Rejected MIME types surface as uninformative 415

🤖 Generated with [Claude Code](https://claude.com/claude-code)