### PR TITLE
feat(infra): ECS + RDS extended alarms with recurring nag notifications

### DIFF
--- a/infra/cloudformation/dev3-doenet-mysql.params
+++ b/infra/cloudformation/dev3-doenet-mysql.params
@@ -134,5 +134,13 @@
   {
     "ParameterKey": "PathPattern",
     "ParameterValue": "notapplicable"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSWarningTopic",
+    "ParameterValue": "/dev3/CloudwatchSNSWarningTopic"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSCriticalTopic",
+    "ParameterValue": "/dev3/CloudwatchSNSCriticalTopic"
   }
 ]

--- a/infra/cloudformation/dev3-doenet.params
+++ b/infra/cloudformation/dev3-doenet.params
@@ -134,5 +134,13 @@
   {
     "ParameterKey": "PathPattern",
     "ParameterValue": "/api"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSWarningTopic",
+    "ParameterValue": "/dev3/CloudwatchSNSWarningTopic"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSCriticalTopic",
+    "ParameterValue": "/dev3/CloudwatchSNSCriticalTopic"
   }
 ]

--- a/infra/cloudformation/prod-doenet-mysql.params
+++ b/infra/cloudformation/prod-doenet-mysql.params
@@ -82,5 +82,13 @@
   {
     "ParameterKey": "EnvironmentKmsKey",
     "ParameterValue": "/prod/EnvironmentKmsKey"
-  }
+  },
+  {
+    "ParameterKey": "CloudwatchSNSWarningTopic",
+    "ParameterValue": "/prod/CloudwatchSNSWarningTopic"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSCriticalTopic",
+    "ParameterValue": "/prod/CloudwatchSNSCriticalTopic"
+  }    
 ]

--- a/infra/cloudformation/prod-doenet.params
+++ b/infra/cloudformation/prod-doenet.params
@@ -134,5 +134,13 @@
   {
     "ParameterKey": "PathPattern",
     "ParameterValue": "/api"
-  }
+  },
+  {
+    "ParameterKey": "CloudwatchSNSWarningTopic",
+    "ParameterValue": "/prod/CloudwatchSNSWarningTopic"
+  },
+  {
+    "ParameterKey": "CloudwatchSNSCriticalTopic",
+    "ParameterValue": "/prod/CloudwatchSNSCriticalTopic"
+  }  
 ]

--- a/infra/cloudformation/rds.yml
+++ b/infra/cloudformation/rds.yml
@@ -102,6 +102,15 @@ Parameters:
   EnvironmentKmsKey:
     Type: "AWS::SSM::Parameter::Value<String>"
     Default: "/webdev/EnvironmentKmsKey"
+
+  CloudwatchSNSWarningTopic:
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/webdev/CloudwatchSNSWarningTopic"
+
+  CloudwatchSNSCriticalTopic:
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/webdev/CloudwatchSNSCriticalTopic"
+
 Conditions:
   RunRdsServerA: !Not
     - !Equals
@@ -432,6 +441,31 @@ Resources:
         - "${DatabaseUrlScheme}://${DBUsername}:${DBPassword}@${DnsRecord}:${DatabasePort}/doenet"
         - DatabaseUrlScheme: !FindInMap [Engine, !Ref DBType, urlScheme]
           DatabasePort: !FindInMap [Engine, !Ref DBType, port]
+
+  RDSExtendedCPUHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+    Properties:
+      AlarmName: !Sub "${EnvironmentName}-RDS-Extended-High-CPU"
+      ActionsEnabled: true
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 20
+      MetricName: CPUUtilization
+      Namespace: AWS/RDS
+      Period: 60
+      Statistic: Average
+      Threshold: 75.0
+      AlarmActions:
+        - !Ref CloudwatchSNSCriticalTopic
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !If
+            - RunRdsServerA
+            - !GetAtt RdsServerA.DBInstanceIdentifier
+            - !GetAtt RdsServerB.DBInstanceIdentifier
 
 Outputs:
   DatabaseHost:

--- a/infra/cloudformation/service-common.yml
+++ b/infra/cloudformation/service-common.yml
@@ -574,6 +574,204 @@ Resources:
       Type: String
       Value: !Ref PrivateNamespace
 
