### PR TITLE
[Infra] Fix: image env vars not configured correctly for dev3 and prod

### DIFF
--- a/infra/cloudformation/dev3-doenet-taskdef-includes.yml
+++ b/infra/cloudformation/dev3-doenet-taskdef-includes.yml
@@ -21,6 +21,12 @@ Environment:
     Value: "false"
   - Name: NODE_OPTIONS
     Value: "--max-old-space-size=1950"
+  - Name: MEDIA_S3_MODE
+    Value: "aws"
+  - Name: MEDIA_S3_REGION
+    Value: "us-east-1"
+  - Name: MEDIA_S3_BUCKET
+    Value: "dev3-media-568298704244-us-east-1"
   # - Name: DISCOURSE_API_USERNAME
   #   Value: "system"
   # - Name: DISCOURSE_URL

--- a/infra/cloudformation/prod-doenet-taskdef-includes.yml
+++ b/infra/cloudformation/prod-doenet-taskdef-includes.yml
@@ -21,6 +21,12 @@ Environment:
     Value: "false"
   - Name: NODE_OPTIONS
     Value: "--max-old-space-size=1950"
+  - Name: MEDIA_S3_MODE
+    Value: "aws"
+  - Name: MEDIA_S3_REGION
+    Value: "us-east-1"
+  - Name: MEDIA_S3_BUCKET
+    Value: "prod-media-350646758180-us-east-1"
   - Name: DISCOURSE_API_USERNAME
     Value: "system"
   - Name: DISCOURSE_URL


### PR DESCRIPTION
#2943 introduced S3-bucket-related environment variables that must be present for the backend to run. However, it forgot to add the vars to the `dev3` and `prod` taskdefs. Result: deployments failed because required env vars were missing.

> [!NOTE]
> These changes have already been deployed to dev3 and prod. This PR is cloudformation bookkeeping.