### PR TITLE
fix(infra): force StackSet update + correct dev3-doenet listener priority

### DIFF
--- a/infra/aws-deploy.sh
+++ b/infra/aws-deploy.sh
@@ -150,7 +150,18 @@ updateStacks() {
   for name in "${STACK_ORDER[@]}"; do 
     printGreen "Deploying Cloudformation stack ${name}"
     param_file="cloudformation/${name}.params"
-    ./scripts/cfn-deploy.sh -s $name -t "https://${TEMPLATE_BUCKET}.s3.amazonaws.com/${STACK_FILE}-${PROJECT}/${STACKS[$name]}.yml" -r ${AWS_REGION} -p "${param_file}" --no-wait-for-completion --changeset-name ${name}-${STACK_FILE};
+    force_update_token=$(date -u +"%Y%m%dT%H%M%SZ")
+    temp_param_file=$(mktemp)
+    trap 'rm -f "$temp_param_file"' RETURN
+    # StackSet updates can skip creating a change set when only the nested template
+    # content changed and the outer stack inputs stayed the same. Replace the
+    # checked-in ForceUpdateToken placeholder only for this deploy so CloudFormation
+    # sees a changed parameter and refreshes the StackSet, while the uploaded .params
+    # artifact remains the stable checked-in source of truth.
+    sed '/"ParameterKey": "ForceUpdateToken"/{n;s/"ParameterValue": "DUMMY"/"ParameterValue": "'"${force_update_token}"'"/;}' "${param_file}" > "$temp_param_file"
+    ./scripts/cfn-deploy.sh -s $name -t "https://${TEMPLATE_BUCKET}.s3.amazonaws.com/${STACK_FILE}-${PROJECT}/${STACKS[$name]}.yml" -r ${AWS_REGION} -p "$temp_param_file" --no-wait-for-completion --changeset-name ${name}-${STACK_FILE};
+    rm -f "$temp_param_file"
+    trap - RETURN
     ./scripts/cfn-wait.sh ${name} ${AWS_REGION};
   done
 }

--- a/infra/cloudformation/dev3-doenet-frontend.params
+++ b/infra/cloudformation/dev3-doenet-frontend.params
@@ -26,9 +26,13 @@
   {
     "ParameterKey": "AppServiceName",
     "ParameterValue": "app"
-  },  
+  },
   {
     "ParameterKey": "SiteServiceName",
     "ParameterValue": "site"
+  },
+  {
+    "ParameterKey": "ForceUpdateToken",
+    "ParameterValue": "DUMMY"
   }
 ]

--- a/infra/cloudformation/dev3-doenet.params
+++ b/infra/cloudformation/dev3-doenet.params
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "Priority",
-    "ParameterValue": "1"
+    "ParameterValue": "10"
   },
   {
     "ParameterKey": "EcsLaunchType",

--- a/infra/cloudformation/prod-doenet-frontend.params
+++ b/infra/cloudformation/prod-doenet-frontend.params
@@ -26,9 +26,13 @@
   {
     "ParameterKey": "AppServiceName",
     "ParameterValue": "app"
-  },  
+  },
   {
     "ParameterKey": "SiteServiceName",
     "ParameterValue": "site"
+  },
+  {
+    "ParameterKey": "ForceUpdateToken",
+    "ParameterValue": "DUMMY"
   }
 ]

--- a/infra/cloudformation/s3-hosted-stackset.yml
+++ b/infra/cloudformation/s3-hosted-stackset.yml
@@ -35,6 +35,10 @@ Parameters:
     Type: "AWS::SSM::Parameter::Value<String>"
     Description: DNS name of the Application Load Balancer
 
+  ForceUpdateToken:
+    Type: String
+    Description: Changes on each deploy to force a StackSet update
+
 Resources:
   StackSetAdministrationRole:
     Type: AWS::IAM::Role
@@ -120,6 +124,8 @@ Resources:
           ParameterValue: !Ref SiteServiceName
         - ParameterKey: LoadBalancerDnsName
           ParameterValue: !Ref LoadBalancerDnsName
+        - ParameterKey: ForceUpdateToken
+          ParameterValue: !Ref ForceUpdateToken
       TemplateURL: !Sub "https://${TemplateS3Bucket}.s3.amazonaws.com/${TemplateS3Key}"
 
 Outputs:

--- a/infra/cloudformation/s3-hosted.yml
+++ b/infra/cloudformation/s3-hosted.yml
@@ -33,6 +33,10 @@ Parameters:
     Type: String
     Description: DNS name of the Application Load Balancer
 
+  ForceUpdateToken:
+    Type: String
+    Description: Changes on each deploy to force a StackSet update
+
 Resources:
   AppBucket:
     Type: AWS::S3::Bucket
@@ -322,6 +326,10 @@ Outputs:
   AppBucketName:
     Description: Name of the app S3 bucket
     Value: !Ref AppBucket
+
+  ForceUpdateToken:
+    Description: Echoes the force-update token used for this deployment
+    Value: !Ref ForceUpdateToken
 
   SiteBucketName:
     Description: Name of the site S3 bucket


### PR DESCRIPTION
## Problem

StackSet updates were silently skipping change-set creation when only the nested template content changed and the outer stack inputs stayed the same, leaving the frontend stuck on a stale build.

## Solution

Add a \`ForceUpdateToken\` parameter to \`s3-hosted.yml\` / \`s3-hosted-stackset.yml\` and threads it into the embedded \`AWS::CloudFormation::StackSet\` parameters so CloudFormation sees a changed input on every deploy.

\`aws-deploy.sh\` rewrites the checked-in \`"DUMMY"\` placeholder to a fresh UTC timestamp into a tempfile per deploy, so the on-disk \`.params\` artifact remains the stable source of truth.