+  CheckAlarmLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: CheckAlarmPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:DescribeAlarms
+                Resource: "*"
+
+  CheckAlarmLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${EnvironmentName}-checkAlarm"
+      Runtime: nodejs24.x
+      Handler: index.handler
+      Role: !GetAtt CheckAlarmLambdaRole.Arn
+      Code:
+        ZipFile: |
+          const { CloudWatchClient, DescribeAlarmsCommand } = require("@aws-sdk/client-cloudwatch");
+
+          const cloudWatchClient = new CloudWatchClient({});
+
+          exports.handler = async (event, context) => {
+              console.log(event);
+              try {
+                  const alarmName = event.alarmName;
+                  if (!alarmName) {
+                      console.error('ALARM_NAME environment variable is not set');
+                      return { statusCode: 400, body: JSON.stringify({ error: 'ALARM_NAME environment variable is not set' }) };
+                  }
+                  console.log(`Checking alarm: ${alarmName}`);
+                  const command = new DescribeAlarmsCommand({ AlarmNames: [alarmName] });
+                  const response = await cloudWatchClient.send(command);
+                  if (!response.MetricAlarms?.length && !response.CompositeAlarms?.length) {
+                      console.error(`Alarm "${alarmName}" not found`);
+                      return { statusCode: 404, body: JSON.stringify({ error: `Alarm "${alarmName}" not found` }) };
+                  }
+                  let alarm = response.MetricAlarms?.length > 0 ? response.MetricAlarms[0] : response.CompositeAlarms[0];
+                  const alarmInfo = {
+                      alarm_name: alarm.AlarmName,
+                      state_value: alarm.StateValue,
+                      state_reason: alarm.StateReason,
+                      state_updated_timestamp: alarm.StateUpdatedTimestamp?.toISOString(),
+                      alarm_description: alarm.AlarmDescription || '',
+                      alarm_arn: alarm.AlarmArn
+                  };
+                  console.log(`Alarm: ${alarmName}, State: ${alarm.StateValue}, Reason: ${alarm.StateReason}, Updated: ${alarm.StateUpdatedTimestamp}`);
+                  return { statusCode: 200, body: { message: 'Alarm state retrieved successfully', alarm_info: alarmInfo } };
+              } catch (error) {
+                  console.error('Error occurred:', error);
+                  if (error.name === 'InvalidParameterValue' || error.name === 'ValidationException')
+                      return { statusCode: 400, body: JSON.stringify({ error: 'Invalid parameter', message: error.message }) };
+                  if (error.name === 'AccessDenied' || error.name === 'UnauthorizedOperation')
+                      return { statusCode: 403, body: JSON.stringify({ error: 'Access denied', message: 'Insufficient permissions to describe CloudWatch alarms' }) };
+                  if (error.name === 'Throttling' || error.name === 'ThrottlingException')
+                      return { statusCode: 429, body: JSON.stringify({ error: 'Request throttled', message: 'Too many requests, please try again later' }) };
+                  return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error', message: error.message || 'An unexpected error occurred' }) };
+              }
+          };
+
+  CheckAlarmLambdaSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${EnvironmentName}/CheckAlarmLambdaArn"
+      Type: String
+      Value: !GetAtt CheckAlarmLambda.Arn
+
+  NagStepFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: NagStepFunctionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt CheckAlarmLambda.Arn
+              - Effect: Allow
+                Action: sns:Publish
+                Resource: !Ref CloudwatchSNSCriticalTopic
+
+  NagStateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub "${EnvironmentName}-nag-state-machine"
+      RoleArn: !GetAtt NagStepFunctionRole.Arn
+      Definition:
+        Comment: A description of my state machine
+        QueryLanguage: JSONata
+        StartAt: Lambda Invoke
+        States:
+          Lambda Invoke:
+            Type: Task
+            Resource: arn:aws:states:::lambda:invoke
+            Output: "{% $merge([$states.result.Payload, {'alarmName': $exists($states.input.alarmName) ? $states.input.alarmName : $states.input.detail.alarmName}]) %}"
+            Arguments:
+              FunctionName: !GetAtt CheckAlarmLambda.Arn
+              Payload:
+                alarmName: "{% $exists($states.input.alarmName) ? $states.input.alarmName : $states.input.detail.alarmName %}"
+            Retry:
+              - ErrorEquals:
+                  - Lambda.ServiceException
+                  - Lambda.AWSLambdaException
+                  - Lambda.SdkClientException
+                  - Lambda.TooManyRequestsException
+                IntervalSeconds: 1
+                MaxAttempts: 3
+                BackoffRate: 2
+                JitterStrategy: FULL
+            Next: Choice
+          Choice:
+            Type: Choice
+            Choices:
+              - Next: SNS Publish
+                Condition: "{% $states.input.body.alarm_info.state_value = 'ALARM' %}"
+            Default: Pass
+          Pass:
+            Type: Pass
+            End: true
+          SNS Publish:
+            Type: Task
+            Resource: arn:aws:states:::sns:publish
+            Output: "{% {'alarmName': $states.input.alarmName} %}"
+            Arguments:
+              Message: "{% $states.input %}"
+              TopicArn: !Ref CloudwatchSNSCriticalTopic
+            Next: Wait
+          Wait:
+            Type: Wait
+            Seconds: 300
+            Next: Lambda Invoke
+
+  NagEventBridgeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: NagEventBridgePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource: !Ref NagStateMachine
+
+  NagEventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${EnvironmentName}-nag-extended-alarms"
+      EventPattern:
+        source:
+          - aws.cloudwatch
+        detail-type:
+          - CloudWatch Alarm State Change
+        detail:
+          alarmName:
+            - wildcard: !Sub "${EnvironmentName}-*-Extended-*"
+          state:
+            value:
+              - ALARM
+      Targets:
+        - Id: NagStateMachine
+          Arn: !Ref NagStateMachine
+          RoleArn: !GetAtt NagEventBridgeRole.Arn
+
+  NagStateMachineSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${EnvironmentName}/NagStateMachineArn"
+      Type: String
+      Value: !Ref NagStateMachine
+
 Outputs:
   CloudwatchSNSWarningTopic:
     Value: !Ref CloudwatchSNSWarningTopic

