### PR TITLE
feat(infra): Route53 health check + cross-region nag forwarding

### DIFF
--- a/infra/cloudformation/dev3-doenet-mysql.params
+++ b/infra/cloudformation/dev3-doenet-mysql.params
@@ -32,7 +32,7 @@
     "ParameterValue": "FARGATE"
   },
   {
-    "ParameterKey": "HealthCheckUrl",
+    "ParameterKey": "HealthCheckUri",
     "ParameterValue": "/health"
   },
   {
@@ -104,8 +104,12 @@
     "ParameterValue": "/dev3/EcsCluster"
   },
   {
-    "ParameterKey": "LoadBalancerListener",
+    "ParameterKey": "LoadBalancerHttpsListener",
     "ParameterValue": "/dev3/LoadBalancerHttpsListener"
+  },
+  {
+    "ParameterKey": "LoadBalancerHttpListener",
+    "ParameterValue": "/dev3/LoadBalancerHttpListener"
   },
   {
     "ParameterKey": "EfsFileSystemId",
@@ -142,5 +146,13 @@
   {
     "ParameterKey": "CloudwatchSNSCriticalTopic",
     "ParameterValue": "/dev3/CloudwatchSNSCriticalTopic"
+  },
+  {
+    "ParameterKey": "HealthCheckTemplateS3Key",
+    "ParameterValue": "dev3-doenet/health-check-us-east-1.yml"
+  },
+  {
+    "ParameterKey": "TemplateS3Bucket",
+    "ParameterValue": "doenet-cf-dev"
   }
 ]

--- a/infra/cloudformation/dev3-doenet.params
+++ b/infra/cloudformation/dev3-doenet.params
@@ -32,8 +32,8 @@
     "ParameterValue": "FARGATE"
   },
   {
-    "ParameterKey": "HealthCheckUrl",
-    "ParameterValue": "/"
+    "ParameterKey": "HealthCheckUri",
+    "ParameterValue": "/api/health"
   },
   {
     "ParameterKey": "UseLbForService",
@@ -104,8 +104,12 @@
     "ParameterValue": "/dev3/EcsCluster"
   },
   {
-    "ParameterKey": "LoadBalancerListener",
+    "ParameterKey": "LoadBalancerHttpsListener",
     "ParameterValue": "/dev3/LoadBalancerHttpsListener"
+  },
+  {
+    "ParameterKey": "LoadBalancerHttpListener",
+    "ParameterValue": "/dev3/LoadBalancerHttpListener"
   },
   {
     "ParameterKey": "EfsFileSystemId",
@@ -142,5 +146,13 @@
   {
     "ParameterKey": "CloudwatchSNSCriticalTopic",
     "ParameterValue": "/dev3/CloudwatchSNSCriticalTopic"
+  },
+  {
+    "ParameterKey": "HealthCheckTemplateS3Key",
+    "ParameterValue": "dev3-doenet/health-check-us-east-1.yml"
+  },
+  {
+    "ParameterKey": "TemplateS3Bucket",
+    "ParameterValue": "doenet-cf-dev"
   }
 ]

--- a/infra/cloudformation/health-check-us-east-1.yml
+++ b/infra/cloudformation/health-check-us-east-1.yml
@@ -1,0 +1,96 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: EventBridge rule for nag alarms — deployed via StackSet to us-east-1
+
+Parameters:
+  EnvironmentName:
+    Type: String
+
+  ServiceName:
+    Type: String
+
+  TargetAccountId:
+    Type: String
+    Description: AWS account ID owning the us-east-2 default event bus
+
+  HealthCheckDomain:
+    Type: String
+    Description: Domain name to monitor with the Route53 health check (e.g. example.com)
+
+  HealthCheckUri:
+    Type: String
+    Description: Path to monitor with the Route53 health check (e.g. api/health)
+
+Resources:
+  NagEventBridgeForwardRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: NagEventBridgeForwardPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: events:PutEvents
+                Resource: !Sub "arn:aws:events:us-east-2:${TargetAccountId}:event-bus/default"
+
+  HealthCheck:
+    Type: AWS::Route53::HealthCheck
+    Properties:
+      HealthCheckConfig:
+        Type: HTTP
+        FullyQualifiedDomainName: !Ref HealthCheckDomain
+        ResourcePath: !Ref HealthCheckUri
+        Port: 80
+        RequestInterval: 30
+        FailureThreshold: 3
+        Regions:
+          - us-east-1
+          - us-west-1
+          - us-west-2
+      HealthCheckTags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-${ServiceName}-health-check"
+
+  HealthCheckAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${EnvironmentName}-${ServiceName}-HealthCheck-Extended-Alarm"
+      AlarmDescription: !Sub "Route53 health check failure for ${HealthCheckUri}"
+      Namespace: AWS/Route53
+      MetricName: HealthCheckStatus
+      Dimensions:
+        - Name: HealthCheckId
+          Value: !Ref HealthCheck
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+
+  NagEventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${EnvironmentName}-${ServiceName}-nag-extended-alarms"
+      EventPattern:
+        source:
+          - aws.cloudwatch
+        detail-type:
+          - CloudWatch Alarm State Change
+        detail:
+          alarmName:
+            - wildcard: !Sub "${EnvironmentName}-${ServiceName}-*-Extended-*"
+          state:
+            value:
+              - ALARM
+      Targets:
+        - Id: UsEast2DefaultBus
+          Arn: !Sub "arn:aws:events:us-east-2:${TargetAccountId}:event-bus/default"
+          RoleArn: !GetAtt NagEventBridgeForwardRole.Arn

