### PR TITLE
fix: show logged-in user's email in account menu

### DIFF
--- a/apps/api/src/query/user.ts
+++ b/apps/api/src/query/user.ts
@@ -87,6 +87,7 @@ export async function getMyUserInfo({
     where: { userId: loggedInUserId },
     select: {
       userId: true,
+      email: true,
       firstNames: true,
       lastNames: true,
       isAnonymous: true,

--- a/apps/api/src/test/users.test.ts
+++ b/apps/api/src/test/users.test.ts
@@ -106,16 +106,17 @@ test("turn author mode on and off", async () => {
   expect(userInfo.user.isAuthor).eq(false);
 });
 
-test("user apis do not provide email", async () => {
-  const { userId: loggedInUserId } = await createTestUser();
+test("a logged-in user can see their own email, but author lookups do not expose email", async () => {
+  const { userId: loggedInUserId, email } = await createTestUser();
+
   const results1 = await getMyUserInfo({ loggedInUserId });
-  expect(results1.user).not.toHaveProperty("email");
+  expect(results1.user.email).eq(email);
 
   const results2 = await getAuthorInfo(loggedInUserId);
   expect(results2).not.toHaveProperty("email");
 
   const results3 = await getUserInfoIfLoggedIn({ loggedInUserId });
-  expect(results3!.user).not.toHaveProperty("email");
+  expect(results3!.user.email).eq(email);
 });
 
 describe("student handles", () => {

--- a/apps/api/src/test/users.test.ts
+++ b/apps/api/src/test/users.test.ts
@@ -106,17 +106,28 @@ test("turn author mode on and off", async () => {
   expect(userInfo.user.isAuthor).eq(false);
 });
 
-test("a logged-in user can see their own email, but author lookups do not expose email", async () => {
+test("a logged-in user can see their own email", async () => {
   const { userId: loggedInUserId, email } = await createTestUser();
 
-  const results1 = await getMyUserInfo({ loggedInUserId });
-  expect(results1.user.email).eq(email);
+  const myInfo = await getMyUserInfo({ loggedInUserId });
+  expect(myInfo.user.email).eq(email);
 
-  const results2 = await getAuthorInfo(loggedInUserId);
-  expect(results2).not.toHaveProperty("email");
+  const optionalInfo = await getUserInfoIfLoggedIn({ loggedInUserId });
+  expect(optionalInfo!.user.email).eq(email);
+});
 
-  const results3 = await getUserInfoIfLoggedIn({ loggedInUserId });
-  expect(results3!.user.email).eq(email);
+test("author lookups do not expose another user's email", async () => {
+  const { userId: viewerUserId } = await createTestUser();
+  const { userId: authorUserId, email: authorEmail } = await createTestUser();
+
+  // sanity-check: the author actually has an email recorded
+  expect(authorEmail).toBeTruthy();
+
+  const authorInfo = await getAuthorInfo(authorUserId);
+  expect(authorInfo).not.toHaveProperty("email");
+  // and verify the viewer's own author lookup is symmetric (still no email)
+  const viewerLookup = await getAuthorInfo(viewerUserId);
+  expect(viewerLookup).not.toHaveProperty("email");
 });
 
 describe("student handles", () => {


### PR DESCRIPTION
## Summary
- Closes #2967.
- `AccountIconAndCard.tsx` already rendered `user.email` in the avatar dropdown, but `getMyUserInfo` in `apps/api/src/query/user.ts` was not selecting `email` from the database, so the field was always `undefined` for the current user.
- Add `email: true` to the `getMyUserInfo` Prisma select so a logged-in user can see what address their account is registered under (per the issue's screenshot).
- Update `apps/api/src/test/users.test.ts`: the existing `"user apis do not provide email"` test was asserting the *opposite* of the new policy. Replace it with `"a logged-in user can see their own email, but author lookups do not expose email"` — same coverage on `getAuthorInfo` (still must not leak email about other users), but `getMyUserInfo`/`getUserInfoIfLoggedIn` now return the requester's own email.

The data flows through the existing `UserInfoWithEmail` shape (already `email: string | null`), so no frontend type changes were needed; the email automatically renders for non-anonymous users.

## Test plan
- [x] `npm test --workspace @doenet-tools/api` passes (updated `users.test.ts`).
- [x] Sign in, open the avatar dropdown, confirm the registered email appears below the user's name.
- [x] Open the avatar dropdown as an anonymous user, confirm `Nickname: ...` still shows instead of an email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)