### PR TITLE
feat(infra): allow dev deploys from infra/* branches

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   push:
-    branches: ["main"]
+    branches: ["main", "infra/*"]
 
 permissions:
   contents: read

--- a/infra/cloudformation/dev3-doenet-repositories.params
+++ b/infra/cloudformation/dev3-doenet-repositories.params
@@ -13,6 +13,6 @@
   },
   {
     "ParameterKey": "GitHubRepos",
-    "ParameterValue": "repo:Doenet/DoenetApps:*"
+    "ParameterValue": "repo:Doenet/DoenetApps:ref:refs/heads/main,repo:Doenet/DoenetApps:ref:refs/heads/infra/*"
   }
 ]

--- a/infra/cloudformation/prod-doenet-repositories.params
+++ b/infra/cloudformation/prod-doenet-repositories.params
@@ -13,6 +13,6 @@
   },
   {
     "ParameterKey": "GitHubRepos",
-    "ParameterValue": "repo:Doenet/DoenetApps:main"
+    "ParameterValue": "repo:Doenet/DoenetApps:ref:refs/heads/main"
   }
 ]


### PR DESCRIPTION
## Problem
- Infrastructure changes (CloudFormation templates, params) currently can only be deploy-tested on dev3 by either (a) merging straight to \`main\` and letting the dev-deploy workflow pick it up, or (b) running \`infra/aws-deploy.sh\` locally with a long-lived AWS session. Both options are bad for risky infra work — landing unverified template changes to \`main\` invites prod-affecting surprises, and local deploys bypass the audited OIDC path.
- The dev3 OIDC trust policy is set to \`repo:Doenet/DoenetApps:*\` (any branch in the repo). That's both wider than we need and inconsistent with prod, which pins to \`main\`.

## Solution
- **\`.github/workflows/dev-deploy.yml\`**: trigger the dev-deploy workflow on pushes to \`main\` **or any \`infra/*\` branch**. Lets an in-flight infra branch get end-to-end deploy validation on dev3 before opening / merging the PR.
- **\`dev3-doenet-repositories.params\`**: tighten the dev3 IAM OIDC trust subject from the catch-all \`repo:Doenet/DoenetApps:*\` to an explicit allowlist of \`main\` + \`infra/*\`, matching what the workflow trigger actually allows. Also moves to the canonical \`ref:refs/heads/...\` subject-claim form.
- **\`prod-doenet-repositories.params\`**: canonicalize the existing prod \`Doenet/DoenetApps:main\` entry to the same long-form \`ref:refs/heads/main\`. No behavioral change; both files now use the same syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)