--- a/infra/cloudformation/prod-doenet.params
+++ b/infra/cloudformation/prod-doenet.params
@@ -32,7 +32,7 @@
     "ParameterValue": "FARGATE"
   },
   {
-    "ParameterKey": "HealthCheckUrl",
+    "ParameterKey": "HealthCheckUri",
     "ParameterValue": "/"
   },
   {
@@ -104,8 +104,12 @@
     "ParameterValue": "/prod/EcsCluster"
   },
   {
-    "ParameterKey": "LoadBalancerListener",
+    "ParameterKey": "LoadBalancerHttpsListener",
     "ParameterValue": "/prod/LoadBalancerHttpsListener"
+  },
+  {
+    "ParameterKey": "LoadBalancerHttpListener",
+    "ParameterValue": "/prod/LoadBalancerHttpListener"
   },
   {
     "ParameterKey": "EfsFileSystemId",
@@ -142,5 +146,13 @@
   {
     "ParameterKey": "CloudwatchSNSCriticalTopic",
     "ParameterValue": "/prod/CloudwatchSNSCriticalTopic"
-  }  
+  },
+  {
+    "ParameterKey": "HealthCheckTemplateS3Key",
+    "ParameterValue": "prod-doenet/health-check-us-east-1.yml"
+  },
+  {
+    "ParameterKey": "TemplateS3Bucket",
+    "ParameterValue": "doenet-cf-prod"
+  }
 ]

--- a/infra/cloudformation/service-common.yml
+++ b/infra/cloudformation/service-common.yml
@@ -410,6 +410,7 @@ Resources:
       Value:
         !If [LbIsEnabled, !GetAtt LoadBalancer.CanonicalHostedZoneID, "not set"]
 
+  # LoadBalancerHttpListener and LoadBalancerListener flip-flop depending on if SSL is enabled.
   LoadBalancerHttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: SSLIsDisabled
@@ -432,14 +433,7 @@ Resources:
       Port: 80
       Protocol: HTTP
 
-  LoadBalancerHttpListenerSSMParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: ECS
-      Name: !Sub "/${EnvironmentName}/LoadBalancerHttpListener"
-      Type: String
-      Value: !If [SSLIsDisabled, !Ref LoadBalancerHttpListener, "not set"]
-
+  # See comment above!!!
   LoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: SSLIsEnabled
@@ -460,6 +454,19 @@ Resources:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 80
       Protocol: HTTP
+
+  LoadBalancerHttpListenerSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: ECS
+      Name: !Sub "/${EnvironmentName}/LoadBalancerHttpListener"
+      Type: String
+      Value:
+        !If [
+          SSLIsEnabled,
+          !Ref LoadBalancerListener,
+          !Ref LoadBalancerHttpListener,
+        ]
 
   LoadBalancerHttpsListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -606,12 +613,14 @@ Resources:
         ZipFile: |
           const { CloudWatchClient, DescribeAlarmsCommand } = require("@aws-sdk/client-cloudwatch");
 
