### PR TITLE
fix: delete image storage object on hard delete (#2937)

### DIFF
--- a/apps/api/src/media/imageContent.test.ts
+++ b/apps/api/src/media/imageContent.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Replace the s3 module so importing imageContent.ts does not trigger
+// loadMediaConfig() at module load time (it would demand real env vars).
+vi.mock("./s3", () => ({
+  deleteImage: vi.fn(),
+  getImageStream: vi.fn(),
+  putImage: vi.fn(),
+}));
+
 import { prisma } from "../model";
 import { createContent } from "../query/activity";
 import { setContentLicense } from "../query/license";
@@ -11,6 +20,7 @@ import {
   findViewableImage,
   setImageStorageKey,
 } from "./imageContent";
+import * as s3 from "./s3";
 
 async function getContent(contentId: Uint8Array) {
   return prisma.content.findUniqueOrThrow({
@@ -300,6 +310,13 @@ describe("setImageStorageKey", () => {
 });
 
 describe("deleteImageContent", () => {
+  beforeEach(() => {
+    vi.mocked(s3.deleteImage).mockReset();
+  });
+  afterEach(() => {
+    vi.mocked(s3.deleteImage).mockReset();
+  });
+
   test("deletes the owner's image row", async () => {
     const owner = await createTestUser();
     const { contentId } = await createImageContent({
@@ -337,6 +354,76 @@ describe("deleteImageContent", () => {
 
     const row = await prisma.content.findUnique({ where: { id: contentId } });
     expect(row).not.toBeNull();
+    expect(vi.mocked(s3.deleteImage)).not.toHaveBeenCalled();
+  });
+
+  test("deletes the storage object before removing the row", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+    await setImageStorageKey({
+      contentId,
+      ownerId: owner.userId,
+      storageKey: "images/x.png",
+    });
+
+    await deleteImageContent({ contentId, ownerId: owner.userId });
+
+    expect(vi.mocked(s3.deleteImage)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(s3.deleteImage)).toHaveBeenCalledWith("images/x.png");
+    const row = await prisma.content.findUnique({ where: { id: contentId } });
+    expect(row).toBeNull();
+  });
+
+  test("skips the storage delete when the row has no storage key", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+
+    await deleteImageContent({ contentId, ownerId: owner.userId });
+
+    expect(vi.mocked(s3.deleteImage)).not.toHaveBeenCalled();
+  });
+
+  test("still deletes the row when the storage delete throws", async () => {
+    const owner = await createTestUser();
+    const { contentId } = await createImageContent({
+      loggedInUserId: owner.userId,
+      parentId: null,
+      name: "x.png",
+      mimeType: "image/png",
+      sizeBytes: 1,
+      imageWidth: 1,
+      imageHeight: 1,
+    });
+    await setImageStorageKey({
+      contentId,
+      ownerId: owner.userId,
+      storageKey: "images/x.png",
+    });
+    vi.mocked(s3.deleteImage).mockRejectedValueOnce(new Error("S3 down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await deleteImageContent({ contentId, ownerId: owner.userId });
+
+    expect(vi.mocked(s3.deleteImage)).toHaveBeenCalledTimes(1);
+    const row = await prisma.content.findUnique({ where: { id: contentId } });
+    expect(row).toBeNull();
+    errSpy.mockRestore();
   });
 });
 

--- a/apps/api/src/media/imageContent.ts
+++ b/apps/api/src/media/imageContent.ts
@@ -1,6 +1,8 @@
 import { prisma } from "../model";
 import { prepareNewChild } from "../content-tree";
 import { filterViewableContent } from "../utils/permissions";
+import { fromUUID } from "../utils/uuid";
+import { deleteImage } from "./s3";
 
 /**
  * Whether a user is in the early-access cohort for image uploads. The image
@@ -98,6 +100,12 @@ export async function setImageStorageKey({
   });
 }
 
+/**
+ * Hard-deletes the image row and best-effort removes the storage object so the
+ * bucket does not accumulate orphaned bytes. A storage failure is logged but
+ * does not block the row delete — better to leave a stray object the sweep job
+ * can catch later than to leave the row pointing at deleted bytes.
+ */
 export async function deleteImageContent({
   contentId,
   ownerId,
@@ -105,6 +113,20 @@ export async function deleteImageContent({
   contentId: Uint8Array;
   ownerId: Uint8Array;
 }) {
+  const row = await prisma.content.findUnique({
+    where: { id: contentId, ownerId, type: "image" },
+    select: { storageKey: true },
+  });
+  if (row?.storageKey) {
+    try {
+      await deleteImage(row.storageKey);
+    } catch (err) {
+      console.error(
+        `Failed to delete storage object for image ${fromUUID(contentId)}`,
+        err,
+      );
+    }
+  }
   await prisma.content.delete({
     where: { id: contentId, ownerId, type: "image" },
   });


### PR DESCRIPTION
## Summary

- Fixes #2937. When `deleteImageContent` runs, it now looks up the row's `storageKey` and best-effort deletes the storage object before removing the row, so hard-delete callers do not leak orphan bytes in the bucket.
- Storage failures are logged (with the image's UUID) but do not block the row delete — better to leave a stray object the eventual sweep job can catch than to leave the row pointing at deleted bytes.
- Goes with option 3 from the issue ("inside `deleteImageContent`, fetch the `storageKey` first and best-effort `deleteImage` it"). Soft-delete cleanup (`isDeletedOn` past recovery window) still needs a separate purge job once the recovery-window policy is settled.
- The upload-rollback path in `upload.ts` keeps its explicit `deleteImage(storageKey)` call because the row's `storageKey` may not be persisted yet when rollback fires (the put can succeed while `setImageStorageKey` fails).

## Test plan

- [x] `deleteImageContent` deletes the storage object and the row when the row has a `storageKey`
- [x] `deleteImageContent` skips the storage delete (no S3 call) when the row has no `storageKey` yet
- [x] `deleteImageContent` still removes the row when the storage delete throws (best-effort)
- [x] Unauthorized delete (different owner) does not touch storage and does not remove the row
- [x] Upload rollback still deletes both the storage object and the row exactly once (existing test in `upload.test.ts`)