--- a/infra/cloudformation/service.yml
+++ b/infra/cloudformation/service.yml
@@ -169,9 +169,13 @@ Parameters:
   #    Type : 'AWS::SSM::Parameter::Value<String>'
   #    Default: '/webdev/LoadBalancerFullName'
 
-  #  CloudwatchSNSTopic:
-  #    Type : 'AWS::SSM::Parameter::Value<String>'
-  #    Default: '/webdev/CloudwatchSNSWarningTopic'
+  CloudwatchSNSWarningTopic:
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/webdev/CloudwatchSNSWarningTopic"
+
+  CloudwatchSNSCriticalTopic:
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/webdev/CloudwatchSNSCriticalTopic"
 
   MinCount:
     Type: Number
@@ -608,7 +612,30 @@ Resources:
       AlarmActions:
         - !If [EcsInEc2, !Ref ScaleECSClusterEC2Up, !Ref "AWS::NoValue"]
         - !Ref ECSServiceScaleUpPolicy
-      #        - !Ref CloudwatchSNSWarningTopic
+      Dimensions:
+        - Name: ServiceName
+          Value: !GetAtt Service.Name
+        - Name: ClusterName
+          Value: !Ref EcsCluster
+
+  ECSClusterExtendedCPUHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+    Properties:
+      AlarmName: !Sub "${EnvironmentName}-${ServiceName}-Extended-High-CPU"
+      ActionsEnabled: true
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 20
+      MetricName: CPUUtilization
+      Namespace: AWS/ECS
+      Period: 60
+      Statistic: Average
+      Threshold: 75.0
+      AlarmActions:
+        - !Ref CloudwatchSNSCriticalTopic
       Dimensions:
         - Name: ServiceName
           Value: !GetAtt Service.Name
@@ -635,6 +662,30 @@ Resources:
         - !If [EcsInEc2, !Ref ScaleECSClusterEC2Down, !Ref "AWS::NoValue"]
         - !Ref ECSServiceScaleDownPolicy
       #        - !Ref CloudwatchSNSWarningTopic
+      Dimensions:
+        - Name: ServiceName
+          Value: !GetAtt Service.Name
+        - Name: ClusterName
+          Value: !Ref EcsCluster
+
+  ECSClusterExtendedMemoryHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+    Properties:
+      AlarmName: !Sub "${EnvironmentName}-${ServiceName}-Extended-High-Memory"
+      ActionsEnabled: true
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 20
+      MetricName: MemoryUtilization
+      Namespace: AWS/ECS
+      Period: 60
+      Statistic: Average
+      Threshold: 75.0
+      AlarmActions:
+        - !Ref CloudwatchSNSCriticalTopic
       Dimensions:
         - Name: ServiceName
           Value: !GetAtt Service.Name


### PR DESCRIPTION
## Problem
- The existing CloudWatch alarms in \`service.yml\` only trigger autoscaling actions; they do not page anyone when a service is genuinely unhealthy for an extended period.
- \`rds.yml\` has no high-CPU alarm at all, so prolonged RDS pressure goes unnoticed.
- Even where an alarm exists, CloudWatch fires the \`ALARM\` notification once on transition and then goes quiet. An incident that stays broken for an hour still only generates one SNS message, which is easy to miss.

## Solution
- **Extended alarms.** Add 20-minute sustained-threshold alarms (\`*-Extended-High-CPU\`, \`*-Extended-High-Memory\`) on the ECS service in \`service.yml\` and a matching \`*-Extended-High-CPU\` on the RDS instance in \`rds.yml\`. All publish to the existing \`CloudwatchSNSCriticalTopic\`.
- **Nag system.** Add a per-environment \`checkAlarm\` Lambda + Step Functions state machine + EventBridge rule in \`service-common.yml\`. EventBridge catches \`*-Extended-*\` alarm transitions to \`ALARM\`, the state machine re-checks every 5 minutes and re-publishes to the critical SNS topic for as long as the alarm is still firing. This converts \"one notification per incident\" into \"recurring notification until resolved.\"
- **Params plumbing.** Wire \`CloudwatchSNSWarningTopic\` / \`CloudwatchSNSCriticalTopic\` overrides into \`dev3-doenet.params\`, \`dev3-doenet-mysql.params\`, \`prod-doenet.params\`, and \`prod-doenet-mysql.params\`. Without these, the templates would fall back to the \`/webdev/...\` SSM defaults, which don't exist in dev3 or prod.


🤖 Generated with [Claude Code](https://claude.com/claude-code)