-          const cloudWatchClient = new CloudWatchClient({});
-
           exports.handler = async (event, context) => {
               console.log(event);
               try {
                   const alarmName = event.alarmName;
+                  const region = event.region;
+
+                  const cloudWatchClient = new CloudWatchClient({region: region});
+
                   if (!alarmName) {
                       console.error('ALARM_NAME environment variable is not set');
                       return { statusCode: 400, body: JSON.stringify({ error: 'ALARM_NAME environment variable is not set' }) };
@@ -688,11 +697,12 @@ Resources:
           Lambda Invoke:
             Type: Task
             Resource: arn:aws:states:::lambda:invoke
-            Output: "{% $merge([$states.result.Payload, {'alarmName': $exists($states.input.alarmName) ? $states.input.alarmName : $states.input.detail.alarmName}]) %}"
+            Output: "{% $merge([$states.result.Payload, {'region': $states.input.region, 'alarmName': $exists($states.input.alarmName) ? $states.input.alarmName : $states.input.detail.alarmName}]) %}"
             Arguments:
               FunctionName: !GetAtt CheckAlarmLambda.Arn
               Payload:
                 alarmName: "{% $exists($states.input.alarmName) ? $states.input.alarmName : $states.input.detail.alarmName %}"
+                region: "{% $states.input.region %}"
             Retry:
               - ErrorEquals:
                   - Lambda.ServiceException
@@ -716,7 +726,7 @@ Resources:
           SNS Publish:
             Type: Task
             Resource: arn:aws:states:::sns:publish
-            Output: "{% {'alarmName': $states.input.alarmName} %}"
+            Output: "{% {'alarmName': $states.input.alarmName, 'region': $states.input.region} %}"
             Arguments:
               Message: "{% $states.input %}"
               TopicArn: !Ref CloudwatchSNSCriticalTopic

--- a/infra/cloudformation/service.yml
+++ b/infra/cloudformation/service.yml
@@ -50,7 +50,8 @@ Metadata:
           - PrivateSubnets
           - SecurityGroup
           - EnvironmentKmsKey
-          - LoadBalancerListener
+          - LoadBalancerHttpsListener
+          - LoadBalancerHttpListener
           - PublicHostedZoneId
           - PublicHostedZoneName
           - LoadBalancerDnsName
@@ -129,9 +130,13 @@ Parameters:
     Type: "AWS::SSM::Parameter::Value<String>"
     Default: "/webdev/EcsCluster"
 
-  LoadBalancerListener:
+  LoadBalancerHttpsListener:
     Type: "AWS::SSM::Parameter::Value<String>"
     Default: "/webdev/LoadBalancerHttpsListener"
+
+  LoadBalancerHttpListener:
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/webdev/LoadBalancerHttpListener"
 
   EfsFileSystemId:
     Type: "AWS::SSM::Parameter::Value<String>"
@@ -199,9 +204,9 @@ Parameters:
     Type: Number
     Description: The ordering of rules in the listener (cannot be the same as another app)
 
-  HealthCheckUrl:
+  HealthCheckUri:
     Type: String
-    Description: The URL used by the Target Group to verify the container is functioning properly before placing in service
+    Description: The URI used by the Target Group to verify the container is functioning properly before placing in service
 
   UseLbForService:
     Type: String
@@ -240,6 +245,15 @@ Parameters:
     Description: ECS-Optimized AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+
+  TemplateS3Bucket:
+    Type: String
+    Description: S3 bucket containing CloudFormation templates
+
+  HealthCheckTemplateS3Key:
+    Type: String
+    Description: S3 key for the health-check-us-east-1.yml template
+    Default: cloudformation/health-check-us-east-1.yml
 
 Conditions:
   EcsInFargate: !Equals
@@ -697,7 +711,7 @@ Resources:
     Condition: UseLbForService
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPath: !Ref HealthCheckUrl
+      HealthCheckPath: !Ref HealthCheckUri
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -768,7 +782,21 @@ Resources:
             SourceIpConfig:
               Values: !Ref RestrictedCIDRs
           - !Ref "AWS::NoValue"
-      ListenerArn: !Ref LoadBalancerListener
+      ListenerArn: !Ref LoadBalancerHttpsListener
+      Priority: !Ref Priority
+
+  ServiceHttpListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: UseLbForService
+    Properties:
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+      Conditions:
+        - Field: path-pattern
+          Values:
+            - !Ref HealthCheckUri
+      ListenerArn: !Ref LoadBalancerHttpListener
       Priority: !Ref Priority
 
   PublicDnsRecord:
@@ -839,7 +867,7 @@ Resources:
   #          Values:
   #            - !FindInMap [Service, !Ref ServiceName, pathpattern]
   #            - !FindInMap [Service, !Ref ServiceName, pathpatternstar]
-  #      ListenerArn: !Ref LoadBalancerListener
+  #      ListenerArn: !Ref LoadBalancerHttpsListener
   #      Priority: !FindInMap [Service, !Ref ServiceName, priority]
 
   #  ApplicationLBStatusCheckAlarm:
@@ -1256,3 +1284,36 @@ Resources:
         - COGNITO
       GenerateSecret: true
       UserPoolId: !Ref UserPool
+
+  NagEventBridgeStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Condition: UseLbForService
+    Properties:
+      StackSetName: !Sub "${EnvironmentName}-${ServiceName}-nag-eventbridge-us-east-1"
+      Description: Forwards nag alarm events from us-east-1 to the us-east-2 default event bus
+      AdministrationRoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/AWSCloudFormationStackSetAdministrationRole"
+      ExecutionRoleName: AWSCloudFormationStackSetExecutionRole
+      Capabilities:
+        - CAPABILITY_NAMED_IAM
+      PermissionModel: SELF_MANAGED
+      StackInstancesGroup:
+        - DeploymentTargets:
+            Accounts:
+              - !Ref AWS::AccountId
+          Regions:
+            - us-east-1
+      Parameters:
+        - ParameterKey: EnvironmentName
+          ParameterValue: !Ref EnvironmentName
+        - ParameterKey: ServiceName
+          ParameterValue: !Ref ServiceName
+        - ParameterKey: TargetAccountId
+          ParameterValue: !Ref AWS::AccountId
+        - ParameterKey: HealthCheckDomain
+          ParameterValue: !If
+            - UseDomainNames
+            - !Select [0, !Ref DomainNames]
+            - !Sub "${ServiceName}.${PublicHostedZoneName}"
+        - ParameterKey: HealthCheckUri
+          ParameterValue: !Sub "${HealthCheckUri}"
+      TemplateURL: !Sub "https://${TemplateS3Bucket}.s3.amazonaws.com/${HealthCheckTemplateS3Key}"


### PR DESCRIPTION
## Problem
- We have nothing actively probing the service's external hostname from outside AWS, so an ALB-level or DNS-level outage doesn't trigger any of the existing alarms (those only watch internal ECS/RDS metrics).
- Route53 health checks must live in **us-east-1**, but the nag state machine added in #2974 lives in us-east-2 with the rest of the service infra, so a us-east-1 alarm has no way to reach the nagger.
- The CheckAlarm Lambda from #2974 hard-codes the region to wherever it's running, so even if events did get forwarded, it couldn't re-describe the alarm to decide whether to keep nagging.
- service.yml only exposes the HTTPS listener as a parameter, so there's no way to attach a plain-HTTP rule for the Route53 probe (Route53 health checks default to HTTP/80 and would have to be paid HTTPS otherwise).

## Solution
- **New \`health-check-us-east-1.yml\` template, deployed as a StackSet from service.yml to us-east-1.** Contains the Route53 health check on the service's external hostname + an EventBridge rule that catches its \`*-Extended-*\` alarm transitions and forwards them to the default event bus in us-east-2, where the existing nag state machine picks them up.
- **\`NagEventBridgeStackSet\` in service.yml** wires the StackSet up, plus new \`TemplateS3Bucket\` / \`HealthCheckTemplateS3Key\` params so it knows where to find the nested template.
- **Split \`LoadBalancerListener\` → \`LoadBalancerHttpsListener\` + new \`LoadBalancerHttpListener\`** in service.yml, and add a new \`ServiceHttpListenerRule\` that routes the \`HealthCheckUri\` path on port 80 to the same target group as the HTTPS rule. Lets the Route53 probe hit \`/api/health\` over plain HTTP without exposing the rest of the API on port 80.
- **Rebuild the \`/\${env}/LoadBalancerHttpListener\` SSM param in service-common.yml** so it always resolves to whichever port-80 listener actually exists for the environment (\`LoadBalancerListener\` when SSL is enabled, \`LoadBalancerHttpListener\` when not). Also fixes a pre-existing bug where the \`\!If\` fallback was the literal string \`\"LoadBalancerHttpListener\"\` instead of a \`\!Ref\`.
- **Make \`CheckAlarmLambda\` + nag state machine region-aware** so they describe alarms in the region carried on the inbound event, letting the same us-east-2 nagger handle the forwarded us-east-1 Route53 health-check alarm.
- **Rename \`HealthCheckUrl\` → \`HealthCheckUri\`** everywhere (it's a path, not a URL). \`dev3-doenet.params\` switches the path from \`/\` to \`/api/health\` to match the real health endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)